### PR TITLE
Fix deps directory creation

### DIFF
--- a/contrib/setup-bitwuzla.sh
+++ b/contrib/setup-bitwuzla.sh
@@ -3,7 +3,7 @@ set -e
 
 BITWUZLA_VERSION=0e81e616af4d4421729884f01928b194c3536c76
 DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-DEPS="$( cd "$( dirname "$DIR" )/deps" && pwd )"
+DEPS="$( dirname "$DIR" )/deps"
 
 mkdir -p $DEPS
 

--- a/contrib/setup-bitwuzla.sh
+++ b/contrib/setup-bitwuzla.sh
@@ -2,8 +2,8 @@
 set -e
 
 BITWUZLA_VERSION=0e81e616af4d4421729884f01928b194c3536c76
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
-DEPS="$( dirname "$DIR" )/deps"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+DEPS="$(dirname "$DIR")/deps"
 
 mkdir -p $DEPS
 


### PR DESCRIPTION
When the `deps` directory doesn't exist, the `contrib/setup-bitwuzla.sh` script will fail, because it tries to `cd` into it before trying to create it.