### PR TITLE
Remove some preinstalled packages on CI runner to gain more free space

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -35,7 +35,9 @@ jobs:
       - name: Install Packages (Linux)
         if: runner.os == 'Linux'
         run: |
-          # Remove the largest ones first to free up some space.
+          # Remove some packages first to free up some space.
+          # inspired by https://github.com/marketplace/actions/maximize-build-disk-space
+          sudo rm -rf /usr/share/dotnet /usr/local/lib/android /opt/ghc /opt/hostedtoolcache/CodeQL
           sudo apt-get remove \
             azure-cli \
             google-chrome-stable \
@@ -58,7 +60,6 @@ jobs:
           echo "LDFLAGS=-L$(brew --prefix)/lib $LDFLAGS" >> "$GITHUB_ENV"
           echo "CFLAGS=-I$(brew --prefix)/include $CFLAGS" >> "$GITHUB_ENV"
           echo "CPPFLAGS=-I$(brew --prefix)/include $CPPFLAGS" >> "$GITHUB_ENV"
-
 
       - name: Python Dependencies
         run: |


### PR DESCRIPTION
CI run `ubuntu-latest:z3-static` has been failing regularly due to insufficient disk space. This PR removes some unnecessary preinstalled packages from the runner.

Examples of recent failed runs:

- https://github.com/stanford-centaur/smt-switch/actions/runs/18076950461
- https://github.com/stanford-centaur/smt-switch/actions/runs/18076332446
- https://github.com/stanford-centaur/smt-switch/actions/runs/18023317071
- https://github.com/stanford-centaur/smt-switch/pull/428#issuecomment-3336020817