### PR TITLE
Support get-unsat-assumptions in Z3 backend

### DIFF
--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -169,9 +169,12 @@ class MsatSolver : public AbsSmtSolver
   size_t max_assump_clauses_;  ///< number of assumption clauses before clearing
                                ///< them
   bool last_query_assuming;    ///< set to true if last query was
-                             ///< check-sat-assuming used to respect
-                             ///< get_unsat_assumptions interface (will complain
-                             ///< if not called after check-sat-assuming)
+                               ///< check-sat-assuming (as opposed to
+                               ///< just check-sat).
+                               ///< This boolean is used to respect the
+                               ///< get_unsat_assumptions interface (will
+                               ///< complain if not called after
+                               ///< check-sat-assuming).
 
   // clears assumption clauses
   // needed to simulate the same check_sat_assuming interface as other solvers

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -47,9 +47,8 @@ class MsatSolver : public AbsSmtSolver
         env_uninitialized(true),
         logic(""),
         num_assump_clauses_(0),
-        max_assump_clauses_(10000)
-    {
-    };
+        max_assump_clauses_(10000),
+        last_query_assuming(true){};
   MsatSolver(msat_config c, msat_env e)
       : AbsSmtSolver(MSAT),
         cfg(c),
@@ -169,6 +168,10 @@ class MsatSolver : public AbsSmtSolver
   size_t num_assump_clauses_;  ///< counts how many assumption clauses are added
   size_t max_assump_clauses_;  ///< number of assumption clauses before clearing
                                ///< them
+  bool last_query_assuming;    ///< set to true if last query was
+                             ///< check-sat-assuming used to respect
+                             ///< get_unsat_assumptions interface (will complain
+                             ///< if not called after check-sat-assuming)
 
   // clears assumption clauses
   // needed to simulate the same check_sat_assuming interface as other solvers

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -193,6 +193,7 @@ void MsatSolver::assert_formula(const Term & t)
 Result MsatSolver::check_sat()
 {
   initialize_env();
+  last_query_assuming = false;
   clear_assumption_clauses();
   msat_result mres = msat_solve(env);
 
@@ -213,6 +214,7 @@ Result MsatSolver::check_sat()
 Result MsatSolver::check_sat_assuming(const TermVec & assumptions)
 {
   initialize_env();
+  last_query_assuming = true;
   clear_assumption_clauses();
   size_t num_assumps = assumptions.size();
   vector<msat_term> m_assumps;
@@ -372,12 +374,12 @@ void MsatSolver::get_unsat_assumptions(UnorderedTermSet & out)
   initialize_env();
   size_t core_size;
   msat_term * mcore = msat_get_unsat_assumptions(env, &core_size);
-  if (!mcore || !core_size)
+  if (!last_query_assuming)
   {
-    throw InternalSolverException(
-        "Got an empty unsat core. Ensure your last call was unsat and had "
-        "assumptions in check_sat_assuming that are required to get an unsat "
-        "result");
+    throw SmtException(
+        "Called get_unsat_assumptions after check-sat, or "
+        "check-sat-assuming with no assumptions. Should be "
+        "used after a non-trivial call to check-sat-assuming.");
   }
   msat_term * mcore_iter = mcore;
   for (size_t i = 0; i < core_size; ++i)

--- a/src/solver_enums.cpp
+++ b/src/solver_enums.cpp
@@ -97,6 +97,7 @@ const unordered_map<SolverEnum, unordered_set<SolverAttribute>>
             THEORY_REAL,
             ARRAY_FUN_BOOLS,
             CONSTARR,
+            UNSAT_CORE,
             QUANTIFIERS,
             UNINTERP_SORT } },
 

--- a/tests/python/test_unsat_core.py
+++ b/tests/python/test_unsat_core.py
@@ -17,7 +17,6 @@
 import pytest
 import smt_switch as ss
 
-# z3 backend doesn't support unsat assumptions yet
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_unsat_assumptions_simple(create_solver):
     solver = create_solver(False)

--- a/tests/python/test_unsat_core.py
+++ b/tests/python/test_unsat_core.py
@@ -18,7 +18,7 @@ import pytest
 import smt_switch as ss
 
 # z3 backend doesn't support unsat assumptions yet
-@pytest.mark.parametrize("create_solver", [f for name, f in ss.solvers.items() if name != 'z3'])
+@pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_unsat_assumptions_simple(create_solver):
     solver = create_solver(False)
     solver.set_opt("produce-unsat-assumptions", "true")

--- a/tests/test-unsat-core.cpp
+++ b/tests/test-unsat-core.cpp
@@ -35,14 +35,7 @@ class UnsatCoreTests : public ::testing::Test,
     SolverConfiguration sc = GetParam();
     s = create_solver(sc);
     s->set_opt("incremental", "true");
-    if (sc.solver_enum == GENERIC_SOLVER)
-    {
-      s->set_opt("produce-unsat-assumptions", "true");
-    }
-    else
-    {
-      s->set_opt("produce-unsat-assumptions", "true");
-    }
+    s->set_opt("produce-unsat-assumptions", "true");
     boolsort = s->make_sort(BOOL);
     bvsort = s->make_sort(BV, 8);
   }
@@ -96,6 +89,24 @@ TEST_P(UnsatCoreTests, UnsatCoreNonLit)
   UnorderedTermSet core;
   s->get_unsat_assumptions(core);
   ASSERT_TRUE(core.size() > 1);
+}
+
+TEST_P(UnsatCoreTests, NoAssumptionsNeeded)
+{
+  Term a = s->make_symbol("a", boolsort);
+  Term b = s->make_symbol("b", boolsort);
+  // make unsat without assumptions
+  s->assert_formula(a);
+  Term nota = s->make_term(Not, a);
+  s->assert_formula(nota);
+
+  Result r = s->check_sat_assuming({ b });
+  UnorderedTermSet core;
+  s->get_unsat_assumptions(core);
+  // a and not(a) were not in assumptions
+  // so shouldn't show up in unsat assumptions
+  ASSERT_TRUE(core.find(a) == core.end());
+  ASSERT_TRUE(core.find(nota) == core.end());
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/z3/include/z3_solver.h
+++ b/z3/include/z3_solver.h
@@ -38,7 +38,12 @@ namespace smt {
 class Z3Solver : public AbsSmtSolver
 {
  public:
-  Z3Solver() : AbsSmtSolver(Z3), ctx(), slv(ctx), context_level(0){};
+  Z3Solver()
+      : AbsSmtSolver(Z3),
+        ctx(),
+        slv(ctx),
+        context_level(0),
+        last_query_assuming(false){};
   Z3Solver(const Z3Solver &) = delete;
   Z3Solver & operator=(const Z3Solver &) = delete;
   ~Z3Solver(){};
@@ -123,11 +128,14 @@ class Z3Solver : public AbsSmtSolver
 
   uint64_t context_level;  ///< context level for incremental solving
 
+  bool last_query_assuming;  ///< used to determine if last query was
+                             ///< check_sat_assuming (vs just check_sat)
+
   // helper function
   inline Result check_sat_assuming(expr_vector & z3assumps)
   {
+    last_query_assuming = true;
     check_result r = slv.check(z3assumps);
-    ;
     if (r == unsat)
     {
       return Result(UNSAT);


### PR DESCRIPTION
This PR adds support and tests `get_unsat_assumptions` for the Z3 backend.