### PR TITLE
Unify static lib repacking to always use script

### DIFF
--- a/btor/CMakeLists.txt
+++ b/btor/CMakeLists.txt
@@ -24,18 +24,31 @@ target_link_libraries(smt-switch-btor m)
 if (SMT_SWITCH_LIB_TYPE STREQUAL STATIC)
   # we want the static library to include the boolector source
   # we need to unpack and repack the libraries
-  add_custom_target(repack-btor-static-lib
-    ALL
+  add_custom_command(
+    OUTPUT static-smt-switch-btor.stamp
     COMMAND
-      mkdir smt-switch-btor && cd smt-switch-btor && ar -x "../$<TARGET_FILE_NAME:smt-switch-btor>" && cd ../ &&
-      mkdir boolector && cd boolector && ar -x "${BTOR_HOME}/build/lib/libboolector.a" &&
-      ar -x "${PROJECT_SOURCE_DIR}/deps/install/lib/libcadical.a" &&
-      ar -x "${BTOR_HOME}/deps/btor2tools/build/lib/libbtor2parser.a" && cd ../ &&
-      ar -qc "$<TARGET_FILE_NAME:smt-switch-btor>" ./boolector/*.o ./smt-switch-btor/*.o &&
+      mkdir smt-switch-btor-working && cd smt-switch-btor-working &&
+      # create new static library that combines them all
+      ${PROJECT_SOURCE_DIR}/scripts/repack-static-lib.sh "$<TARGET_FILE_NAME:smt-switch-btor>"
+        "${BTOR_HOME}/build/lib/libboolector.a"
+        "${PROJECT_SOURCE_DIR}/deps/install/lib/libcadical.a"
+        "${BTOR_HOME}/deps/btor2tools/build/lib/libbtor2parser.a"
+        "../$<TARGET_FILE_NAME:smt-switch-btor>" &&
+      # replace the original one
+      mv "$<TARGET_FILE_NAME:smt-switch-btor>" "../$<TARGET_FILE_NAME:smt-switch-btor>" &&
       # now clean up
-      rm -rf smt-switch-btor boolector
+      cd .. && rm -rf smt-switch-btor-working
+    COMMAND ${CMAKE_COMMAND} -E touch static-smt-switch-btor.stamp
     DEPENDS
       smt-switch-btor
+    WORKING_DIRECTORY ${CMAKE_CURRENT_BINARY_DIR}
+    VERBATIM
+    )
+
+  add_custom_target(repack-btor-static-lib
+    ALL
+    DEPENDS
+      static-smt-switch-btor.stamp
     )
 endif()
 

--- a/msat/CMakeLists.txt
+++ b/msat/CMakeLists.txt
@@ -21,22 +21,18 @@ target_link_libraries(smt-switch-msat ${GMPXX_LIBRARIES})
 if (SMT_SWITCH_LIB_TYPE STREQUAL STATIC)
   # we want the static library to include the mathsat source
   # we need to unpack and repack the libraries
-  # newer versions of mathsat (5.6.4+) have the same issue as cvc5 where
-  # unpacking and repacking with ar seemed to lose info (missing symbols)
-  # the work around is to just copy libmathsat.a and add to it
   add_custom_command(
     OUTPUT static-smt-switch-msat.stamp
     COMMAND
-    mkdir ssm && cd ssm &&
-    ar -x "../$<TARGET_FILE_NAME:smt-switch-msat>" && cd ../
-    && rm "$<TARGET_FILE_NAME:smt-switch-msat>" &&
-    # copy the mathsat static library to libsmt-switch-msat.a
-    cp "${MSAT_HOME}/lib/libmathsat.a" "$<TARGET_FILE_NAME:smt-switch-msat>" &&
-    # add the smt-switch-msat object files to the static library
-    bash -c "ar -rs $<TARGET_FILE_NAME:smt-switch-msat> ./ssm/*.o"
-    &&
-    # now clean up the temporary directory
-    rm -rf ssm
+      mkdir smt-switch-msat-working && cd smt-switch-msat-working &&
+      # create new static library that combines them all
+      ${PROJECT_SOURCE_DIR}/scripts/repack-static-lib.sh "$<TARGET_FILE_NAME:smt-switch-msat>"
+        "${MSAT_HOME}/lib/libmathsat.a"
+        "../$<TARGET_FILE_NAME:smt-switch-msat>" &&
+      # replace the original one
+      mv "$<TARGET_FILE_NAME:smt-switch-msat>" "../$<TARGET_FILE_NAME:smt-switch-msat>" &&
+      # now clean up the temporary directory
+      cd .. && rm -rf smt-switch-msat-working
     COMMAND ${CMAKE_COMMAND} -E touch static-smt-switch-msat.stamp
     DEPENDS
       smt-switch-msat


### PR DESCRIPTION
Use the `repack-static-libs.sh` script for repacking all static libs, because it can handle the archive files containing both x86_64 and arm64 code on macOS properly.