### PR TITLE
Store CI failing logs as artifacts

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,7 +100,7 @@ jobs:
         if: steps.test-cpp.outcome == 'failure'
         uses: actions/upload-artifact@v4
         with:
-          name: failing-test-log
+          name: ${{ matrix.os }}-${{ matrix.name }}${{ matrix.name_suffix }}-test-log-${{ github.run_id }}
           path: build/Testing/Temporary/LastTest.log
 
       - name: Fail pipeline due to C++ test failure

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -90,9 +90,24 @@ jobs:
           make -j$NUM_CORES
 
       - name: Test C++
+        id: test-cpp
+        continue-on-error: true
         run: |
           cd build
           make test
+
+      - name: Upload failing test log
+        if: steps.test-cpp.outcome == 'failure'
+        uses: actions/upload-artifact@v4
+        with:
+          name: failing-test-log
+          path: build/Testing/Temporary/LastTest.log
+
+      - name: Fail pipeline due to C++ test failure
+        if: steps.test-cpp.outcome == 'failure'
+        run: |
+          echo "C++ tests failed. Inspect the artifact for details."
+          exit 1
 
       - name: Test Python Bindings
         run: |


### PR DESCRIPTION
This PR improves the CI workflow by preserving test logs when C++ tests fail,
making debugging failing tests, especially the cross-platform ones, much easier.
An example: https://github.com/Po-Chun-Chien/smt-switch/actions/runs/15453186386

The artifacts will be automatically deleted after the retention period.
