### PR TITLE
Update boolector to most recent version (3.2.3 plus extra)

### DIFF
--- a/btor/CMakeLists.txt
+++ b/btor/CMakeLists.txt
@@ -16,7 +16,7 @@ target_include_directories (smt-switch-btor PUBLIC "${BTOR_HOME}/src")
 
 target_link_libraries(smt-switch-btor "${BTOR_HOME}/build/lib/libboolector.a")
 target_link_libraries(smt-switch-btor "${BTOR_HOME}/deps/cadical/build/libcadical.a")
-target_link_libraries(smt-switch-btor "${BTOR_HOME}/deps/btor2tools/build/libbtor2parser.a")
+target_link_libraries(smt-switch-btor "${BTOR_HOME}/deps/btor2tools/build/lib/libbtor2parser.a")
 target_link_libraries(smt-switch-btor smt-switch)
 target_link_libraries(smt-switch-btor pthread)
 target_link_libraries(smt-switch-btor m)
@@ -30,7 +30,7 @@ if (SMT_SWITCH_LIB_TYPE STREQUAL STATIC)
       mkdir smt-switch-btor && cd smt-switch-btor && ar -x "../$<TARGET_FILE_NAME:smt-switch-btor>" && cd ../ &&
       mkdir boolector && cd boolector && ar -x "${BTOR_HOME}/build/lib/libboolector.a" &&
       ar -x "${BTOR_HOME}/deps/cadical/build/libcadical.a" &&
-      ar -x "${BTOR_HOME}/deps/btor2tools/build/libbtor2parser.a" && cd ../ &&
+      ar -x "${BTOR_HOME}/deps/btor2tools/build/lib/libbtor2parser.a" && cd ../ &&
       ar -qc "$<TARGET_FILE_NAME:smt-switch-btor>" ./boolector/*.o ./smt-switch-btor/*.o &&
       # now clean up
       rm -rf smt-switch-btor boolector

--- a/contrib/setup-btor.sh
+++ b/contrib/setup-btor.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-BTOR_VERSION=95859db82fe5b08d063a16d6a7ffe4a941cb0f7d
+BTOR_VERSION=97698b06a5de1a4e5743c034c867d384630dc936
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
 

--- a/contrib/setup-btor.sh
+++ b/contrib/setup-btor.sh
@@ -31,7 +31,7 @@ else
     echo "$DEPS/boolector already exists. If you want to rebuild, please remove it manually."
 fi
 
-if [ -f $DEPS/boolector/build/lib/libboolector.a ] && [ -f $DEPS/boolector/deps/cadical/build/libcadical.a ] && [ -f $DEPS/boolector/deps/btor2tools/build/btor2parser.o ] ; then \
+if [ -f $DEPS/boolector/build/lib/libboolector.a ] && [ -f $DEPS/boolector/deps/cadical/build/libcadical.a ] && [ -f $DEPS/boolector/deps/btor2tools/build/lib/libbtor2parser.a ] ; then \
     echo "It appears boolector was setup successfully into $DEPS/boolector."
     echo "You may now install it with make ./configure.sh --btor && cd build && make"
 else


### PR DESCRIPTION
This resolves the GTest errors uncovered in #343 by pulling in https://github.com/Boolector/boolector/commit/05a38915d642a3f296ff041230a6945d703a268a. That commit updates the GTest version used by Boolector from 1.10.0 to 1.12.1, which includes [the fix](https://github.com/google/googletest/pull/2815).