### PR TITLE
Fix issue with GMP backed pysmt

### DIFF
--- a/python/smt_switch/pysmt_frontend/pysmt_solver.py
+++ b/python/smt_switch/pysmt_frontend/pysmt_solver.py
@@ -352,7 +352,7 @@ class SwitchConverter(Converter, DagWalker):
             val = formula.constant_value()
             res = self.make_term(f'{val.numerator}/{val.denominator}', sort)
         else:
-            res = self.make_term(repr(formula.constant_value()), sort)
+            res = self.make_term(str(formula.constant_value()), sort)
         return res
 
     walk_bool_constant = _walk_constant


### PR DESCRIPTION
I bug was reported to me by @cterrill26 when pySMT uses GMP to for integer constants that the converter fails (see https://github.com/pysmt/pysmt/blob/master/pysmt/constants.py).

This bug results from  `(repr(formula.constant_value())` returning `"mpz(value)"` (with value being an integer constant) where we want `"value"`.  Using `str` instead of `repr` resolves this problem. 

I submit no tests of this change as doing so would require building with GMP present and without. 