### PR TITLE
Update dependencies in README and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,9 +36,7 @@ jobs:
           sudo apt-get install -y \
             cmake \
             gperf \
-            libgmp-dev \
-            ninja-build \
-            openjdk-8-jdk
+            ninja-build
 
       - name: Install Packages (macOS)
         if: runner.os == 'macOS'
@@ -46,7 +44,6 @@ jobs:
           brew update
           brew install \
             gperf \
-            ninja \
             ${{ matrix.extra_macos_packages }}
           echo "LDFLAGS=-L$(brew --prefix)/lib $LDFLAGS" >> "$GITHUB_ENV"
           echo "CFLAGS=-I$(brew --prefix)/include $CFLAGS" >> "$GITHUB_ENV"
@@ -58,13 +55,12 @@ jobs:
           python3 -m venv ./.venv
           source ./.venv/bin/activate
           python3 -m pip install \
-            Cython>=3.0.0 \
+            Cython \
             meson \
-            pyparsing \
+            packaging \
             pysmt \
             pytest \
-            setuptools \
-            toml
+            setuptools
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
 
       - name: Install Bison

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -65,24 +65,18 @@ jobs:
             gperf \
             gmp-devel \
             ninja-build \
-            java-1.8.0-openjdk-devel \
             glibc-static \
             libstdc++-static
           bash {project}/ci-scripts/cibw-build-deps.sh
         CIBW_BEFORE_ALL_MACOS: |
           brew update
-          brew install gperf ninja
+          brew install gperf
           brew install SRI-CSL/sri-csl/libpoly
           bash {project}/ci-scripts/cibw-build-deps.sh
         CIBW_BEFORE_BUILD: >
           python3 -m pip install \
             Cython>=3.0.0 \
-            meson \
-            pyparsing \
-            pytest \
-            setuptools \
-            tomli \
-            wheel
+            setuptools
           bash {project}/ci-scripts/cibw-build-before.sh
         CIBW_ENVIRONMENT_MACOS: >
           DYLD_LIBRARY_PATH="$(pwd)/install/lib:$DYLD_LIBRARY_PATH"

--- a/README.md
+++ b/README.md
@@ -67,7 +67,6 @@ Smt-Switch depends on the following libraries. Dependencies needed only for cert
 * pthread [optional: Bitwuzla]
 * gmp [optional: cvc5, MathSAT, Yices2]
 * autoconf [optional: Yices2 setup script]
-* Java [optional: cvc5 ANTLR]
 * Flex >= 2.6.4 [optional: SMT-LIB parser]
 * Bison >= 3.7 [optional: SMT-LIB parser]
 * Python [optional: Python bindings]


### PR DESCRIPTION
These are not needed, because:
1. nothing requires them anymore (e.g., JDK),
2. they come preinstalled in the runner images we use (e.g., GMP, ninja), or
3. they are already installed another way (e.g., Python build dependencies installed in an isolated environment).