### PR TITLE
Update Cadical to 2.1.3 (latest available)

### DIFF
--- a/contrib/setup-cadical.sh
+++ b/contrib/setup-cadical.sh
@@ -3,7 +3,7 @@ set -o errexit
 set -o pipefail
 set -o nounset
 
-CADICAL_VERSION=rel-1.7.4
+CADICAL_VERSION=rel-2.1.3
 
 SCRIPT_NAME="$(basename "${BASH_SOURCE[0]}")"
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"


### PR DESCRIPTION
The pre-2.1.0 versions no longer work with cvc5.