### PR TITLE
Add BUILD_TESTS option to CMakeLists.txt

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -131,9 +131,6 @@ if (BUILD_BITWUZLA OR BUILD_CVC5 OR BUILD_MSAT OR BUILD_YICES2 OR BUILD_Z3)
   find_package(GMP REQUIRED)
 endif()
 
-# build testing infrastructure
-enable_testing()
-
 # should we build boolector?
 option (BUILD_BTOR
   "Should we build the libraries for boolector" OFF)
@@ -226,10 +223,19 @@ if (BUILD_PYTHON_BINDINGS)
   add_subdirectory(python)
 endif()
 
-# Add tests subdirectory
-# The CMakeLists.txt file there sets up googletest
-# and builds all the parametrized tests
-add_subdirectory(tests)
+# should we build the tests
+option (BUILD_TESTS
+  "Should we build the test suite" ON)
+
+if (BUILD_TESTS)
+  # build testing infrastructure
+  enable_testing()
+
+  # Add tests subdirectory
+  # The CMakeLists.txt file there sets up googletest
+  # and builds all the parametrized tests
+  add_subdirectory(tests)
+endif()
 
 # install smt-switch
 install(TARGETS smt-switch DESTINATION lib)

--- a/configure.sh
+++ b/configure.sh
@@ -27,6 +27,7 @@ Configures the CMAKE build environment.
 --build-dir=STR         custom build directory  (default: build)
 --debug                 build debug with debug symbols (default: off)
 --static                create static libaries (default: off)
+--without-tests         build without the smt-switch test suite (default: off)
 --python                compile with python bindings (default: off)
 --smtlib-reader         include the smt-lib reader - requires bison/flex (default:off)
 --bison-dir=STR         custom bison installation directory
@@ -58,6 +59,7 @@ msat_home=default
 yices2_home=default
 z3_home=default
 static=default
+build_tests=default
 python=default
 smtlib_reader=default
 bison_dir=default
@@ -175,6 +177,9 @@ do
         --static)
             static=yes
             ;;
+        --without-tests)
+            build_tests=no
+            ;;
         --python)
             python=yes
             ;;
@@ -269,6 +274,9 @@ cmake_opts="$cmake_opts -DCMAKE_BUILD_TYPE=$build_type"
 
 [ $static != default ] \
     && cmake_opts="$cmake_opts -DSMT_SWITCH_LIB_TYPE=STATIC"
+
+[ $build_tests != default ] \
+    && cmake_opts="$cmake_opts -DBUILD_TESTS=$build_tests"
 
 [ $python != default ] \
     && cmake_opts="$cmake_opts -DBUILD_PYTHON_BINDINGS=ON"


### PR DESCRIPTION
Defaults to ON, when disabled prevents googletest being downloaded and tests being compiled.
When using smt-switch as a library there is generally no need to download googletest and run its test suite.