### PR TITLE
Mutually recursive datatype support in CVC4 backend

### DIFF
--- a/cvc4/include/cvc4_solver.h
+++ b/cvc4/include/cvc4_solver.h
@@ -89,6 +89,9 @@ class CVC4Solver : public AbsSmtSolver
   Term get_constructor(const Sort & s, std::string name) const override;
   Term get_tester(const Sort & s, std::string name) const override;
   Term get_selector(const Sort & s, std::string con, std::string name) const override;
+  SortVec make_datatype_sorts(
+      const std::vector<DatatypeDecl> & decls,
+      const UnorderedSortSet & uninterp_sorts) const override;
 
   Term make_term(bool b) const override;
   Term make_term(int64_t i, const Sort & sort) const override;

--- a/cvc4/src/cvc4_solver.cpp
+++ b/cvc4/src/cvc4_solver.cpp
@@ -836,6 +836,41 @@ Term CVC4Solver::get_selector(const Sort & s, std::string con, std::string name)
   }
 };
 
+SortVec CVC4Solver::make_datatype_sorts(
+    const std::vector<DatatypeDecl> & decls,
+    const UnorderedSortSet & uninterp_sorts) const
+{
+  try
+  {
+    SortVec dt_sorts;
+    dt_sorts.reserve(uninterp_sorts.size());
+
+    std::vector<CVC4::api::DatatypeDecl> cvc4_decls;
+    cvc4_decls.reserve(decls.size());
+    for (const auto & d : decls)
+    {
+      cvc4_decls.push_back(
+          std::static_pointer_cast<CVC4DatatypeDecl>(d)->datatypedecl);
+    }
+
+    std::set<CVC4::api::Sort> cvc4_sorts;
+    for (const auto & s : uninterp_sorts)
+    {
+      cvc4_sorts.insert(std::static_pointer_cast<CVC4Sort>(s)->sort);
+    }
+
+    for (const auto & csort : solver.mkDatatypeSorts(cvc4_decls, cvc4_sorts))
+    {
+      dt_sorts.push_back(std::make_shared<CVC4Sort>(csort));
+    }
+    return dt_sorts;
+  }
+  catch (::CVC4::api::CVC4ApiException & e)
+  {
+    throw InternalSolverException(e.what());
+  }
+}
+
 Term CVC4Solver::make_term(Op op, const Term & t0, const Term & t1) const
 {
   try

--- a/include/solver.h
+++ b/include/solver.h
@@ -338,6 +338,30 @@ class AbsSmtSolver
    */
   virtual Term get_selector(const Sort & s, std::string con, std::string name) const = 0;
 
+  /** Declare uninterpreted sorts as datatype sorts
+   *  Each uninterpreted sort must correspond to a DatatypeDecl
+   *    i.e. they must have the exact same name
+   *  This allows defining mutually recursive datatype sorts, by
+   *    - First creating uninterpreted sorts as a "forward reference"
+   *    - Using these to define Datatypes (with the same names)
+   *        using the above methods
+   *    - Then turning the uninterpreted sorts into datatype sorts.
+   *
+   *  @param decls the datatype decls
+   *  @param uninterp_sorts vector of uninterpreted sorts
+   *  @return datatype sorts corresponding to the uninterpreted sort inputs
+   *
+   *  Note, there has to be a one-to-one and onto mapping between decls
+   *  and uninterpreted sorts according to their names.
+   *
+   */
+  virtual SortVec make_datatype_sorts(
+      const std::vector<DatatypeDecl> & decls,
+      const UnorderedSortSet & uninterp_sorts) const;
+
+  /** Convenience function that calls make_datatype_sorts with a single sort. */
+  Sort make_datatype_sort(const DatatypeDecl & decl,
+                          const Sort & uninterp_sort) const;
 
   // Methods implemented at the abstract level
   // Note: These can be overloaded in the specific solver implementation for

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -36,6 +36,24 @@ Result AbsSmtSolver::check_sat_assuming_set(
       "check_sat_assuming_set not implemented by default");
 }
 
+SortVec AbsSmtSolver::make_datatype_sorts(
+    const std::vector<DatatypeDecl> & decls,
+    const UnorderedSortSet & uninterp_sorts) const
+{
+  throw NotImplementedException(
+      "make_datatype_sorts for mutually recursive datatypes not yet implementd "
+      "by "
+      + to_string(solver_enum));
+}
+
+Sort AbsSmtSolver::make_datatype_sort(const DatatypeDecl & decl,
+                                      const Sort & uninterp_sort) const
+{
+  SortVec datatype_sorts = make_datatype_sorts({ decl }, { uninterp_sort });
+  assert(datatype_sorts.size() == 1);
+  return datatype_sorts[0];
+}
+
 Term AbsSmtSolver::substitute(const Term term,
                               const UnorderedTermMap & substitution_map) const
 {

--- a/tests/test-dt.cpp
+++ b/tests/test-dt.cpp
@@ -41,6 +41,43 @@ class DTTests : public ::testing::Test,
   Sort intsort;
 };
 
+TEST_P(DTTests, DeclareSimpleList)
+{
+  SolverConfiguration sc = GetParam();
+  if (sc.is_logging_solver || s->get_solver_enum() == GENERIC_SOLVER)
+  {
+    return;
+  }
+
+  DatatypeDecl listSpec = s->make_datatype_decl("list");
+  DatatypeConstructorDecl nildecl = s->make_datatype_constructor_decl("nil");
+  DatatypeConstructorDecl consdecl = s->make_datatype_constructor_decl("cons");
+  s->add_selector(consdecl, "head", s->make_sort(INT));
+  s->add_selector_self(consdecl, "tail");
+  s->add_constructor(listSpec, nildecl);
+  s->add_constructor(listSpec, consdecl);
+  Sort listsort = s->make_sort(listSpec);
+}
+
+TEST_P(DTTests, DeclareSimpleListWithForwardRef)
+{
+  SolverConfiguration sc = GetParam();
+  if (sc.is_logging_solver || s->get_solver_enum() == GENERIC_SOLVER)
+  {
+    return;
+  }
+
+  DatatypeDecl listSpec = s->make_datatype_decl("list");
+  Sort forward_ref_listsort = s->make_sort("list", 0);
+  DatatypeConstructorDecl nildecl = s->make_datatype_constructor_decl("nil");
+  DatatypeConstructorDecl consdecl = s->make_datatype_constructor_decl("cons");
+  s->add_selector(consdecl, "head", s->make_sort(INT));
+  s->add_selector(consdecl, "tail", forward_ref_listsort);
+  s->add_constructor(listSpec, nildecl);
+  s->add_constructor(listSpec, consdecl);
+  Sort listsort = s->make_datatype_sort(listSpec, forward_ref_listsort);
+}
+
 TEST_P(DTTests, DatatypeDecl)
 {
     SolverConfiguration sc = GetParam();


### PR DESCRIPTION
This PR adds support for mutually recursive datatypes in the CVC4 backend. This is accomplished by using uninterpreted sorts as unresolved datatype sorts to allow referencing them before completely defining the datatype. This is a direct wrapping of the CVC4 API's approach.