### PR TITLE
Fix issues with CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,6 +18,8 @@ jobs:
         include:
           - name: msat
             setup_opts: --auto-yes
+          - name: yices2
+            extra_macos_packages: autoconf
 
     name: ${{ matrix.os }}:${{ matrix.name }} 
     runs-on: ${{ matrix.os}}
@@ -41,7 +43,8 @@ jobs:
           brew update
           brew install \
             gmp \
-            gperf
+            gperf \
+            ${{ matrix.extra_macos_packages }}
 
       - name: Python Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
             gmp \
             gperf \
             ${{ matrix.extra_macos_packages }}
+          echo "LDFLAGS=-L$(brew --prefix)/lib $LDFLAGS" >> "$GITHUB_ENV"
+          echo "CFLAGS=-I$(brew --prefix)/include $CFLAGS" >> "$GITHUB_ENV"
+          echo "CPPFLAGS=-I$(brew --prefix)/include $CPPFLAGS" >> "$GITHUB_ENV"
+
 
       - name: Python Dependencies
         run: |

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,9 +45,11 @@ jobs:
 
       - name: Python Dependencies
         run: |
-          python3 -m pip install --user Cython==0.29.*
-          python3 -m pip install --user pytest scikit-build toml pyparsing
-          echo "$(python3 -m site --user-base)/bin" >> $GITHUB_PATH
+          python3 -m venv ./.venv
+          source ./.venv/bin/activate
+          python3 -m pip install Cython==0.29.*
+          python3 -m pip install pytest scikit-build toml pyparsing
+          echo "$PWD/.venv/bin" >> $GITHUB_PATH
 
       - name: Install Bison
         run: ./contrib/setup-bison.sh
@@ -73,7 +75,7 @@ jobs:
           make test
 
       - name: Install Python Bindings
-        run: python3 -m pip install --user -e ./build/python[test,pysmt]
+        run: python3 -m pip install -e ./build/python[test,pysmt]
 
       - name: Test Python Bindings
         run: pytest ./tests

--- a/ci-scripts/setup-msat.sh
+++ b/ci-scripts/setup-msat.sh
@@ -43,13 +43,13 @@ if [ ! -d "$DEPS/mathsat" ]; then
     cd $DEPS
     mkdir mathsat
     if [[ "$OSTYPE" == linux* ]]; then
-        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.4-linux-x86_64.tar.gz
+        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.10-linux-x86_64.tar.gz
     elif [[ "$OSTYPE" == darwin* ]]; then
-        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.4-darwin-libcxx-x86_64.tar.gz
+        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.10-osx.tar.gz
     elif [[ "$OSTYPE" == msys* ]]; then
-        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.4-win64-msvc.zip
+        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.10-win64-msvc.zip
     elif [[ "$OSTYPE" == cygwin* ]]; then
-        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.4-linux-x86_64.tar.gz
+        curl -o mathsat.tar.gz -L https://mathsat.fbk.eu/download.php?file=mathsat-5.6.10-linux-x86_64.tar.gz
     else
         echo "Unrecognized OSTYPE=$OSTYPE"
         exit 1

--- a/contrib/setup-bison.sh
+++ b/contrib/setup-bison.sh
@@ -3,6 +3,7 @@ set -e
 
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
 DEPS=$DIR/../deps
+VERSION=3.8.2
 
 mkdir -p $DEPS
 
@@ -12,17 +13,17 @@ if [ -d "$DEPS/bison" ]; then
     exit 1
 fi
 
-curl http://ftp.gnu.org/gnu/bison/bison-3.7.tar.xz --output $DEPS/bison-3.7.tar.xz
+curl http://ftp.gnu.org/gnu/bison/bison-$VERSION.tar.xz --output $DEPS/bison-$VERSION.tar.xz
 
-if [ ! -f "$DEPS/bison-3.7.tar.xz" ]; then
-    echo "It seems like downloading bison to $DEPS/bison-3.7.tar.xz failed"
+if [ ! -f "$DEPS/bison-$VERSION.tar.xz" ]; then
+    echo "It seems like downloading bison to $DEPS/bison-$VERSION.tar.xz failed"
     exit 1
 fi
 
 cd $DEPS
-tar -xf bison-3.7.tar.xz
-rm bison-3.7.tar.xz
-mv ./bison-3.7 ./bison
+tar -xf bison-$VERSION.tar.xz
+rm bison-$VERSION.tar.xz
+mv ./bison-$VERSION ./bison
 cd bison
 mkdir bison-install
 ./configure --prefix $DEPS/bison/bison-install --exec-prefix $DEPS/bison/bison-install


### PR DESCRIPTION
This fixes a number of issues that make our CI workflows fail:
* `pip install --user` outside an environment not working due to [PEP 668](https://peps.python.org/pep-0668/)
* old versions of Bison being broken by GCC updates
* dependencies (autoconf) not being installed on the current GitHub macOS images
* paths on macOS being broken due to Homebrew updates