### PR TITLE
Enable `--arrays-exp` in cvc5 by default

### DIFF
--- a/cvc5/include/cvc5_solver.h
+++ b/cvc5/include/cvc5_solver.h
@@ -47,6 +47,7 @@ class Cvc5Solver : public AbsSmtSolver
   {
     solver.setOption("lang", "smt2");
     solver.setOption("bv-print-consts-as-indexed-symbols", "true");
+    solver.setOption("arrays-exp", "true");
   };
   Cvc5Solver(const Cvc5Solver &) = delete;
   Cvc5Solver & operator=(const Cvc5Solver &) = delete;

--- a/tests/test-generic-solver.cpp
+++ b/tests/test-generic-solver.cpp
@@ -614,7 +614,7 @@ void new_cvc5(SmtSolver & gs, int buffer_size)
   gs.reset();
   string path = (STRFY(CVC5_HOME));
   path += "/build/bin/cvc5";
-  vector<string> args = { "--lang=smt2", "--incremental", "--dag-thresh=0" };
+  vector<string> args = { "--lang=smt2", "--incremental", "--dag-thresh=0", "--arrays-exp" };
   gs = std::make_shared<GenericSolver>(path, args, buffer_size, buffer_size);
   init_solver(gs);
 }


### PR DESCRIPTION
Cvc5 has disabled constant arrays by default in newer versions (since https://github.com/cvc5/cvc5/commit/fbf4750bf951debe903dd00393072aa2e1d426d3). The `--arrays-exp` flag needs to be enabled to keep the old behavior.