### PR TITLE
Require a list or set in check-sat-assuming through Python interface

### DIFF
--- a/python/smt_switch/smt_switch_imp.pxi
+++ b/python/smt_switch/smt_switch_imp.pxi
@@ -1,4 +1,5 @@
 from abc import ABC, abstractmethod
+from collections.abc import Iterable, Sequence
 
 from cython.operator cimport dereference as dref
 from libcpp.string cimport string
@@ -284,6 +285,9 @@ cdef class SmtSolver:
     def check_sat_assuming(self, assumptions):
         cdef c_TermVec ctv
         cdef Result r = Result()
+        if not isinstance(assumptions, list) and \
+           not isinstance(assumptions, set):
+            raise ValueError('check_sat_assuming takes a list or set of Term assumptions')
         for a in assumptions:
             if not isinstance(a, Term):
                 raise ValueError("Expecting a Term but got {}")

--- a/tests/python/test_unit.py
+++ b/tests/python/test_unit.py
@@ -123,15 +123,15 @@ def test_check_sat_assuming(create_solver):
 
     xeq0 = solver.make_term(ss.primops.Equal, x, solver.make_term(0, bvsort8))
     solver.assert_formula(solver.make_term(ss.primops.Not, xeq0))
-    solver.assert_formula(solver.make_term(ss.primops.Implies, b, xeq0))
 
-    try:
-        solver.check_sat_assuming([xeq0])
-        assert False, "Expecting a thrown exception for check_sat_assuming with a formula"
-    except:
-        pass
+    with pytest.raises(ValueError):
+        # expect an exception if assumptions are not a list or set
+        solver.check_sat_assuming(xeq0)
 
-    r = solver.check_sat_assuming([b])
+    r = solver.check_sat_assuming([xeq0])
+    assert r.is_unsat()
+
+    r = solver.check_sat_assuming({xeq0})
     assert r.is_unsat()
 
 


### PR DESCRIPTION
It can be easy to accidentally pass a single term to check_sat_assuming and not get an error. There was no error because terms are iterable, so it adds all the children as assumptions. However, this is typically not the desired behavior and can be very confusing.