### PR TITLE
Only trigger CI on push

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,4 +1,4 @@
-on: [push, pull_request]
+on: push
 name: CI
 
 jobs:


### PR DESCRIPTION
The pull request trigger is superfluous, as the CI would have been triggered when that commit was originally pushed anyway. We just waste resources by currently triggering two copies of the workflow whenever someone pushes a branch then opens a pull request.