### PR TITLE
Remove "Install Python Bindings" step from CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -98,11 +98,6 @@ jobs:
           cd build
           make test
 
-      - name: Install Python Bindings
-        run: |
-          source ./.venv/bin/activate
-          python3 -m pip install -e ./build/python[test,pysmt]
-
       - name: Test Python Bindings
         run: |
           source ./.venv/bin/activate

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -61,6 +61,7 @@ jobs:
             Cython>=3.0.0 \
             meson \
             pyparsing \
+            pysmt \
             pytest \
             setuptools \
             toml \


### PR DESCRIPTION
The build step already runs `pip install`, so this is just a waste of time and space.

The extras need to be installed manually: `pytest` already was; added `pysmt`.