### PR TITLE
Don't install gmp in CI on macOs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -44,7 +44,6 @@ jobs:
         run: |
           brew update
           brew install \
-            gmp \
             gperf \
             ninja \
             ${{ matrix.extra_macos_packages }}


### PR DESCRIPTION
It is already installed on macos-latest.