### PR TITLE
Avoid debugger stopping on raised error

### DIFF
--- a/python/smt_switch/__init__.py.in
+++ b/python/smt_switch/__init__.py.in
@@ -1,6 +1,11 @@
 from .smt_switch import *
 
 try:
+    # try importing pysmt first
+    # this helps with some debuggers so they don't treat the ModuleNotFoundError
+    # raised by pysmt_frontend as uncaught (thus stopping execution) if pysmt is
+    # not available
+    import pysmt
     from . import pysmt_frontend
 except ImportError:
     pass


### PR DESCRIPTION
Some debuggers stop at https://github.com/stanford-centaur/smt-switch/blob/e8478feb3a28d2c0f78ae7c380157e59ddeba912/python/smt_switch/pysmt_frontend/__init__.py#L3 when `pysmt` is not installed. This happens even though the error is caught [here](https://github.com/stanford-centaur/smt-switch/blob/e8478feb3a28d2c0f78ae7c380157e59ddeba912/python/smt_switch/__init__.py.in#L4).

To avoid this issue, it helps to try to import `pysmt` earlier, so the debugger can tell the raised error is caught.