### PR TITLE
Fix wheels CI for building wheels

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,6 +1,9 @@
 name: Build and Upload Wheels
 
 on:
+  push:
+    branches:
+      - makaimann/fix-wheels-ci
   release:
     types: [published]
   schedule:

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -87,7 +87,11 @@ jobs:
         CIBW_ENVIRONMENT_MACOS: >
           DYLD_LIBRARY_PATH="$(pwd)/install/lib:$DYLD_LIBRARY_PATH"
           MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos-target }}
-        CIBW_TEST_COMMAND: pytest {project}/tests
+        CIBW_TEST_COMMAND: |
+          # cibuildwheel creates a dedicated virtualenv for the test
+          # make sure to use that python (just calling pytest may use system pytest)
+          python3 -m pip install pytest
+          python3 -m pytest {project}/tests
 
     - name: Upload wheels to PyPI
       if: >

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,9 +1,6 @@
 name: Build and Upload Wheels
 
 on:
-  push:
-    branches:
-      - makaimann/fix-wheels-ci
   release:
     types: [published]
   schedule:

--- a/contrib/setup-cvc5.sh
+++ b/contrib/setup-cvc5.sh
@@ -23,7 +23,8 @@ if [ ! -d "$DEPS/cvc5" ]; then
     git clone https://github.com/cvc5/cvc5.git
     cd cvc5
     git checkout -f ${CVC5_VERSION}
-    ./configure.sh --prefix=$DEPS/install --static --auto-download --dep-path="$DEPS/install"
+    # ensure the cvc5 libraries are placed in deps/install/lib
+    ./configure.sh --prefix=$DEPS/install --static --auto-download --dep-path="$DEPS/install" -DCMAKE_INSTALL_LIBDIR=lib
     cd build
     make -j$NUM_CORES
     make install
@@ -33,11 +34,8 @@ else
 fi
 
 LIBS="$DEPS/install/lib"
-LIBS64="$DEPS/install/lib64" # for systems that install to lib64 (ex: arm)
 
-if [[ -f $LIBS/libcvc5.a || -f $LIBS64/libcvc5.a ]] && \
-   [[ -f $LIBS/libcvc5parser.a || -f $LIBS64/libcvc5parser.a ]] && \
-   [[ -f $LIBS/libcadical.a || -f $LIBS64/libcadical.a ]]; then
+if [ -f $LIBS/libcvc5.a ] && [ -f $LIBS/libcvc5parser.a ] && [ -f $LIBS/libcadical.a ]; then
     echo "It appears cvc5 was setup successfully into $DEPS/install."
     echo "You may now configure smt-switch to build with a cvc5 backend using ./configure.sh --cvc5 && cd build && make"
 else

--- a/contrib/setup-cvc5.sh
+++ b/contrib/setup-cvc5.sh
@@ -33,10 +33,13 @@ else
 fi
 
 LIBS="$DEPS/install/lib"
+LIBS64="$DEPS/install/lib64" # for systems that install to lib64 (ex: arm)
 
-if [ -f $LIBS/libcvc5.a ] && [ -f $LIBS/libcvc5parser.a ] && [ -f $LIBS/libcadical.a ]; then
-    echo "It appears cvc5 was setup successfully into $DEPS/cvc5."
-    echo "You may now install it with ./configure.sh --cvc5 && cd build && make"
+if [[ -f $LIBS/libcvc5.a || -f $LIBS64/libcvc5.a ]] && \
+   [[ -f $LIBS/libcvc5parser.a || -f $LIBS64/libcvc5parser.a ]] && \
+   [[ -f $LIBS/libcadical.a || -f $LIBS64/libcadical.a ]]; then
+    echo "It appears cvc5 was setup successfully into $DEPS/install."
+    echo "You may now configure smt-switch to build with a cvc5 backend using ./configure.sh --cvc5 && cd build && make"
 else
     echo "Building cvc5 failed."
     echo "You might be missing some dependencies."


### PR DESCRIPTION
There were two minor issues causing the `Build Wheels` CI job to fail. This PR resolves both.

### Issue 1
After https://github.com/stanford-centaur/smt-switch/pull/369 merged, the `setup-cvc5.sh` script could not find the `cvc5` libraries on aarch64, because it's stored in `<prefix>/lib64` instead of `<prefix>/lib`.

**Solution:** This PR simply checks both `lib` and `lib64`. This seemed simpler than trying to determine which path it should be based on the architecture -- either location is fine regardless.

### Issue 2
The `CIBW_TEST_COMMAND` is how `cibuildwheel` tests the final wheel. This test was failing nondeterministically. It was because `cibuildwheel` creates a fresh virtualenv that it installs the final (repaired and packaged) wheel in. However, using `pytest` on the CLI used the system python instead of the virtualenv python. Sometimes this found the wrong wheel (the one in the build dir before it's repaired).

**Solution:** I'm not sure why this sometimes worked and sometimes didn't, but ensuring we use the virtualenv python appears to resolve this issue.