### PR TITLE
Allow using local GTest

### DIFF
--- a/configure.sh
+++ b/configure.sh
@@ -28,6 +28,7 @@ Configures the CMAKE build environment.
 --debug                 build debug with debug symbols (default: off)
 --static                create static libaries (default: off)
 --without-tests         build without the smt-switch test suite (default: off)
+--no-system-gtest       do not use system GTest sources; forces download (default: off)
 --python                compile with python bindings (default: off)
 --smtlib-reader         include the smt-lib reader - requires bison/flex (default:off)
 --bison-dir=STR         custom bison installation directory
@@ -60,6 +61,7 @@ yices2_home=default
 z3_home=default
 static=default
 build_tests=default
+system_gtest=default
 python=default
 smtlib_reader=default
 bison_dir=default
@@ -180,6 +182,9 @@ do
         --without-tests)
             build_tests=no
             ;;
+        --no-system-gtest)
+            system_gtest=no
+            ;;
         --python)
             python=yes
             ;;
@@ -277,6 +282,9 @@ cmake_opts="$cmake_opts -DCMAKE_BUILD_TYPE=$build_type"
 
 [ $build_tests != default ] \
     && cmake_opts="$cmake_opts -DBUILD_TESTS=$build_tests"
+
+[ $system_gtest != default ] \
+    && cmake_opts="$cmake_opts -DSYSTEM_GTEST=$system_gtest"
 
 [ $python != default ] \
     && cmake_opts="$cmake_opts -DBUILD_PYTHON_BINDINGS=ON"

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,26 +3,31 @@
 # build testing infrastructure
 enable_testing()
 
