### PR TITLE
Remove unneeded dependencies

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,8 @@ jobs:
           - name: msat
             setup_opts: --auto-yes
           - name: yices2
-            extra_macos_packages: autoconf
+            extra_linux_packages: gperf
+            macos_packages: autoconf gperf
           - library_type: static
             name_suffix: -static
             config_opts: --static
@@ -37,15 +38,13 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             cmake \
-            gperf
+            ${{ matrix.extra_linux_packages }}
 
       - name: Install Packages (macOS)
-        if: runner.os == 'macOS'
+        if: runner.os == 'macOS' && matrix.macos_packages
         run: |
           brew update
-          brew install \
-            gperf \
-            ${{ matrix.extra_macos_packages }}
+          brew install ${{ matrix.macos_packages }}
           echo "LDFLAGS=-L$(brew --prefix)/lib $LDFLAGS" >> "$GITHUB_ENV"
           echo "CFLAGS=-I$(brew --prefix)/include $CFLAGS" >> "$GITHUB_ENV"
           echo "CPPFLAGS=-I$(brew --prefix)/include $CPPFLAGS" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -59,7 +59,6 @@ jobs:
           python3 -m venv ./.venv
           source ./.venv/bin/activate
           python3 -m pip install \
-            Cython \
             packaging \
             pysmt \
             pytest \

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -62,7 +62,6 @@ jobs:
             packaging \
             pysmt \
             pytest \
-            setuptools \
             ${{ matrix.extra_python_packages }}
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,8 +37,7 @@ jobs:
           sudo apt-get update
           sudo apt-get install -y \
             cmake \
-            gperf \
-            ninja-build
+            gperf
 
       - name: Install Packages (macOS)
         if: runner.os == 'macOS'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -45,6 +45,10 @@ jobs:
         run: |
           brew update
           brew install ${{ matrix.macos_packages }}
+
+      - name: Fix Homebrew paths (macOS)
+        if: runner.os == 'macOS'
+        run: |
           echo "LDFLAGS=-L$(brew --prefix)/lib $LDFLAGS" >> "$GITHUB_ENV"
           echo "CFLAGS=-I$(brew --prefix)/include $CFLAGS" >> "$GITHUB_ENV"
           echo "CPPFLAGS=-I$(brew --prefix)/include $CPPFLAGS" >> "$GITHUB_ENV"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,6 +16,8 @@ jobs:
         - yices2
         - z3
         include:
+          - name: bitwuzla
+            extra_python_packages: meson
           - name: msat
             setup_opts: --auto-yes
           - name: yices2
@@ -56,11 +58,11 @@ jobs:
           source ./.venv/bin/activate
           python3 -m pip install \
             Cython \
-            meson \
             packaging \
             pysmt \
             pytest \
-            setuptools
+            setuptools \
+            ${{ matrix.extra_python_packages }}
           echo "$PWD/.venv/bin" >> $GITHUB_PATH
 
       - name: Install Bison

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Smt-Switch depends on the following libraries. Dependencies needed only for cert
 * Flex >= 2.6.4 [optional: SMT-LIB parser]
 * Bison >= 3.7 [optional: SMT-LIB parser]
 * Python [optional: Python bindings]
-* Cython >= 3.0.0 [optional: Python bindings]
 * setuptools >= 61.0.0 [optional: Python bindings]
 * packaging [optional: Python bindings]
 
@@ -116,7 +115,7 @@ It is highly recommended to use a Python [virtual environment](https://docs.pyth
 
 First, install the required Python modules:
 ```
-python3 -m pip install Cython setuptools packaging pytest
+python3 -m pip install setuptools packaging pytest
 ```
 If you're building the python bindings in a setting where you don't care too much about runtime speed (e.g. for CI), you can add the option `--install-option="--no-cython-compile"` to the end of the Cython installation command to install it faster.
 

--- a/README.md
+++ b/README.md
@@ -70,7 +70,6 @@ Smt-Switch depends on the following libraries. Dependencies needed only for cert
 * Flex >= 2.6.4 [optional: SMT-LIB parser]
 * Bison >= 3.7 [optional: SMT-LIB parser]
 * Python [optional: Python bindings]
-* setuptools >= 61.0.0 [optional: Python bindings]
 * packaging [optional: Python bindings]
 
 # Operating Systems
@@ -115,7 +114,7 @@ It is highly recommended to use a Python [virtual environment](https://docs.pyth
 
 First, install the required Python modules:
 ```
-python3 -m pip install setuptools packaging pytest
+python3 -m pip install packaging pytest
 ```
 If you're building the python bindings in a setting where you don't care too much about runtime speed (e.g. for CI), you can add the option `--install-option="--no-cython-compile"` to the end of the Cython installation command to install it faster.
 

--- a/ci-scripts/cibw-build-deps.sh
+++ b/ci-scripts/cibw-build-deps.sh
@@ -18,7 +18,7 @@ set -e
 
 python3 -m venv ./build-deps-env
 source ./build-deps-env/bin/activate
-python3 -m pip install meson setuptools pyparsing tomli
+python3 -m pip install meson pyparsing tomli
 
 ./contrib/setup-bitwuzla.sh
 # the version of ld.gold is too old in manylinux_2_28, remove it so cvc5 falls back on bfd

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -10,7 +10,6 @@ include(CheckPythonModule)
 
 # Verify required Python packages are installed
 check_python_module("packaging")
-check_python_module("setuptools")
 
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/gen-smt-solver-declarations.py"

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,7 +11,6 @@ include(CheckPythonModule)
 # Verify required Python packages are installed
 check_python_module("packaging")
 check_python_module("setuptools")
-check_python_module("Cython" 3.0.0)
 
 configure_file(
     "${CMAKE_CURRENT_SOURCE_DIR}/gen-smt-solver-declarations.py"


### PR DESCRIPTION
Reduces unnecessary clutter and reduces CI time.

We don't need to install the Python dependencies ourselves, because `pip` creates a new virtual environment for building the wheel anyway and installs them there.