### PR TITLE
Add missing stdint.h C header

### DIFF
--- a/include/sort.h
+++ b/include/sort.h
@@ -18,6 +18,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <string>
 #include <unordered_set>
 #include <vector>


### PR DESCRIPTION
Fixes a compilation error in newer compilers (GCC >= 15).