-# Download and unpack googletest at configure time
-configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
-execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "CMake step for googletest failed: ${result}")
-endif()
-execute_process(COMMAND ${CMAKE_COMMAND} --build .
-  RESULT_VARIABLE result
-  WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
-if(result)
-  message(FATAL_ERROR "Build step for googletest failed: ${result}")
-endif()
+# first try finding a system installation of googletest
+find_package(GTest CONFIG)
 
-# Add googletest directly to our build. This defines
-# the gtest and gtest_main targets.
-add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
-                 ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
-                 EXCLUDE_FROM_ALL)
+if(NOT GTest_FOUND)
+  # Download and unpack googletest at configure time
+  configure_file(CMakeLists.txt.in googletest-download/CMakeLists.txt)
+  execute_process(COMMAND ${CMAKE_COMMAND} -G "${CMAKE_GENERATOR}" .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+  if(result)
+    message(FATAL_ERROR "CMake step for googletest failed: ${result}")
+  endif()
+  execute_process(COMMAND ${CMAKE_COMMAND} --build .
+    RESULT_VARIABLE result
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}/googletest-download )
+  if(result)
+    message(FATAL_ERROR "Build step for googletest failed: ${result}")
+  endif()
+
+  # Add googletest directly to our build. This defines
+  # the gtest and gtest_main targets.
+  add_subdirectory(${CMAKE_CURRENT_BINARY_DIR}/googletest-src
+                  ${CMAKE_CURRENT_BINARY_DIR}/googletest-build
+                  EXCLUDE_FROM_ALL)
+endif()
 
 add_library(test-deps "${SMT_SWITCH_LIB_TYPE}"
   "${PROJECT_SOURCE_DIR}/tests/available_solvers.cpp"
@@ -62,7 +67,7 @@ endif()
 
 macro(switch_add_test name)
   add_executable(${name} "${PROJECT_SOURCE_DIR}/tests/${name}.cpp")
-  target_link_libraries(${name} gtest_main)
+  target_link_libraries(${name} gtest gtest_main)
   target_link_libraries(${name} test-deps)
   add_test(NAME ${name}_test COMMAND ${name})
 endmacro()

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -3,8 +3,14 @@
 # build testing infrastructure
 enable_testing()
 
-# first try finding a system installation of googletest
-find_package(GTest CONFIG)
+option (SYSTEM_GTEST "Should we try to use the system GTest" ON)
+
+if (SYSTEM_GTEST)
+  # try finding a system installation of googletest
+  find_package(GTest 1.12 CONFIG)
+else()
+  set(GTest_FOUND FALSE)
+endif()
 
 if(NOT GTest_FOUND)
   # Download and unpack googletest at configure time

--- a/tests/btor/CMakeLists.txt
+++ b/tests/btor/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(switch_add_btor_test name)
   add_executable(${name} "${PROJECT_SOURCE_DIR}/tests/btor/${name}.cpp")
-  target_link_libraries(${name} gtest_main)
+  target_link_libraries(${name} gtest gtest_main)
   target_link_libraries(${name} test-deps)
   add_test(NAME ${name}_test COMMAND ${name})
 endmacro()

--- a/tests/cvc5/CMakeLists.txt
+++ b/tests/cvc5/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(switch_add_cvc5_test name)
   add_executable(${name} "${PROJECT_SOURCE_DIR}/tests/cvc5/${name}.cpp")
-  target_link_libraries(${name} gtest_main)
+  target_link_libraries(${name} gtest gtest_main)
   target_link_libraries(${name} test-deps)
   add_test(NAME ${name}_test COMMAND ${name})
 endmacro()

--- a/tests/msat/CMakeLists.txt
+++ b/tests/msat/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(switch_add_msat_test name)
   add_executable(${name} "${PROJECT_SOURCE_DIR}/tests/msat/${name}.cpp")
-  target_link_libraries(${name} gtest_main)
+  target_link_libraries(${name} gtest gtest_main)
   target_link_libraries(${name} test-deps)
   add_test(NAME ${name}_test COMMAND ${name})
 endmacro()

--- a/tests/portfolio/CMakeLists.txt
+++ b/tests/portfolio/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(switch_add_portfolio_test name)
   add_executable(${name} "${PROJECT_SOURCE_DIR}/tests/portfolio/${name}.cpp")
-  target_link_libraries(${name} gtest_main)
+  target_link_libraries(${name} gtest gtest_main)
   target_link_libraries(${name} test-deps)
   add_test(NAME ${name}_test COMMAND ${name})
 endmacro()

--- a/tests/unit/CMakeLists.txt
+++ b/tests/unit/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(switch_add_unit_test name)
   add_executable(${name} "${PROJECT_SOURCE_DIR}/tests/unit/${name}.cpp")
-  target_link_libraries(${name} gtest_main)
+  target_link_libraries(${name} gtest gtest_main)
   target_link_libraries(${name} test-deps)
   add_test(NAME ${name}_test COMMAND ${name})
 endmacro()

--- a/tests/yices2/CMakeLists.txt
+++ b/tests/yices2/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(switch_add_yices2_test name)
   add_executable(${name} "${PROJECT_SOURCE_DIR}/tests/yices2/${name}.cpp")
-  target_link_libraries(${name} gtest_main)
+  target_link_libraries(${name} gtest gtest_main)
   target_link_libraries(${name} test-deps)
   add_test(NAME ${name}_test COMMAND ${name})
 endmacro()

--- a/tests/z3/CMakeLists.txt
+++ b/tests/z3/CMakeLists.txt
@@ -1,6 +1,6 @@
 macro(switch_add_z3_test name)
   add_executable(${name} "${PROJECT_SOURCE_DIR}/tests/z3/${name}.cpp")
-  target_link_libraries(${name} gtest_main)
+  target_link_libraries(${name} gtest gtest_main)
   target_link_libraries(${name} test-deps)
   add_test(NAME ${name}_test COMMAND ${name})
 endmacro()


### PR DESCRIPTION
This searches for the system-provided version of GTest first, and only downloads it if it's not available.

Another possible improvement would be to not re-download GTest every time `configure.sh` is run.