### PR TITLE
Install older version of setuptools on macOS CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -43,7 +43,13 @@ jobs:
             gmp \
             gperf
 
-      - name: Python Dependencies
+      # install previous version of setuptools as temporary fix
+       # see also recommendations here: https://github.com/pypa/setuptools/issues/3227
+      - name: Python Dependencies (macOS)
+        if: runner.os == 'macOS'
+        run: python3 -m pip install 'setuptools<61'
+
+      - name: Python Dependencies (all)
         run: |
           python3 -m pip install Cython pytest scikit-build toml
 


### PR DESCRIPTION
Python bindings installation is failing on macOS, likely due to an updated `setuptools`. Install an older version to temporarily avoid this issue.

See https://github.com/upscale-project/pono/pull/302 and https://github.com/pypa/setuptools/issues/3227 for more information.