### PR TITLE
Update checkout action in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -26,7 +26,7 @@ jobs:
     runs-on: ${{ matrix.os}}
 
     steps:
-      - uses: actions/checkout@v2
+      - uses: actions/checkout@v4
 
       - name: Install Packages (Linux)
         if: runner.os == 'Linux'


### PR DESCRIPTION
CI is currently printing warnings because v2 of the checkout action uses a deprecated version of Node.