### PR TITLE
build: Fix CMAKE_BINARY_DIR usage

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -141,7 +141,7 @@ if(SMTLIB_READER)
   add_flex_bison_dependency(SmtLibScanner SmtLibParser)
 
   # putting generated header files in build dir
-  list(APPEND INCLUDE_DIRS "${CMAKE_BINARY_DIR}")
+  list(APPEND INCLUDE_DIRS "${CMAKE_CURRENT_BINARY_DIR}")
 
   list(
     APPEND SOURCES
@@ -290,9 +290,9 @@ install(
 )
 
 if(SMTLIB_READER)
-  install(FILES "${CMAKE_BINARY_DIR}/smtlibparser.h" DESTINATION include/smt-switch)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/smtlibparser.h" DESTINATION include/smt-switch)
 
-  install(FILES "${CMAKE_BINARY_DIR}/location.hh" DESTINATION include/smt-switch)
+  install(FILES "${CMAKE_CURRENT_BINARY_DIR}/location.hh" DESTINATION include/smt-switch)
 endif()
 
 # uninstall target

--- a/cmake_uninstall.cmake.in
+++ b/cmake_uninstall.cmake.in
@@ -1,17 +1,24 @@
-if(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
-  message(FATAL_ERROR "Cannot find install manifest: @CMAKE_BINARY_DIR@/install_manifest.txt")
-endif(NOT EXISTS "@CMAKE_BINARY_DIR@/install_manifest.txt")
+if(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
+  message(
+    FATAL_ERROR
+    "Cannot find install manifest: @CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt"
+  )
+endif(NOT EXISTS "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt")
 
-file(READ "@CMAKE_BINARY_DIR@/install_manifest.txt" files)
+file(READ "@CMAKE_CURRENT_BINARY_DIR@/install_manifest.txt" files)
 string(REGEX REPLACE "\n" ";" files "${files}")
 foreach(file ${files})
   message(STATUS "Uninstalling $ENV{DESTDIR}${file}")
   if(IS_SYMLINK "$ENV{DESTDIR}${file}" OR EXISTS "$ENV{DESTDIR}${file}")
     exec_program(
-      "@CMAKE_COMMAND@" ARGS "-E remove \"$ENV{DESTDIR}${file}\""
-      OUTPUT_VARIABLE rm_out
-      RETURN_VALUE rm_retval
-      )
+      "@CMAKE_COMMAND@"
+      ARGS
+      "-E remove \"$ENV{DESTDIR}${file}\""
+      OUTPUT_VARIABLE
+      rm_out
+      RETURN_VALUE
+      rm_retval
+    )
     if(NOT "${rm_retval}" STREQUAL 0)
       message(FATAL_ERROR "Problem when removing $ENV{DESTDIR}${file}")
     endif(NOT "${rm_retval}" STREQUAL 0)


### PR DESCRIPTION
Smt-switch fails to build as a subproject, because `CMAKE_BINARY_DIR` points to the top-level build directory. Instead it should be `CMAKE_CURRENT_BINARY_DIR`. The uninstall script has a larger diff because it was reformatted.