### PR TITLE
Explicitly find PythonLibs

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -125,6 +125,9 @@ if (BUILD_PYTHON_BINDINGS)
   # i.e. when the following issue is resolved:
   # https://github.com/scikit-build/scikit-build/issues/506
   find_package(PythonInterp 3.5 REQUIRED)
+  if (PYTHON_INTERP_FOUND)
+    find_package(PythonLibs "${PYTHON_VERSION_MAJOR}.${PYTHON_VERSION_MINOR}" REQUIRED)
+  endif()
 endif()
 
 if (BUILD_BITWUZLA OR BUILD_CVC4 OR BUILD_MSAT OR BUILD_YICES2 OR BUILD_Z3)


### PR DESCRIPTION
There was a case on Mac where the correct python interpreter was found, but the `scikit-build` CMake files pulled in a `python2.7` library. This PR explicitly looks for the Python library with the same version, separately from the `scikit-build` infrastructure.