### PR TITLE
style: Add minimal ruff config and autoformat Python sources

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 __pycache__/
+.ruff_cache/
 build/
 deps/

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,0 +1,14 @@
+# Minimal configuration for `ruff format`. Lint rules are added in a follow-up.
+#
+# Formatter defaults are what we want, so they are left unset: 88-column line
+# length and double quotes.
+
+# Matches requires-python = ">=3.9" in python/pyproject.toml, and the
+# find_package(Python 3.9 ...) in CMakeLists.txt.
+target-version = "py39"
+
+extend-exclude = ["build", "deps"]
+
+# pre-commit passes explicit file paths, which would otherwise override the
+# excludes above.
+force-exclude = true

--- a/README.md
+++ b/README.md
@@ -136,7 +136,8 @@ solver = pysmt_frontend.Solver("cvc5")
 solver = pysmt_frontend.Solver("cvc5", LOGIC)
 
 # Note a solver can be used as a context manager:
-with pysmt_frontend.Solver("cvc5") as solver: ...
+with pysmt_frontend.Solver("cvc5") as solver:
+    ...
 ```
 
 Please refer to the pySMT docs for further information.

--- a/examples/python_qf_ufbv.py
+++ b/examples/python_qf_ufbv.py
@@ -4,16 +4,16 @@ from smt_switch.primops import Apply, Distinct, Equal, Extract, BVAnd, BVUge
 
 if __name__ == "__main__":
     s = ss.create_btor_solver(True)
-    s.set_logic('QF_UFBV')
-    s.set_opt('incremental', 'true')
-    s.set_opt('produce-models', 'true')
-    s.set_opt('produce-unsat-assumptions', 'true')
+    s.set_logic("QF_UFBV")
+    s.set_opt("incremental", "true")
+    s.set_opt("produce-models", "true")
+    s.set_opt("produce-unsat-assumptions", "true")
     bvs = s.make_sort(ss.sortkinds.BV, 32)
     funs = s.make_sort(ss.sortkinds.FUNCTION, [bvs, bvs])
 
-    x = s.make_symbol('x', bvs)
-    y = s.make_symbol('y', bvs)
-    f = s.make_symbol('f', funs)
+    x = s.make_symbol("x", bvs)
+    y = s.make_symbol("y", bvs)
+    f = s.make_symbol("f", funs)
 
     ext = ss.Op(Extract, 15, 0)
     x0 = s.make_term(ext, x)
@@ -30,8 +30,8 @@ if __name__ == "__main__":
     s.pop(1)
 
     xy = s.make_term(BVAnd, x, y)
-    a1 = s.make_term(BVUge, xy, x);
-    a2 = s.make_term(BVUge, xy, y);
-    a3 = s.make_term(BVUge, x0, y0);
-    print(s.check_sat_assuming([a1,a2,a3]))
+    a1 = s.make_term(BVUge, xy, x)
+    a2 = s.make_term(BVUge, xy, y)
+    a3 = s.make_term(BVUge, x0, y0)
+    print(s.check_sat_assuming([a1, a2, a3]))
     print(s.get_unsat_assumptions())

--- a/python/gen-smt-solver-declarations.py
+++ b/python/gen-smt-solver-declarations.py
@@ -7,25 +7,25 @@
 
 import argparse
 
-CREATE_BTOR='''
+CREATE_BTOR = """
 def create_btor_solver(logging):
     cdef SmtSolver solver = SmtSolver()
     solver.css = cpp_create_btor_solver(logging)
     return solver
 solvers["btor"] = create_btor_solver
-'''
+"""
 
 
-CREATE_BITWUZLA='''
+CREATE_BITWUZLA = """
 def create_bitwuzla_solver(logging):
     cdef SmtSolver solver = SmtSolver()
     solver.css = cpp_create_bitwuzla_solver(logging)
     return solver
 solvers["bitwuzla"] = create_bitwuzla_solver
-'''
+"""
 
 
-CREATE_CVC5='''
+CREATE_CVC5 = """
 def create_cvc5_solver(logging):
     cdef SmtSolver solver = SmtSolver()
     solver.css = cpp_create_cvc5_solver(logging)
@@ -36,10 +36,10 @@ def create_cvc5_interpolator():
     cdef SmtSolver solver = SmtSolver()
     solver.css = cpp_create_cvc5_interpolator()
     return solver
-'''
+"""
 
 
-CREATE_MSAT='''
+CREATE_MSAT = """
 def create_msat_solver(logging):
     cdef SmtSolver solver = SmtSolver()
     solver.css = cpp_create_msat_solver(logging)
@@ -50,117 +50,121 @@ def create_msat_interpolator():
     cdef SmtSolver solver = SmtSolver()
     solver.css = cpp_create_msat_interpolator()
     return solver
-'''
+"""
 
-CREATE_YICES2='''
+CREATE_YICES2 = """
 def create_yices2_solver(logging):
     cdef SmtSolver solver = SmtSolver()
     solver.css = cpp_create_yices2_solver(logging)
     return solver
 solvers["yices2"] = create_yices2_solver
-'''
+"""
 
-CREATE_Z3='''
+CREATE_Z3 = """
 def create_z3_solver(logging):
     cdef SmtSolver solver = SmtSolver()
     solver.css = cpp_create_z3_solver(logging)
     return solver
 solvers["z3"] = create_z3_solver
-'''
+"""
 
 
-DECLARE_BTOR='''
+DECLARE_BTOR = """
 cdef extern from "boolector_factory.h":
     c_SmtSolver cpp_create_btor_solver "smt::BoolectorSolverFactory::create" (bint logging) except +
-'''
+"""
 
 
-DECLARE_BITWUZLA='''
+DECLARE_BITWUZLA = """
 cdef extern from "bitwuzla_factory.h":
     c_SmtSolver cpp_create_bitwuzla_solver "smt::BitwuzlaSolverFactory::create" (bint logging) except +
-'''
+"""
 
 
-DECLARE_CVC5='''
+DECLARE_CVC5 = """
 cdef extern from "cvc5_factory.h":
     c_SmtSolver cpp_create_cvc5_solver "smt::Cvc5SolverFactory::create" (bint logging) except +
     c_SmtSolver cpp_create_cvc5_interpolator "smt::Cvc5SolverFactory::create_interpolating_solver" () except +
-'''
+"""
 
 
-DECLARE_MSAT='''
+DECLARE_MSAT = """
 cdef extern from "msat_factory.h":
     c_SmtSolver cpp_create_msat_solver "smt::MsatSolverFactory::create" (bint logging) except +
     c_SmtSolver cpp_create_msat_interpolator "smt::MsatSolverFactory::create_interpolating_solver" () except +
-'''
+"""
 
-DECLARE_YICES2='''
+DECLARE_YICES2 = """
 cdef extern from "yices2_factory.h":
     c_SmtSolver cpp_create_yices2_solver "smt::Yices2SolverFactory::create" (bint logging) except +
-'''
+"""
 
-DECLARE_Z3='''
+DECLARE_Z3 = """
 cdef extern from "z3_factory.h":
     c_SmtSolver cpp_create_z3_solver "smt::Z3SolverFactory::create" (bint logging) except +
-'''
+"""
 
 
 if __name__ == "__main__":
-    parser = argparse.ArgumentParser(description="Generate smt_switch python binding implementations.")
-    parser.add_argument('--dest-dir', help='Where to put the generated files', required=True)
-    parser.add_argument('--btor', action='store_true', help='Build with Boolector')
-    parser.add_argument('--bitwuzla', action='store_true', help='Build with Bitwuzla')
-    parser.add_argument('--cvc5', action='store_true', help='Build with CVC5')
-    parser.add_argument('--msat', action='store_true', help='Build with MathSAT')
-    parser.add_argument('--yices2', action='store_true', help='Build with Yices2')
-    parser.add_argument('--z3', action='store_true', help='Build with Z3')
+    parser = argparse.ArgumentParser(
+        description="Generate smt_switch python binding implementations."
+    )
+    parser.add_argument(
+        "--dest-dir", help="Where to put the generated files", required=True
+    )
+    parser.add_argument("--btor", action="store_true", help="Build with Boolector")
+    parser.add_argument("--bitwuzla", action="store_true", help="Build with Bitwuzla")
+    parser.add_argument("--cvc5", action="store_true", help="Build with CVC5")
+    parser.add_argument("--msat", action="store_true", help="Build with MathSAT")
+    parser.add_argument("--yices2", action="store_true", help="Build with Yices2")
+    parser.add_argument("--z3", action="store_true", help="Build with Z3")
 
     args = parser.parse_args()
     dest_dir = args.dest_dir
 
     imports = []
 
-    pxd = 'from .cppapi cimport c_SmtSolver'
-    pyx = 'from .api cimport SmtSolver\n\n# collect available solvers here\nsolvers = {}\n\n%s'
+    pxd = "from .cppapi cimport c_SmtSolver"
+    pyx = "from .api cimport SmtSolver\n\n# collect available solvers here\nsolvers = {}\n\n%s"
     if args.btor:
         pxd += "\n" + DECLARE_BTOR
         pyx += "\n" + CREATE_BTOR
-        imports.append('cpp_create_btor_solver')
+        imports.append("cpp_create_btor_solver")
 
     if args.bitwuzla:
         pxd += "\n" + DECLARE_BITWUZLA
         pyx += "\n" + CREATE_BITWUZLA
-        imports.append('cpp_create_bitwuzla_solver')
+        imports.append("cpp_create_bitwuzla_solver")
 
     if args.cvc5:
         pxd += "\n" + DECLARE_CVC5
         pyx += "\n" + CREATE_CVC5
-        imports.append('cpp_create_cvc5_solver')
-        imports.append('cpp_create_cvc5_interpolator')
+        imports.append("cpp_create_cvc5_solver")
+        imports.append("cpp_create_cvc5_interpolator")
 
     if args.msat:
         pxd += "\n" + DECLARE_MSAT
         pyx += "\n" + CREATE_MSAT
-        imports.append('cpp_create_msat_solver')
-        imports.append('cpp_create_msat_interpolator')
+        imports.append("cpp_create_msat_solver")
+        imports.append("cpp_create_msat_interpolator")
 
     if args.yices2:
         pxd += "\n" + DECLARE_YICES2
         pyx += "\n" + CREATE_YICES2
-        imports.append('cpp_create_yices2_solver')
+        imports.append("cpp_create_yices2_solver")
 
     if args.z3:
         pxd += "\n" + DECLARE_Z3
         pyx += "\n" + CREATE_Z3
-        imports.append('cpp_create_z3_solver')
+        imports.append("cpp_create_z3_solver")
 
     if imports:
-        CREATE_IMPORTS ='from .smt_solvers cimport ' + ','.join(imports)
+        CREATE_IMPORTS = "from .smt_solvers cimport " + ",".join(imports)
     else:
-        CREATE_IMPORTS = '# Built with no solvers...'
+        CREATE_IMPORTS = "# Built with no solvers..."
 
-    with open(dest_dir + "/smt_solvers.pxd", 'w') as f:
+    with open(dest_dir + "/smt_solvers.pxd", "w") as f:
         f.write(pxd)
 
-    with open(dest_dir + "/smt_solvers.pyx", 'w') as f:
-        f.write(pyx%CREATE_IMPORTS)
+    with open(dest_dir + "/smt_solvers.pyx", "w") as f:
+        f.write(pyx % CREATE_IMPORTS)

--- a/python/smt_switch/pysmt_frontend/__init__.py
+++ b/python/smt_switch/pysmt_frontend/__init__.py
@@ -7,32 +7,36 @@ from pysmt.environment import get_env
 
 from .pysmt_solver import SWITCH_SOLVERS
 
-__ALL__ = ['SWITCH_SOLVERS', 'Solver']
+__ALL__ = ["SWITCH_SOLVERS", "Solver"]
 
 
 try:
     from .pysmt_solver import SwitchBtor
-    __ALL__.append('SwitchBtor')
+
+    __ALL__.append("SwitchBtor")
 except ImportError:
     pass
 
 try:
     from .pysmt_solver import SwitchCvc5
-    __ALL__.append('SwitchCvc5')
+
+    __ALL__.append("SwitchCvc5")
 except ImportError:
     pass
 
 try:
     from .pysmt_solver import SwitchMsat
-    __ALL__.append('SwitchMsat')
+
+    __ALL__.append("SwitchMsat")
 except ImportError:
     pass
 
-def Solver(name: str, logic: tp.Optional[logics.Logic]=None) -> SolverT:
-    '''
+
+def Solver(name: str, logic: tp.Optional[logics.Logic] = None) -> SolverT:
+    """
     Convience function for building a pysmt solver object with a switch backend.
     Similar to `pysmt.shortcuts.Solver`.
-    '''
+    """
     try:
         cls = SWITCH_SOLVERS[name]
     except KeyError:

--- a/python/smt_switch/pysmt_frontend/pysmt_solver.py
+++ b/python/smt_switch/pysmt_frontend/pysmt_solver.py
@@ -8,10 +8,18 @@ import operator
 import smt_switch as ss
 
 
-from pysmt.exceptions import (UndefinedLogicError,
-        SolverReturnedUnknownResultError, ConvertExpressionError, PysmtValueError)
-from pysmt.solvers.solver import (IncrementalTrackingSolver, UnsatCoreSolver,
-                                  Converter, SolverOptions)
+from pysmt.exceptions import (
+    UndefinedLogicError,
+    SolverReturnedUnknownResultError,
+    ConvertExpressionError,
+    PysmtValueError,
+)
+from pysmt.solvers.solver import (
+    IncrementalTrackingSolver,
+    UnsatCoreSolver,
+    Converter,
+    SolverOptions,
+)
 from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
 from pysmt.solvers.eager import EagerModel
 from pysmt.walkers import DagWalker
@@ -22,12 +30,13 @@ from pysmt import typing as pysmt_types
 
 SWITCH_SOLVERS = {}
 
+
 class SwitchOptions(SolverOptions):
     def __call__(self, solver):
         if self.generate_models:
-            solver.solver.set_opt('produce-models', 'true')
+            solver.solver.set_opt("produce-models", "true")
         if self.incremental:
-            solver.solver.set_opt('incremental', 'true')
+            solver.solver.set_opt("incremental", "true")
 
         for k, v in self.solver_options.items():
             try:
@@ -45,24 +54,24 @@ def _parse_real(s):
                 num.append(c)
                 continue
             elif num:
-                tree.append(int(''.join(num)))
+                tree.append(int("".join(num)))
                 num = []
 
-            if c == ')':
+            if c == ")":
                 break
-            elif c == ' ':
+            elif c == " ":
                 continue
-            elif c == '(':
+            elif c == "(":
                 tree.append(_parse(it))
-            elif c == '-':
+            elif c == "-":
                 tree.append(operator.neg)
-            elif c == '/':
+            elif c == "/":
                 tree.append(fractions.Fraction)
             else:
                 raise ValueError()
 
         if num:
-            tree.append(int(''.join(num)))
+            tree.append(int("".join(num)))
 
         assert tree
         if len(tree) == 1:
@@ -74,21 +83,18 @@ def _parse_real(s):
     return _parse(iter(repr(s)))
 
 
-class _SwitchSolver(IncrementalTrackingSolver,
-                   SmtLibBasicSolver,
-                   SmtLibIgnoreMixin):
+class _SwitchSolver(IncrementalTrackingSolver, SmtLibBasicSolver, SmtLibIgnoreMixin):
     OptionsClass = SwitchOptions
 
     def __init__(self, environment, logic, **options):
-        IncrementalTrackingSolver.__init__(self,
-                        environment=environment,
-                        logic=logic,
-                        **options)
+        IncrementalTrackingSolver.__init__(
+            self, environment=environment, logic=logic, **options
+        )
 
         self.solver = self._create_solver()
         self.options(self)
         self.mgr = environment.formula_manager
-        self.converter = SwitchConverter(environment,  self.solver, self.mgr)
+        self.converter = SwitchConverter(environment, self.solver, self.mgr)
 
     def get_model(self):
         assignment = {}
@@ -176,14 +182,13 @@ def _build_logics(logics_params):
     return logics
 
 
-if 'btor' in  ss.solvers:
+if "btor" in ss.solvers:
     logics_params = dict(
         quantifier_free=[True],
         arrays=[True, False],
         bit_vectors=[True, False],
         uninterpreted=[True, False],
     )
-
 
     class SwitchBtor(_SwitchSolver):
         LOGICS = _build_logics(logics_params)
@@ -192,14 +197,13 @@ if 'btor' in  ss.solvers:
         @clear_pending_pop
         def _reset_assertions(self):
             self.solver = self._create_solver()
-            self.converter = SwitchConverter(self.environment,  self.solver, self.mgr)
+            self.converter = SwitchConverter(self.environment, self.solver, self.mgr)
             self.options(self)
 
+    SWITCH_SOLVERS["btor"] = SwitchBtor
 
-    SWITCH_SOLVERS['btor'] = SwitchBtor
 
-
-if 'bitwuzla' in  ss.solvers:
+if "bitwuzla" in ss.solvers:
     logics_params = dict(
         quantifier_free=[True],
         arrays=[True, False],
@@ -212,10 +216,10 @@ if 'bitwuzla' in  ss.solvers:
         LOGICS = _build_logics(logics_params)
         _create_solver = staticmethod(ft.partial(ss.create_bitwuzla_solver, False))
 
-    SWITCH_SOLVERS['bitwuzla'] = SwitchBitwuzla
+    SWITCH_SOLVERS["bitwuzla"] = SwitchBitwuzla
 
 
-if 'msat' in ss.solvers:
+if "msat" in ss.solvers:
     logics_params = dict(
         quantifier_free=[True],
         arrays=[True, False],
@@ -232,9 +236,9 @@ if 'msat' in ss.solvers:
         LOGICS = _build_logics(logics_params)
         _create_solver = staticmethod(ft.partial(ss.create_msat_solver, False))
 
-    SWITCH_SOLVERS['msat'] = SwitchMsat
+    SWITCH_SOLVERS["msat"] = SwitchMsat
 
-if 'cvc5' in ss.solvers:
+if "cvc5" in ss.solvers:
     logics_params = dict(
         quantifier_free=[True],
         arrays=[True, False],
@@ -257,7 +261,7 @@ if 'cvc5' in ss.solvers:
             # to avoid heisenbug
             gc.collect()
 
-    SWITCH_SOLVERS['cvc5'] = SwitchCvc5
+    SWITCH_SOLVERS["cvc5"] = SwitchCvc5
 
 
 def check_args(cmp, n):
@@ -265,9 +269,11 @@ def check_args(cmp, n):
         @ft.wraps(f)
         def walk_op(self, formula, args, **kwargs):
             if not cmp(len(args), n):
-                raise ConvertExpressionError('Incorrect number of arguments')
+                raise ConvertExpressionError("Incorrect number of arguments")
             return f(self, formula, args, **kwargs)
+
         return walk_op
+
     return wrapper
 
 
@@ -276,6 +282,7 @@ def make_walk_nary(n, primop):
     def walk_op(self, formula, args, **kwargs):
         res = self.make_term(primop, *args)
         return res
+
     return walk_op
 
 
@@ -289,6 +296,7 @@ def make_walk_variadic(n, primop):
         builder = ft.partial(self.make_term, primop)
         res = ft.reduce(builder, args)
         return res
+
     return walk_op
 
 
@@ -337,10 +345,9 @@ class SwitchConverter(Converter, DagWalker):
         elif sort.is_real_type():
             c_sort = self.make_sort(ss.sortkinds.REAL)
         else:
-            raise ConvertExpressionError(f'Unsupported sort: {sort}')
+            raise ConvertExpressionError(f"Unsupported sort: {sort}")
 
         return self.declared_sorts.setdefault(sort, c_sort)
-
 
     # Declarations
     @check_args(operator.eq, 0)
@@ -366,7 +373,7 @@ class SwitchConverter(Converter, DagWalker):
             res = self.make_term(bool(formula.constant_value()))
         elif formula.constant_type().is_real_type():
             val = formula.constant_value()
-            res = self.make_term(f'{val.numerator}/{val.denominator}', sort)
+            res = self.make_term(f"{val.numerator}/{val.denominator}", sort)
         else:
             res = self.make_term(str(formula.constant_value()), sort)
         return res
@@ -423,7 +430,7 @@ class SwitchConverter(Converter, DagWalker):
                 formula.bv_extract_end(),
                 formula.bv_extract_start(),
             ),
-            *args
+            *args,
         )
         return res
 
@@ -437,16 +444,14 @@ class SwitchConverter(Converter, DagWalker):
     @check_args(operator.eq, 1)
     def walk_bv_rol(self, formula, args, **kwargs):
         res = self.make_term(
-            ss.Op(ss.primops.Rotate_Left, formula.bv_rotation_step()),
-            *args
+            ss.Op(ss.primops.Rotate_Left, formula.bv_rotation_step()), *args
         )
         return res
 
     @check_args(operator.eq, 1)
     def walk_bv_ror(self, formula, args, **kwargs):
         res = self.make_term(
-            ss.Op(ss.primops.Rotate_Right, formula.bv_rotation_step()),
-            *args
+            ss.Op(ss.primops.Rotate_Right, formula.bv_rotation_step()), *args
         )
         return res
 
@@ -455,8 +460,7 @@ class SwitchConverter(Converter, DagWalker):
     @check_args(operator.eq, 1)
     def walk_bv_sext(self, formula, args, **kwargs):
         res = self.make_term(
-            ss.Op(ss.primops.Sign_Extend, formula.bv_extend_step()),
-            *args
+            ss.Op(ss.primops.Sign_Extend, formula.bv_extend_step()), *args
         )
         return res
 
@@ -476,24 +480,25 @@ class SwitchConverter(Converter, DagWalker):
     @check_args(operator.eq, 1)
     def walk_bv_zext(self, formula, args, **kwargs):
         res = self.make_term(
-            ss.Op(ss.primops.Zero_Extend, formula.bv_extend_step()),
-            *args
+            ss.Op(ss.primops.Zero_Extend, formula.bv_extend_step()), *args
         )
         return res
 
-    #array operators
+    # array operators
     walk_array_select = make_walk_binary(ss.primops.Select)
     walk_array_store = make_walk_nary(3, ss.primops.Store)
 
 
-_INDEXED_OPERATORS = frozenset((
-    ss.primops.Extract,
-    ss.primops.Repeat,
-    ss.primops.Rotate_Left,
-    ss.primops.Rotate_Right,
-    ss.primops.Sign_Extend,
-    ss.primops.Zero_Extend,
-))
+_INDEXED_OPERATORS = frozenset(
+    (
+        ss.primops.Extract,
+        ss.primops.Repeat,
+        ss.primops.Rotate_Left,
+        ss.primops.Rotate_Right,
+        ss.primops.Sign_Extend,
+        ss.primops.Zero_Extend,
+    )
+)
 
 
 class BackVisitor(ss.TermDagVisitor):
@@ -538,19 +543,19 @@ class BackVisitor(ss.TermDagVisitor):
             ss.primops.Distinct: mgr.AllDifferent,
             ss.primops.Div: mgr.Div,
             ss.primops.Equal: mgr.EqualsOrIff,
-            #ss.primops.Exists:
+            # ss.primops.Exists:
             ss.primops.Extract: self._convert_extract,
-            #ss.primops.Forall:
+            # ss.primops.Forall:
             ss.primops.Ge: mgr.GE,
             ss.primops.Gt: mgr.GT,
             ss.primops.Implies: mgr.Implies,
-            #ss.primops.Int_To_BV: NOT SUPPORTED BY PYSMT
-            #ss.primops.Is_Int: NOT SUPPORTED BY PYSMT
+            # ss.primops.Int_To_BV: NOT SUPPORTED BY PYSMT
+            # ss.primops.Is_Int: NOT SUPPORTED BY PYSMT
             ss.primops.Ite: mgr.Ite,
             ss.primops.Le: mgr.LE,
             ss.primops.Lt: mgr.LT,
             ss.primops.Minus: mgr.Minus,
-            #ss.primops.Mod: NOT SUPPORTED BY PYSMT
+            # ss.primops.Mod: NOT SUPPORTED BY PYSMT
             ss.primops.Mult: mgr.Times,
             ss.primops.Negate: self._convert_negate,
             ss.primops.Not: mgr.Not,
@@ -563,7 +568,7 @@ class BackVisitor(ss.TermDagVisitor):
             ss.primops.Select: mgr.Select,
             ss.primops.Sign_Extend: mgr.BVSExt,
             ss.primops.Store: mgr.Store,
-            #ss.primops.To_Int: NOT SUPPORTED BY PYSMT
+            # ss.primops.To_Int: NOT SUPPORTED BY PYSMT
             ss.primops.To_Real: mgr.ToReal,
             ss.primops.Xor: mgr.Xor,
             ss.primops.Zero_Extend: mgr.BVZExt,
@@ -639,7 +644,7 @@ class BackVisitor(ss.TermDagVisitor):
             r = _parse_real(term)
             return self.mgr.Real(r)
         else:
-            raise ConvertExpressionError(f'Unsupported sort: {sort}')
+            raise ConvertExpressionError(f"Unsupported sort: {sort}")
 
     def _convert_array_value(self, arr, sort):
         assignment = {}
@@ -669,7 +674,7 @@ class BackVisitor(ss.TermDagVisitor):
         elif sort.is_real_type():
             return self.mgr.Real(0)
         else:
-            raise TypeError(f'Unsupported sort: {sort}')
+            raise TypeError(f"Unsupported sort: {sort}")
 
     def _convert_abs(self, child):
         assert child.get_type().is_int_type()

--- a/tests/python/available_solvers.py
+++ b/tests/python/available_solvers.py
@@ -17,5 +17,7 @@
 import smt_switch as ss
 
 
-termiter_support_solvers = {k:v for k, v in ss.solvers.items() if k != 'yices2'}
-int_support_solvers      = {k:v for k, v in ss.solvers.items() if k != 'btor' and k != 'bitwuzla'}
+termiter_support_solvers = {k: v for k, v in ss.solvers.items() if k != "yices2"}
+int_support_solvers = {
+    k: v for k, v in ss.solvers.items() if k != "btor" and k != "bitwuzla"
+}

--- a/tests/python/test_arrays.py
+++ b/tests/python/test_arrays.py
@@ -20,25 +20,26 @@ from smt_switch.primops import Distinct, Equal, Select, Store
 
 from available_solvers import int_support_solvers
 
+
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_array_read_over_write(create_solver):
     solver = create_solver(False)
-    solver.set_logic('QF_ABV')
+    solver.set_logic("QF_ABV")
 
-    bvsort8  = solver.make_sort(ss.sortkinds.BV, 8)
+    bvsort8 = solver.make_sort(ss.sortkinds.BV, 8)
     bvsort32 = solver.make_sort(ss.sortkinds.BV, 32)
-    arrsort  = solver.make_sort(ss.sortkinds.ARRAY, bvsort8, bvsort32)
+    arrsort = solver.make_sort(ss.sortkinds.ARRAY, bvsort8, bvsort32)
 
-    i = solver.make_symbol('i', bvsort8)
-    j = solver.make_symbol('j', bvsort8)
-    e = solver.make_symbol('e', bvsort32)
-    a = solver.make_symbol('a', arrsort)
+    i = solver.make_symbol("i", bvsort8)
+    j = solver.make_symbol("j", bvsort8)
+    e = solver.make_symbol("e", bvsort32)
+    a = solver.make_symbol("a", arrsort)
 
-    solver.assert_formula(solver.make_term(Distinct,
-                                           solver.make_term(Select,
-                                                            solver.make_term(Store, a, j, e),
-                                                            i),
-                                           e))
+    solver.assert_formula(
+        solver.make_term(
+            Distinct, solver.make_term(Select, solver.make_term(Store, a, j, e), i), e
+        )
+    )
     solver.assert_formula(solver.make_term(Equal, i, j))
     r = solver.check_sat()
     assert r.is_unsat()
@@ -47,20 +48,22 @@ def test_array_read_over_write(create_solver):
 @pytest.mark.parametrize("create_solver", [f for n, f in int_support_solvers.items()])
 def test_array_lia_extensionality(create_solver):
     solver = create_solver(False)
-    solver.set_logic('QF_ALIA')
+    solver.set_logic("QF_ALIA")
 
     intsort = solver.make_sort(ss.sortkinds.INT)
     arrsort = solver.make_sort(ss.sortkinds.ARRAY, [intsort, intsort])
 
-    i = solver.make_symbol('i', intsort)
-    j = solver.make_symbol('j', intsort)
-    a = solver.make_symbol('a', arrsort)
-    b = solver.make_symbol('b', arrsort)
+    i = solver.make_symbol("i", intsort)
+    j = solver.make_symbol("j", intsort)
+    a = solver.make_symbol("a", arrsort)
+    b = solver.make_symbol("b", arrsort)
 
     solver.assert_formula(solver.make_term(Equal, a, b))
     solver.assert_formula(solver.make_term(Equal, i, j))
-    solver.assert_formula(solver.make_term(Distinct,
-                                           solver.make_term(Select, a, i),
-                                           solver.make_term(Select, b, j)))
+    solver.assert_formula(
+        solver.make_term(
+            Distinct, solver.make_term(Select, a, i), solver.make_term(Select, b, j)
+        )
+    )
     r = solver.check_sat()
     assert r.is_unsat()

--- a/tests/python/test_bv.py
+++ b/tests/python/test_bv.py
@@ -18,24 +18,29 @@ import pytest
 import smt_switch as ss
 import available_solvers
 
+
 # @pytest.mark.parametrize("create_solver", ss.solvers.values())
-@pytest.mark.parametrize("create_solver", available_solvers.termiter_support_solvers.values())
+@pytest.mark.parametrize(
+    "create_solver", available_solvers.termiter_support_solvers.values()
+)
 def test_bvadd(create_solver):
     solver = create_solver(False)
-    solver.set_opt('produce-models', 'true')
-    solver.set_logic('QF_BV')
+    solver.set_opt("produce-models", "true")
+    solver.set_logic("QF_BV")
 
     bvsort8 = solver.make_sort(ss.sortkinds.BV, 8)
-    x = solver.make_symbol('x', bvsort8)
-    y = solver.make_symbol('y', bvsort8)
+    x = solver.make_symbol("x", bvsort8)
+    y = solver.make_symbol("y", bvsort8)
     xpy = solver.make_term(ss.primops.BVAdd, x, y)
-    solver.assert_formula(solver.make_term(ss.primops.Equal, xpy, solver.make_term(6, bvsort8)))
+    solver.assert_formula(
+        solver.make_term(ss.primops.Equal, xpy, solver.make_term(6, bvsort8))
+    )
 
     solver.check_sat()
 
     xv = solver.get_value(x)
     yv = solver.get_value(y)
-    assert (int(xv) + int(yv))%(2**8) == 6
+    assert (int(xv) + int(yv)) % (2**8) == 6
 
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
@@ -56,33 +61,32 @@ def test_hackers_delight(create_solver):
     # We want to check that these are correct
 
     solver = create_solver(False)
-    solver.set_logic('QF_BV')
-    solver.set_opt('produce-models', 'true')
-    solver.set_opt('incremental', 'true')
+    solver.set_logic("QF_BV")
+    solver.set_opt("produce-models", "true")
+    solver.set_opt("incremental", "true")
 
     bv32 = solver.make_sort(ss.sortkinds.BV, 32)
 
-    x = solver.make_symbol('x', bv32)
-    a = solver.make_symbol('a', bv32)
-    b = solver.make_symbol('b', bv32)
+    x = solver.make_symbol("x", bv32)
+    a = solver.make_symbol("a", bv32)
+    b = solver.make_symbol("b", bv32)
 
     # x is a or b
     x_eq_a = solver.make_term(ss.primops.Equal, x, a)
-    solver.assert_formula(solver.make_term(ss.primops.And,
-                                           x_eq_a,
-                                           solver.make_term(ss.primops.Equal, x, b)))
+    solver.assert_formula(
+        solver.make_term(
+            ss.primops.And, x_eq_a, solver.make_term(ss.primops.Equal, x, b)
+        )
+    )
 
     # Updated x value
-    xn = solver.make_symbol('xn', bv32)
+    xn = solver.make_symbol("xn", bv32)
     # x after executing alternative code
-    xn_ = solver.make_symbol('xn_', bv32)
+    xn_ = solver.make_symbol("xn_", bv32)
 
-    ite_assignment = solver.make_term(ss.primops.Equal,
-                                      xn,
-                                      solver.make_term(ss.primops.Ite,
-                                                       x_eq_a,
-                                                       b,
-                                                       a))
+    ite_assignment = solver.make_term(
+        ss.primops.Equal, xn, solver.make_term(ss.primops.Ite, x_eq_a, b, a)
+    )
 
     print("Asserting", ite_assignment)
     solver.assert_formula(ite_assignment)
@@ -90,28 +94,29 @@ def test_hackers_delight(create_solver):
     # Push a context -- all assertions and check-sat calls are in a different context
     solver.push()
     # Encoding option 1
-    assignment1 = solver.make_term(ss.primops.Equal,
-                                   xn_,
-                                   solver.make_term(ss.primops.BVXor, a,
-                                                    solver.make_term(ss.primops.BVXor, b, x)))
+    assignment1 = solver.make_term(
+        ss.primops.Equal,
+        xn_,
+        solver.make_term(ss.primops.BVXor, a, solver.make_term(ss.primops.BVXor, b, x)),
+    )
 
     solver.assert_formula(assignment1)
     solver.assert_formula(solver.make_term(ss.primops.Distinct, xn, xn_))
     r = solver.check_sat()
-    assert(r.is_unsat())
+    assert r.is_unsat()
     # Pop the context
     solver.pop()
 
     solver.push()
-    assignment2 = solver.make_term(ss.primops.Equal,
-                                   xn_,
-                                   solver.make_term(ss.primops.BVSub,
-                                                    solver.make_term(ss.primops.BVAdd, a, b),
-                                                    x))
+    assignment2 = solver.make_term(
+        ss.primops.Equal,
+        xn_,
+        solver.make_term(ss.primops.BVSub, solver.make_term(ss.primops.BVAdd, a, b), x),
+    )
     solver.assert_formula(assignment2)
     solver.assert_formula(solver.make_term(ss.primops.Distinct, xn, xn_))
     r = solver.check_sat()
-    assert(r.is_unsat())
+    assert r.is_unsat()
     solver.pop()
 
 
@@ -123,19 +128,20 @@ def test_complex_expr(create_solver):
     bv128 = solver.make_sort(ss.sortkinds.BV, 128)
     bv32 = solver.make_sort(ss.sortkinds.BV, 32)
 
-    x = solver.make_symbol('x', bv128)
-    y = solver.make_symbol('y', bv128)
-    a = solver.make_symbol('a', bv32)
-    b = solver.make_symbol('b', bv32)
-    c = solver.make_symbol('c', bv32)
-    d = solver.make_symbol('d', bv32)
+    x = solver.make_symbol("x", bv128)
+    y = solver.make_symbol("y", bv128)
+    a = solver.make_symbol("a", bv32)
+    b = solver.make_symbol("b", bv32)
+    c = solver.make_symbol("c", bv32)
+    d = solver.make_symbol("d", bv32)
 
-    abcd = solver.make_term(ss.primops.Concat,
-                            a,
-                            solver.make_term(ss.primops.Concat,
-                                             b,
-                                             solver.make_term(ss.primops.Concat,
-                                                              c, d)))
+    abcd = solver.make_term(
+        ss.primops.Concat,
+        a,
+        solver.make_term(
+            ss.primops.Concat, b, solver.make_term(ss.primops.Concat, c, d)
+        ),
+    )
 
     t0 = solver.make_term(ss.primops.BVXor, x, y)
     t1 = solver.make_term(ss.primops.BVSub, x, abcd)
@@ -143,19 +149,21 @@ def test_complex_expr(create_solver):
     t3 = solver.make_term(Op(ss.primops.Extract, 31, 0), t0)
     t4 = solver.make_term(ss.primops.BVOr, t3, c)
     t5 = solver.make_term(ss.primops.BVAshr, b, d)
-    t6 = solver.make_term(ss.primops.Concat,
-                            t4,
-                            solver.make_term(ss.primops.Concat,
-                                            a,
-                                            solver.make_term(ss.primops.Concat,
-                                                            t5, b)))
-    t7 = solver.make_term(ss.primops.Ite, solver.make_term(ss.primops.BVUle, x, y),
-                            t2, t6)
+    t6 = solver.make_term(
+        ss.primops.Concat,
+        t4,
+        solver.make_term(
+            ss.primops.Concat, a, solver.make_term(ss.primops.Concat, t5, b)
+        ),
+    )
+    t7 = solver.make_term(
+        ss.primops.Ite, solver.make_term(ss.primops.BVUle, x, y), t2, t6
+    )
     t8 = solver.make_term(ss.primops.BVLshr, t7, t0)
 
-    t8_sub = solver.substitute(t8, {x:x, y:y, a:a, b:b, c:c, d:d})
+    t8_sub = solver.substitute(t8, {x: x, y: y, a: a, b: b, c: c, d: d})
     # should be identical
-    assert t8 == t8_sub, "Expecting identical terms but got:\n\t%s\n\t%s"%(t8, t8_sub)
+    assert t8 == t8_sub, "Expecting identical terms but got:\n\t%s\n\t%s" % (t8, t8_sub)
 
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
@@ -165,11 +173,8 @@ def test_bv_ops(create_solver):
 
     one = solver.make_term(1, bvsort32)
     t0 = solver.make_term(ss.Op(ss.primops.Rotate_Left, 3), one)
-    t = solver.make_term(ss.Op(ss.primops.Rotate_Right, 3),
-                    t0)
-    constraint = solver.make_term(ss.primops.Distinct,
-                                 one,
-                                 t)
+    t = solver.make_term(ss.Op(ss.primops.Rotate_Right, 3), t0)
+    constraint = solver.make_term(ss.primops.Distinct, one, t)
     solver.assert_formula(constraint)
     r = solver.check_sat()
     assert r.is_unsat(), "{} and {} should be identical".format(one, t)

--- a/tests/python/test_enums.py
+++ b/tests/python/test_enums.py
@@ -19,7 +19,9 @@ import smt_switch as ss
 from available_solvers import int_support_solvers
 
 
-@pytest.mark.parametrize("create_solver", [f for name, f in int_support_solvers.items()])
+@pytest.mark.parametrize(
+    "create_solver", [f for name, f in int_support_solvers.items()]
+)
 def test_sortkind(create_solver):
     solver = create_solver(False)
     bvsort = solver.make_sort(ss.sortkinds.BV, 8)
@@ -30,7 +32,9 @@ def test_sortkind(create_solver):
     assert sk is ss.sortkinds.BV
 
 
-@pytest.mark.parametrize("create_solver", [f for name, f in int_support_solvers.items()])
+@pytest.mark.parametrize(
+    "create_solver", [f for name, f in int_support_solvers.items()]
+)
 def test_primop(create_solver):
     solver = create_solver(False)
     bvsort = solver.make_sort(ss.sortkinds.BV, 8)

--- a/tests/python/test_itp.py
+++ b/tests/python/test_itp.py
@@ -19,7 +19,7 @@ import smt_switch as ss
 from typing import Set
 
 
-def get_free_vars(t:ss.Term)->Set[ss.Term]:
+def get_free_vars(t: ss.Term) -> Set[ss.Term]:
     to_visit = [t]
     visited = set()
 
@@ -40,44 +40,34 @@ def get_free_vars(t:ss.Term)->Set[ss.Term]:
 
     return free_vars
 
+
 # Note: Msat is only interpolant producing solver currently
-@pytest.mark.parametrize("itp_name", [name for name in ss.solvers if name in {'msat', 'cvc5'}])
+@pytest.mark.parametrize(
+    "itp_name", [name for name in ss.solvers if name in {"msat", "cvc5"}]
+)
 def test_simple_itp(itp_name):
     try:
-        itp = eval(f'ss.create_{itp_name}_interpolator()')
+        itp = eval(f"ss.create_{itp_name}_interpolator()")
     except:
         raise NotImplementedError("Haven't handled interpolator {}".format(itp_name))
 
     intsort = itp.make_sort(ss.sortkinds.INT)
-    x = itp.make_symbol('x', intsort)
-    y = itp.make_symbol('y', intsort)
-    z = itp.make_symbol('z', intsort)
-    w = itp.make_symbol('w', intsort)
+    x = itp.make_symbol("x", intsort)
+    y = itp.make_symbol("y", intsort)
+    z = itp.make_symbol("z", intsort)
+    w = itp.make_symbol("w", intsort)
 
     # x < y
-    A = itp.make_term(ss.primops.Lt,
-                         x,
-                         y)
+    A = itp.make_term(ss.primops.Lt, x, y)
 
     # y < w
-    A = itp.make_term(ss.primops.And,
-                         A,
-                         itp.make_term(ss.primops.Lt,
-                                           y,
-                                           w))
-
+    A = itp.make_term(ss.primops.And, A, itp.make_term(ss.primops.Lt, y, w))
 
     # z > w
-    B = itp.make_term(ss.primops.Gt,
-                         z,
-                         w)
+    B = itp.make_term(ss.primops.Gt, z, w)
 
     # z < x
-    B = itp.make_term(ss.primops.And,
-                         B,
-                         itp.make_term(ss.primops.Lt,
-                                           z,
-                                           x))
+    B = itp.make_term(ss.primops.And, B, itp.make_term(ss.primops.Lt, z, x))
 
     I = itp.get_interpolant(A, B)
     assert I is not None

--- a/tests/python/test_lia.py
+++ b/tests/python/test_lia.py
@@ -19,27 +19,34 @@ import smt_switch as ss
 
 from available_solvers import int_support_solvers
 
-@pytest.mark.parametrize("create_solver", [f for name, f in int_support_solvers.items()])
+
+@pytest.mark.parametrize(
+    "create_solver", [f for name, f in int_support_solvers.items()]
+)
 def test_simple(create_solver):
     solver = create_solver(False)
-    solver.set_opt('produce-models', 'true')
-    solver.set_logic('QF_LIA')
+    solver.set_opt("produce-models", "true")
+    solver.set_logic("QF_LIA")
 
     intsort = solver.make_sort(ss.sortkinds.INT)
-    x = solver.make_symbol('x', intsort)
-    y = solver.make_symbol('y', intsort)
-    z = solver.make_symbol('z', intsort)
+    x = solver.make_symbol("x", intsort)
+    y = solver.make_symbol("y", intsort)
+    z = solver.make_symbol("z", intsort)
 
     two = solver.make_term(2, intsort)
     three = solver.make_term(3, intsort)
     five = solver.make_term(5, intsort)
 
-    t1 = solver.make_term(ss.primops.Plus,
-                          solver.make_term(ss.primops.Mult, two, x),
-                          solver.make_term(ss.primops.Mult, three, y))
-    t2 = solver.make_term(ss.primops.Minus,
-                          solver.make_term(ss.primops.Mult, five, y),
-                          solver.make_term(ss.primops.Mult, three, z))
+    t1 = solver.make_term(
+        ss.primops.Plus,
+        solver.make_term(ss.primops.Mult, two, x),
+        solver.make_term(ss.primops.Mult, three, y),
+    )
+    t2 = solver.make_term(
+        ss.primops.Minus,
+        solver.make_term(ss.primops.Mult, five, y),
+        solver.make_term(ss.primops.Mult, three, z),
+    )
 
     f1 = solver.make_term(ss.primops.Lt, t1, five)
     f2 = solver.make_term(ss.primops.Ge, t2, two)
@@ -54,5 +61,5 @@ def test_simple(create_solver):
     yv = int(solver.get_value(y))
     zv = int(solver.get_value(z))
 
-    assert 2*xv + 3*yv < 5
-    assert 5*yv - 3*zv >= 2
+    assert 2 * xv + 3 * yv < 5
+    assert 5 * yv - 3 * zv >= 2

--- a/tests/python/test_pysmt.py
+++ b/tests/python/test_pysmt.py
@@ -7,13 +7,17 @@ from pysmt import typing as st
 from pysmt import logics as sl
 import smt_switch.pysmt_frontend as fe
 
-@pytest.mark.parametrize('solver_str', fe.SWITCH_SOLVERS.keys())
-@pytest.mark.parametrize(('T', 'logic'), [
-    (st.BV8, sl.QF_BV),
-    (st.INT, sl.QF_LIA),
-    (st.REAL, sl.QF_LRA),
-    ])
-@pytest.mark.parametrize('implicit', [True, False])
+
+@pytest.mark.parametrize("solver_str", fe.SWITCH_SOLVERS.keys())
+@pytest.mark.parametrize(
+    ("T", "logic"),
+    [
+        (st.BV8, sl.QF_BV),
+        (st.INT, sl.QF_LIA),
+        (st.REAL, sl.QF_LRA),
+    ],
+)
+@pytest.mark.parametrize("implicit", [True, False])
 def test_basic(solver_str, T, logic, implicit):
     x = sc.FreshSymbol(T)
     problem = sc.And(x < 2, x > 0)
@@ -22,7 +26,6 @@ def test_basic(solver_str, T, logic, implicit):
         args = ()
     else:
         args = (logic,)
-
 
     if logic not in fe.SWITCH_SOLVERS[solver_str].LOGICS:
         with pytest.raises(RuntimeError):

--- a/tests/python/test_reals.py
+++ b/tests/python/test_reals.py
@@ -22,30 +22,45 @@ from smt_switch.primops import Equal, Ge, Lt, Minus, Mult, Plus
 import available_solvers
 from available_solvers import int_support_solvers
 
-termiter_and_int_keys = available_solvers.termiter_support_solvers.keys() & available_solvers.int_support_solvers.keys()
+termiter_and_int_keys = (
+    available_solvers.termiter_support_solvers.keys()
+    & available_solvers.int_support_solvers.keys()
+)
 termiter_and_int_solvers = [f for f in {ss.solvers[n] for n in termiter_and_int_keys}]
+
 
 @pytest.mark.parametrize("create_solver", termiter_and_int_solvers)
 def test_reals_simple(create_solver):
     solver = create_solver(False)
-    solver.set_logic('QF_LRA')
+    solver.set_logic("QF_LRA")
 
     realsort = solver.make_sort(REAL)
 
-    x = solver.make_symbol('x', realsort)
-    y = solver.make_symbol('y', realsort)
+    x = solver.make_symbol("x", realsort)
+    y = solver.make_symbol("y", realsort)
 
     c1 = solver.make_term(2, realsort)
-    c2 = solver.make_term('457/32', realsort)
-    c3 = solver.make_term('1.352968', realsort)
-    c4 = solver.make_term('457/64', realsort)
+    c2 = solver.make_term("457/32", realsort)
+    c3 = solver.make_term("1.352968", realsort)
+    c4 = solver.make_term("457/64", realsort)
     print(c4)
 
-    solver.assert_formula(solver.make_term(Ge, solver.make_term(Minus,
-                                                                solver.make_term(Mult, c1, x),
-                                                                solver.make_term(Mult, c2, y)), c1))
-    solver.assert_formula(solver.make_term(Lt, solver.make_term(Minus, x, solver.make_term(1, realsort)),
-                                           solver.make_term(Mult, c4, y)))
+    solver.assert_formula(
+        solver.make_term(
+            Ge,
+            solver.make_term(
+                Minus, solver.make_term(Mult, c1, x), solver.make_term(Mult, c2, y)
+            ),
+            c1,
+        )
+    )
+    solver.assert_formula(
+        solver.make_term(
+            Lt,
+            solver.make_term(Minus, x, solver.make_term(1, realsort)),
+            solver.make_term(Mult, c4, y),
+        )
+    )
     r = solver.check_sat()
     assert r.is_unsat()
 
@@ -53,29 +68,31 @@ def test_reals_simple(create_solver):
 @pytest.mark.parametrize("create_solver", [f for n, f in int_support_solvers.items()])
 def test_reals_subs_check(create_solver):
     solver = create_solver(False)
-    solver.set_logic('QF_LRA')
-    solver.set_opt('produce-models', 'true')
-    solver.set_opt('incremental', 'true')
+    solver.set_logic("QF_LRA")
+    solver.set_opt("produce-models", "true")
+    solver.set_opt("incremental", "true")
 
     realsort = solver.make_sort(REAL)
 
-    x = solver.make_symbol('x', realsort)
-    y = solver.make_symbol('y', realsort)
-    z = solver.make_symbol('z', realsort)
+    x = solver.make_symbol("x", realsort)
+    y = solver.make_symbol("y", realsort)
+    z = solver.make_symbol("z", realsort)
 
     three = solver.make_term(3, realsort)
-    ten   = solver.make_term(10, realsort)
-    c     = solver.make_term("1237/5", realsort)
+    ten = solver.make_term(10, realsort)
+    c = solver.make_term("1237/5", realsort)
 
-    constraint1 = solver.make_term(Lt, solver.make_term(Plus,
-                                                        solver.make_term(Mult, three, x),
-                                                        solver.make_term(Mult, c, y)),
-                                   ten)
+    constraint1 = solver.make_term(
+        Lt,
+        solver.make_term(
+            Plus, solver.make_term(Mult, three, x), solver.make_term(Mult, c, y)
+        ),
+        ten,
+    )
 
-    constraint2 = solver.make_term(Ge, solver.make_term(Minus,
-                                                        y,
-                                                        solver.make_term(Mult, c, z)),
-                                   three)
+    constraint2 = solver.make_term(
+        Ge, solver.make_term(Minus, y, solver.make_term(Mult, c, z)), three
+    )
 
     solver.push()
 
@@ -90,7 +107,7 @@ def test_reals_subs_check(create_solver):
 
     solver.pop()
 
-    substitution_map = {x:xv, y:yv, z:zv}
+    substitution_map = {x: xv, y: yv, z: zv}
     c1sub = solver.substitute(constraint1, substitution_map)
     c2sub = solver.substitute(constraint2, substitution_map)
 

--- a/tests/python/test_sorting_network.py
+++ b/tests/python/test_sorting_network.py
@@ -19,30 +19,34 @@ import pytest
 
 import smt_switch as ss
 
-@pytest.mark.parametrize("create_solver,num_vars",
-                         product(ss.solvers.values(), [3, 6, 8]))
+
+@pytest.mark.parametrize(
+    "create_solver,num_vars", product(ss.solvers.values(), [3, 6, 8])
+)
 def test_sorting_network(create_solver, num_vars):
     solver = create_solver(False)
-    solver.set_opt('produce-models', 'true')
-    solver.set_opt('incremental', 'true')
+    solver.set_opt("produce-models", "true")
+    solver.set_opt("incremental", "true")
 
     boolsort = solver.make_sort(ss.sortkinds.BOOL)
     boollist = []
     for i in range(num_vars):
-        boollist.append(solver.make_symbol('b' + str(i), boolsort))
+        boollist.append(solver.make_symbol("b" + str(i), boolsort))
 
     sn = ss.SortingNetwork(solver)
     sortedlist = sn.sorting_network(boollist)
 
     # Test each possible return value
-    for num_true in range(num_vars+1):
+    for num_true in range(num_vars + 1):
         solver.push()
         if num_true:
             # ensure there are at least num_true set to true
-            solver.assert_formula(sortedlist[num_true-1])
+            solver.assert_formula(sortedlist[num_true - 1])
         if num_true < num_vars:
             # ensure there aren't more than num_true set to true
-            solver.assert_formula(solver.make_term(ss.primops.Not, sortedlist[num_true]))
+            solver.assert_formula(
+                solver.make_term(ss.primops.Not, sortedlist[num_true])
+            )
         res = solver.check_sat()
         assert res.is_sat()
 

--- a/tests/python/test_unit.py
+++ b/tests/python/test_unit.py
@@ -18,28 +18,31 @@ import pytest
 import smt_switch as ss
 import available_solvers
 
-@pytest.mark.parametrize("create_solver", available_solvers.termiter_support_solvers.values())
+
+@pytest.mark.parametrize(
+    "create_solver", available_solvers.termiter_support_solvers.values()
+)
 def test_unit_op(create_solver):
     solver = create_solver(False)
 
     null_op = ss.Op()
     ext = ss.Op(ss.primops.Extract, 2, 0)
 
-    x = solver.make_symbol('x', solver.make_sort(ss.sortkinds.BV, 4))
+    x = solver.make_symbol("x", solver.make_sort(ss.sortkinds.BV, 4))
 
-    assert not null_op, 'null op should return false for bool'
-    assert ext, 'non-null op should return true for bool'
+    assert not null_op, "null op should return false for bool"
+    assert ext, "non-null op should return true for bool"
     try:
         null_op_x = solver.make_term(null_op, x)
-        assert False, 'Should get a ValueError'
+        assert False, "Should get a ValueError"
     except ValueError as e:
         pass
     except:
-        assert False, 'Should have gotten a ValueError'
+        assert False, "Should have gotten a ValueError"
 
     ext_x = solver.make_term(ext, x)
-    assert ext == ext_x.get_op(), 'Extraction ops should match'
-    assert ext != null_op, 'Extract op should not be equivalent to a null op'
+    assert ext == ext_x.get_op(), "Extraction ops should match"
+    assert ext != null_op, "Extract op should not be equivalent to a null op"
 
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
@@ -47,12 +50,12 @@ def test_sort(create_solver):
     solver = create_solver(False)
 
     boolsort = solver.make_sort(ss.sortkinds.BOOL)
-    bvsort   = solver.make_sort(ss.sortkinds.BV, 8)
-    arrsort  = solver.make_sort(ss.sortkinds.ARRAY, [bvsort, bvsort])
+    bvsort = solver.make_sort(ss.sortkinds.BV, 8)
+    arrsort = solver.make_sort(ss.sortkinds.ARRAY, [bvsort, bvsort])
 
     # TODO: test functions when boolector supports querying the sort
 
-    names = ['b', 'bv', 'a']
+    names = ["b", "bv", "a"]
     sorts = [boolsort, bvsort, arrsort]
 
     for n, s in zip(names, sorts):
@@ -61,7 +64,9 @@ def test_sort(create_solver):
         assert t.get_sort().get_sort_kind() == s.get_sort_kind()
 
 
-@pytest.mark.parametrize("create_solver", available_solvers.termiter_support_solvers.values())
+@pytest.mark.parametrize(
+    "create_solver", available_solvers.termiter_support_solvers.values()
+)
 def test_unit_iter(create_solver):
     solver = create_solver(False)
 
@@ -69,15 +74,17 @@ def test_unit_iter(create_solver):
     ext = ss.Op(ss.primops.Extract, 2, 0)
 
     bvsort = solver.make_sort(ss.sortkinds.BV, 4)
-    x = solver.make_symbol('x', bvsort)
-    f = solver.make_symbol('f', solver.make_sort(ss.sortkinds.FUNCTION, [bvsort, bvsort]))
+    x = solver.make_symbol("x", bvsort)
+    f = solver.make_symbol(
+        "f", solver.make_sort(ss.sortkinds.FUNCTION, [bvsort, bvsort])
+    )
 
     fx = solver.make_term(ss.primops.Apply, f, x)
 
     cnt = 0
     for t in fx:
-        assert cnt != 0 or t == f, 'First child should be f'
-        assert cnt != 1 or t == x, 'Second child should be x'
+        assert cnt != 0 or t == f, "First child should be f"
+        assert cnt != 1 or t == x, "Second child should be x"
         cnt += 1
 
     assert cnt == 2, "Expecting two children"
@@ -90,12 +97,11 @@ def test_bool(create_solver):
 
     boolsort = solver.make_sort(ss.sortkinds.BOOL)
     x = solver.make_symbol("x", boolsort)
-    y = solver.make_symbol('y', boolsort)
+    y = solver.make_symbol("y", boolsort)
 
-    solver.assert_formula(solver.make_term(ss.primops.And,
-                                           x,
-                                           solver.make_term(ss.primops.Not,
-                                                            y)))
+    solver.assert_formula(
+        solver.make_term(ss.primops.And, x, solver.make_term(ss.primops.Not, y))
+    )
     solver.check_sat()
     xv = solver.get_value(x)
     yv = solver.get_value(y)
@@ -116,7 +122,7 @@ def test_check_sat_assuming(create_solver):
     solver = create_solver(False)
     solver.set_opt("incremental", "true")
     boolsort = solver.make_sort(ss.sortkinds.BOOL)
-    bvsort8  = solver.make_sort(ss.sortkinds.BV, 8)
+    bvsort8 = solver.make_sort(ss.sortkinds.BV, 8)
 
     x = solver.make_symbol("x", bvsort8)
     b = solver.make_symbol("b", boolsort)
@@ -127,7 +133,9 @@ def test_check_sat_assuming(create_solver):
 
     try:
         solver.check_sat_assuming([xeq0])
-        assert False, "Expecting a thrown exception for check_sat_assuming with a formula"
+        assert False, (
+            "Expecting a thrown exception for check_sat_assuming with a formula"
+        )
     except:
         pass
 
@@ -139,17 +147,17 @@ def test_check_sat_assuming(create_solver):
 def test_multi_arg_fun(create_solver):
     solver = create_solver(False)
     bvsort = solver.make_sort(ss.sortkinds.BV, 8)
-    funsort = solver.make_sort(ss.sortkinds.FUNCTION, [bvsort]*8)
+    funsort = solver.make_sort(ss.sortkinds.FUNCTION, [bvsort] * 8)
 
-    vs=[]
+    vs = []
     for i in range(7):
-        vs.append(solver.make_symbol('x%i'%i, bvsort))
+        vs.append(solver.make_symbol("x%i" % i, bvsort))
 
-    vs2=[]
+    vs2 = []
     for i in range(7):
-        vs2.append(solver.make_symbol('y%i'%i, bvsort))
+        vs2.append(solver.make_symbol("y%i" % i, bvsort))
 
-    f = solver.make_symbol('f', funsort)
+    f = solver.make_symbol("f", funsort)
     res = solver.make_term(ss.primops.Apply, [f] + vs)
     assert res == solver.make_term(ss.primops.Apply, f, *vs)
 

--- a/tests/python/test_unit_vals.py
+++ b/tests/python/test_unit_vals.py
@@ -19,7 +19,10 @@ import smt_switch as ss
 from smt_switch.primops import Distinct, Equal, Select, Store
 import available_solvers
 
-termiter_and_int_keys = available_solvers.termiter_support_solvers.keys() & available_solvers.int_support_solvers.keys()
+termiter_and_int_keys = (
+    available_solvers.termiter_support_solvers.keys()
+    & available_solvers.int_support_solvers.keys()
+)
 termiter_and_int_solvers = [f for f in {ss.solvers[n] for n in termiter_and_int_keys}]
 
 
@@ -32,4 +35,6 @@ def test_unit_bigint(create_solver):
     maxsint_64 = solver.make_term(int("0x7FFFFFFFFFFFFFFF", 16), intsort)
 
     solver.assert_formula(solver.make_term(ss.primops.Gt, bigint, maxsint_64))
-    assert solver.check_sat().is_sat(), "Expecting to represent a large integer without overflow"
+    assert solver.check_sat().is_sat(), (
+        "Expecting to represent a large integer without overflow"
+    )

--- a/tests/python/test_unsat_core.py
+++ b/tests/python/test_unsat_core.py
@@ -17,6 +17,7 @@
 import pytest
 import smt_switch as ss
 
+
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_unsat_assumptions_simple(create_solver):
     solver = create_solver(False)
@@ -26,7 +27,7 @@ def test_unsat_assumptions_simple(create_solver):
     a = solver.make_symbol("a", boolsort)
     b = solver.make_symbol("b", boolsort)
     notB = solver.make_term(ss.primops.Not, b)
-    r = solver.check_sat_assuming([a, b, notB]);
+    r = solver.check_sat_assuming([a, b, notB])
     core = solver.get_unsat_assumptions()
     assert b in core, "expecting b to be in core"
     assert notB in core, "expecting (not b) to be in core"

--- a/tests/python/test_visitor.py
+++ b/tests/python/test_visitor.py
@@ -16,21 +16,26 @@ import pytest
 import smt_switch as ss
 from smt_switch.primops import Ite, Equal, BVOr, BVUlt
 
-@pytest.mark.parametrize("create_solver", [f for name, f in ss.solvers.items() if name != 'yices2'])
+
+@pytest.mark.parametrize(
+    "create_solver", [f for name, f in ss.solvers.items() if name != "yices2"]
+)
 def test_identity_visit_basic(create_solver):
     solver = create_solver(False)
 
     bv32 = solver.make_sort(ss.sortkinds.BV, 32)
 
-    x = solver.make_symbol('x', bv32)
-    y = solver.make_symbol('y', bv32)
-    a = solver.make_symbol('a', bv32)
-    b = solver.make_symbol('b', bv32)
+    x = solver.make_symbol("x", bv32)
+    y = solver.make_symbol("y", bv32)
+    a = solver.make_symbol("a", bv32)
+    b = solver.make_symbol("b", bv32)
 
-    y_assignment = solver.make_term(Ite,
-                                    solver.make_term(BVUlt, x, y),
-                                    solver.make_term(BVOr, x, a),
-                                    solver.make_term(BVOr, x, b))
+    y_assignment = solver.make_term(
+        Ite,
+        solver.make_term(BVUlt, x, y),
+        solver.make_term(BVOr, x, a),
+        solver.make_term(BVOr, x, b),
+    )
 
     idvisitor = ss.IdentityVisitor(solver)
     rebuilt_y_assignment = idvisitor.walk_dag(y_assignment)


### PR DESCRIPTION
Add a root .ruff.toml containing only the settings that `ruff format` reads, and run `ruff format` across the repository. No lint rules are configured yet and no lint findings are addressed; those follow in separate commits so that this diff stays purely mechanical and reviewable.

target-version is py39 to match requires-python in python/pyproject.toml and find_package(Python 3.9 ...) in CMakeLists.txt. Line length (88) and quote style (double) are left at ruff's defaults.

Verified formatting-only: the abstract syntax tree of every reformatted .py file is identical before and after. README.md is included because ruff formats Python code blocks embedded in Markdown.