### PR TITLE
Add path to z3 library to Python extension link flags

### DIFF
--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -14,7 +14,7 @@ PROJECT_SOURCE_DIR = "@PROJECT_SOURCE_DIR@"
 PROJECT_BINARY_DIR = "@PROJECT_BINARY_DIR@"
 SMT_SWITCH_LIB_TYPE = "@SMT_SWITCH_LIB_TYPE@"
 BITWUZLA_LDFLAGS = "@BITWUZLA_LDFLAGS@".split(";")
-Z3_LDFLAGS = "@Z3_LDFLAGS@".split(";")
+Z3_LIBRARY_LOCATION = "@Z3_LIBRARY_LOCATION@"
 
 # Get the platform-specific library extension
 if sys.platform == "darwin":
@@ -90,7 +90,7 @@ if not os.path.isfile(os.path.join('smt_switch', ext_filename)):
         if "bitwuzla" in built_solvers:
             extra_link_args += BITWUZLA_LDFLAGS
         if "z3" in built_solvers:
-            extra_link_args += Z3_LDFLAGS
+            extra_link_args.append(Z3_LIBRARY_LOCATION)
 
     # Handle OS-specific settings.
     if sys.platform == 'darwin':

--- a/z3/CMakeLists.txt
+++ b/z3/CMakeLists.txt
@@ -2,8 +2,14 @@
 if(DEFINED Z3_INSTALL_DIR)
   list(PREPEND CMAKE_PREFIX_PATH "${Z3_INSTALL_DIR}")
 endif()
-find_package(PkgConfig REQUIRED)
-pkg_check_modules(Z3 REQUIRED z3)
+find_package(Z3 REQUIRED)
+
+# Variables needed in setup.py
+# TODO: move all compilation commands into CMake
+get_target_property(Z3_CONFIGURATIONS z3::libz3 IMPORTED_CONFIGURATIONS)
+list(GET Z3_CONFIGURATIONS 0 Z3_DEFAULT_CONFIGURATION)
+get_target_property(Z3_LIBRARY_LOCATION z3::libz3 IMPORTED_LOCATION_${Z3_DEFAULT_CONFIGURATION})
+set(Z3_LIBRARY_LOCATION "${Z3_LIBRARY_LOCATION}" PARENT_SCOPE)
 
 add_library(smt-switch-z3 "${SMT_SWITCH_LIB_TYPE}"
   "${CMAKE_CURRENT_SOURCE_DIR}/src/z3_datatype.cpp"
@@ -15,10 +21,9 @@ add_library(smt-switch-z3 "${SMT_SWITCH_LIB_TYPE}"
 
 target_include_directories(smt-switch-z3 PUBLIC "${PROJECT_SOURCE_DIR}/include")
 target_include_directories(smt-switch-z3 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_include_directories(smt-switch-z3 PUBLIC ${Z3_INCLUDE_DIRS})
 target_include_directories(smt-switch-z3 PRIVATE ${GMP_INCLUDE_DIR})
 target_link_libraries(smt-switch-z3 PUBLIC smt-switch)
-target_link_libraries(smt-switch-z3 PUBLIC ${Z3_LDFLAGS})
+target_link_libraries(smt-switch-z3 PUBLIC z3::libz3)
 target_link_libraries(smt-switch-z3 PRIVATE ${GMP_LIBRARIES})
 target_link_libraries(smt-switch-z3 PRIVATE ${GMPXX_LIBRARIES})
 


### PR DESCRIPTION
This also uses the CMake config files provided by Z3 directly instead of using `pkg-config`.