### PR TITLE
Install tracer.hpp header for cadical

### DIFF
--- a/contrib/setup-cadical.sh
+++ b/contrib/setup-cadical.sh
@@ -10,6 +10,7 @@ install_step() {
   install -m644 build/libcadical.a "$install_libdir"
   install -m644 src/ccadical.h "$install_includedir"
   install -m644 src/cadical.hpp "$install_includedir"
+  install -m644 src/tracer.hpp "$install_includedir"
 }
 
 source "$(dirname "$0")/make-steps.sh"


### PR DESCRIPTION
Used by  Bitwuzla for interpolation.