### PR TITLE
update disjoint test 

### DIFF
--- a/tests/test-disjointset.cpp
+++ b/tests/test-disjointset.cpp
@@ -57,22 +57,21 @@ static bool disjoint_set_rank(const Term & t1, const Term & t2)
 
 TEST_P(DisjointSetTests, TestDisjointSet)
 {
-  Term t;
+  Term t1, t2, t3, t4;
   DisjointSet ds(disjoint_set_rank);
 
   ds.add(z, y);
-  t = ds.find(y);
-  EXPECT_TRUE(t == y);
-  t = ds.find(z);
-  EXPECT_TRUE(t == y);
+  t1 = ds.find(y);
+  t2 = ds.find(z);
+  EXPECT_TRUE(t1 == t2);
 
   ds.add(x, y);
-  t = ds.find(y);
-  EXPECT_TRUE(t == y);
+  t3 = ds.find(x);
+  EXPECT_TRUE(t1 == t3);
 
   ds.add(w, z);
-  t = ds.find(w);
-  EXPECT_TRUE(t == y);
+  t4 = ds.find(w);
+  EXPECT_TRUE(t1 == t4);
 }
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedSolverDisjointSetTests,


### PR DESCRIPTION
This PR updates the disjointset test so that it works with different compiler optimizations. 

Previously, the test checks were assuming certain ordering of the terms, and that assumption was sometimes not met because of the compiler optimization.

Now, the updated test doesn't assume the ordering. 