### PR TITLE
Support reset-assertions in Bitwuzla API

### DIFF
--- a/bitwuzla/src/bitwuzla_solver.cpp
+++ b/bitwuzla/src/bitwuzla_solver.cpp
@@ -664,8 +664,8 @@ void BzlaSolver::reset()
 
 void BzlaSolver::reset_assertions()
 {
-  throw NotImplementedException(
-      "Bitwuzla does not currently support reset_assertions");
+  delete bzla;
+  bzla = new bitwuzla::Bitwuzla(*tm, options);
 }
 
 Term BzlaSolver::substitute(const Term term,


### PR DESCRIPTION
According to the [documentation](https://bitwuzla.github.io/docs/c/api.html#reset-assertions-example), one can reset assertions in Bitwuzla by discarding the current solver instance and creating a new one.

This feature allows us to use Bitwuzla as the base solver in the `interp` engine of Pono (see https://github.com/stanford-centaur/pono/pull/395#discussion_r2060967479).