### PR TITLE
style: Apply ruff's safe autofixes and enable the ruff-check hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -39,9 +39,14 @@ repos:
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.6
     hooks:
-      # ruff-format only. ruff-check is intentionally not enabled yet: the lint
-      # rule selection and the resulting fixes are being worked out separately.
-      # See .ruff.toml.
+      # ruff-check comes before ruff-format, the order ruff recommends: --fix
+      # can leave code that the formatter then rewrites.
+      #
+      # The rule selection lives in .ruff.toml, which still carries a block of
+      # temporary ignores for the rules this tree violates. Those are being
+      # removed one at a time, so this hook stays green in the meantime.
+      - id: ruff-check
+        args: [--fix]
       - id: ruff-format
 
   - repo: https://github.com/BlankSpruce/gersemi-pre-commit

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -1,8 +1,3 @@
-# Minimal configuration for `ruff format`. Lint rules are added in a follow-up.
-#
-# Formatter defaults are what we want, so they are left unset: 88-column line
-# length and double quotes.
-
 # Matches requires-python = ">=3.9" in python/pyproject.toml, and the
 # find_package(Python 3.9 ...) in CMakeLists.txt.
 target-version = "py39"
@@ -12,3 +7,81 @@ extend-exclude = ["build", "deps"]
 # pre-commit passes explicit file paths, which would otherwise override the
 # excludes above.
 force-exclude = true
+
+[lint]
+select = ["ALL"]
+
+ignore = [
+  # ---------------------------------------------------------------------------
+  # Permanent: deliberate project decisions.
+  # ---------------------------------------------------------------------------
+  "ANN",    # the codebase is unannotated; revisit if mypy is enabled
+  "COM812", # trailing commas are the formatter's job
+  "CPY001", # copyright headers are a C++-side convention here
+  "D",      # no docstring convention has been adopted
+  "E501",   # the formatter owns line width; long Cython templates cannot wrap
+  "EM",     # message literals inline in `raise` are fine
+  "FBT",    # the generated solver factories take a positional `logging` bool
+  "FIX",    # TODO and HACK comments are allowed
+  "ISC001", # conflicts with the formatter
+  "T20",    # print() is intentional in examples and a few tests
+  "TD002",  # ...without an author
+  "TD003",  # ...or an issue link
+  "TRY003", # see EM
+
+  # ---------------------------------------------------------------------------
+  # Temporary: rules that the existing code still violates, so that the tip of
+  # the branch stays green. Delete each entry once its violations are resolved,
+  # either by fixing the code or by moving the rule above / into
+  # per-file-ignores with a justification.
+  # ---------------------------------------------------------------------------
+  "ARG001",  # unused-function-argument
+  "ARG002",  # unused-method-argument
+  "B011",    # assert-false
+  "B904",    # raise-without-from-inside-except
+  "C408",    # unnecessary-collection-call
+  "C416",    # unnecessary-comprehension
+  "C901",    # complex-structure
+  "E402",    # module-import-not-at-top-of-file
+  "E722",    # bare-except
+  "E741",    # ambiguous-variable-name
+  "F401",    # unused-import
+  "F841",    # unused-variable
+  "FA100",   # future-rewritable-type-annotation
+  "N802",    # invalid-function-name
+  "N803",    # invalid-argument-name
+  "N806",    # non-lowercase-variable-in-function
+  "PERF203", # try-except-in-loop
+  "PERF401", # manual-list-comprehension
+  "PLC0415", # import-outside-top-level
+  "PLR1714", # repeated-equality-comparison
+  "PLR2004", # magic-value-comparison
+  "PT006",   # pytest-parametrize-names-wrong-type
+  "PT015",   # pytest-assert-always-false
+  "PTH123",  # builtin-open
+  "RET504",  # unnecessary-assign
+  "RSE102",  # unnecessary-paren-on-raise-exception
+  "RUF005",  # collection-literal-concatenation
+  "S101",    # assert, in pysmt_frontend; tests and examples are exempt below
+  "S110",    # try-except-pass
+  "S307",    # suspicious-eval-usage
+  "SIM108",  # if-else-block-instead-of-if-exp
+  "SIM117",  # multiple-with-statements
+  "SLF001",  # private-member-access
+  "UP006",   # non-pep585-annotation
+  "UP031",   # printf-string-formatting
+  "UP035",   # deprecated-import
+]
+
+[lint.per-file-ignores]
+# Neither directory is a package: pytest inserts its rootdir on sys.path, and
+# examples/ is meant to be read and run as standalone scripts. `assert` is also
+# how these pytest tests assert.
+"examples/*" = ["INP001", "S101"]
+"tests/python/*" = ["INP001", "S101"]
+
+# `smt_switch` is built by this repository, and `available_solvers` is a helper
+# module in tests/python. Neither lives at the project root, so ruff cannot
+# infer that they are first-party.
+[lint.isort]
+known-first-party = ["available_solvers", "smt_switch"]

--- a/examples/python_qf_ufbv.py
+++ b/examples/python_qf_ufbv.py
@@ -1,6 +1,6 @@
 #!/usr/bin/env python3
 import smt_switch as ss
-from smt_switch.primops import Apply, Distinct, Equal, Extract, BVAnd, BVUge
+from smt_switch.primops import Apply, BVAnd, BVUge, Distinct, Equal, Extract
 
 if __name__ == "__main__":
     s = ss.create_btor_solver(True)

--- a/python/smt_switch/pysmt_frontend/__init__.py
+++ b/python/smt_switch/pysmt_frontend/__init__.py
@@ -1,9 +1,9 @@
 import typing as tp
 
 from pysmt import logics
-from pysmt.solvers.solver import Solver as SolverT
-from pysmt.exceptions import NoSolverAvailableError, NoLogicAvailableError
 from pysmt.environment import get_env
+from pysmt.exceptions import NoLogicAvailableError, NoSolverAvailableError
+from pysmt.solvers.solver import Solver as SolverT
 
 from .pysmt_solver import SWITCH_SOLVERS
 

--- a/python/smt_switch/pysmt_frontend/pysmt_solver.py
+++ b/python/smt_switch/pysmt_frontend/pysmt_solver.py
@@ -1,32 +1,29 @@
-from collections import ChainMap
 import fractions
 import functools as ft
 import gc
 import itertools as it
 import operator
+from collections import ChainMap
 
-import smt_switch as ss
-
-
+from pysmt import typing as pysmt_types
+from pysmt.decorators import catch_conversion_error, clear_pending_pop
 from pysmt.exceptions import (
-    UndefinedLogicError,
-    SolverReturnedUnknownResultError,
     ConvertExpressionError,
     PysmtValueError,
+    SolverReturnedUnknownResultError,
+    UndefinedLogicError,
 )
+from pysmt.logics import SMTLIB2_LOGICS, get_logic
+from pysmt.solvers.eager import EagerModel
+from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
 from pysmt.solvers.solver import (
-    IncrementalTrackingSolver,
-    UnsatCoreSolver,
     Converter,
+    IncrementalTrackingSolver,
     SolverOptions,
 )
-from pysmt.solvers.smtlib import SmtLibBasicSolver, SmtLibIgnoreMixin
-from pysmt.solvers.eager import EagerModel
 from pysmt.walkers import DagWalker
-from pysmt.decorators import clear_pending_pop, catch_conversion_error
-from pysmt.logics import get_logic, SMTLIB2_LOGICS
-from pysmt import typing as pysmt_types
 
+import smt_switch as ss
 
 SWITCH_SOLVERS = {}
 
@@ -53,22 +50,22 @@ def _parse_real(s):
             if c.isdigit():
                 num.append(c)
                 continue
-            elif num:
+            if num:
                 tree.append(int("".join(num)))
                 num = []
 
             if c == ")":
                 break
-            elif c == " ":
+            if c == " ":
                 continue
-            elif c == "(":
+            if c == "(":
                 tree.append(_parse(it))
             elif c == "-":
                 tree.append(operator.neg)
             elif c == "/":
                 tree.append(fractions.Fraction)
             else:
-                raise ValueError()
+                raise ValueError
 
         if num:
             tree.append(int("".join(num)))
@@ -77,8 +74,7 @@ def _parse_real(s):
         if len(tree) == 1:
             assert isinstance(tree[0], (int, fractions.Fraction))
             return tree[0]
-        else:
-            return tree[0](*tree[1:])
+        return tree[0](*tree[1:])
 
     return _parse(iter(repr(s)))
 
@@ -150,10 +146,9 @@ class _SwitchSolver(IncrementalTrackingSolver, SmtLibBasicSolver, SmtLibIgnoreMi
 
         if res.is_sat():
             return True
-        elif res.is_unsat():
+        if res.is_unsat():
             return False
-        else:
-            raise SolverReturnedUnknownResultError()
+        raise SolverReturnedUnknownResultError()
 
     @clear_pending_pop
     def _push(self, levels=1):
@@ -363,8 +358,7 @@ class SwitchConverter(Converter, DagWalker):
 
         if sort_i.is_function_type():
             return self.declared_funs.setdefault(formula, res)
-        else:
-            return self.declared_vars.setdefault(formula, res)
+        return self.declared_vars.setdefault(formula, res)
 
     @check_args(operator.eq, 0)
     def _walk_constant(self, formula, args, **kwargs):
@@ -587,21 +581,20 @@ class BackVisitor(ss.TermDagVisitor):
                     assert op.num_idx == 1
             primop = op.primop
             if primop not in self.convertion_table:
-                raise NotImplementedError()
+                raise NotImplementedError
             return self.convertion_table[primop](*new_children, *indices)
-        elif new_children:
+        if new_children:
             assert term.get_sort().get_sort_kind() is ss.sortkinds.ARRAY
             Kt = self._convert_sort(term.get_sort().get_indexsort())
             return self.mgr.Array(Kt, *new_children, {})
-        elif term.is_value():
+        if term.is_value():
             return self._convert_value(term)
-        elif term.is_symbolic_const():
+        if term.is_symbolic_const():
             sort = self._convert_sort(term.get_sort())
             return self.mgr.Symbol(str(term), sort)
-        else:
-            assert term.get_sort().get_sort_kind() is ss.sortkinds.FUNCTION
-            sort = self._convert_sort(term.get_sort())
-            return self.mgr.Symbol(str(term), sort)
+        assert term.get_sort().get_sort_kind() is ss.sortkinds.FUNCTION
+        sort = self._convert_sort(term.get_sort())
+        return self.mgr.Symbol(str(term), sort)
 
     def _convert_sort(self, sort):
         kind = sort.get_sort_kind()
@@ -609,19 +602,18 @@ class BackVisitor(ss.TermDagVisitor):
             Kt = self._convert_sort(sort.get_indexsort())
             Vt = self._convert_sort(sort.get_elemsort())
             return pysmt_types.ArrayType(Kt, Vt)
-        elif kind is ss.sortkinds.BOOL:
+        if kind is ss.sortkinds.BOOL:
             return pysmt_types.BOOL
-        elif kind is ss.sortkinds.BV:
+        if kind is ss.sortkinds.BV:
             return pysmt_types.BVType(sort.get_width())
-        elif kind is ss.sortkinds.FUNCTION:
+        if kind is ss.sortkinds.FUNCTION:
             domain = [self._convert_sort(s) for s in sort.get_domain_sorts()]
             codomain = self._convert_sort(sort.get_codomain())
             return pysmt_types.FunctionType(codomain, domain)
-        elif kind is ss.sortkinds.INT:
+        if kind is ss.sortkinds.INT:
             return pysmt_types.INT
-        else:
-            assert kind is ss.sortkinds.REAL
-            return pysmt_types.REAL
+        assert kind is ss.sortkinds.REAL
+        return pysmt_types.REAL
 
     def _convert_value(self, term, sort=None):
         # because smt-switch backends cannot be trusted to maintain
@@ -632,19 +624,18 @@ class BackVisitor(ss.TermDagVisitor):
         if sort.is_array_type():
             args = self._convert_array_value(term, sort)
             return self.mgr.Array(*args)
-        elif sort.is_bool_type():
+        if sort.is_bool_type():
             return self.mgr.Bool(bool(term))
-        elif sort.is_bv_type():
+        if sort.is_bv_type():
             return self.mgr.BV(int(term), sort.width)
-        elif sort.is_function_type():
-            raise NotImplementedError()
-        elif sort.is_int_type():
+        if sort.is_function_type():
+            raise NotImplementedError
+        if sort.is_int_type():
             return self.mgr.Int(int(term))
-        elif sort.is_real_type():
+        if sort.is_real_type():
             r = _parse_real(term)
             return self.mgr.Real(r)
-        else:
-            raise ConvertExpressionError(f"Unsupported sort: {sort}")
+        raise ConvertExpressionError(f"Unsupported sort: {sort}")
 
     def _convert_array_value(self, arr, sort):
         assignment = {}
@@ -667,14 +658,13 @@ class BackVisitor(ss.TermDagVisitor):
             return self.mgr.Array(sort.index_type, self._make_0(sort.elem_type))
         if sort.is_bool_type():
             return self.mgr.Bool(0)
-        elif sort.is_bv_type():
+        if sort.is_bv_type():
             return self.mgr.BV(0, sort.width)
-        elif sort.is_int_type():
+        if sort.is_int_type():
             return self.mgr.Int(0)
-        elif sort.is_real_type():
+        if sort.is_real_type():
             return self.mgr.Real(0)
-        else:
-            raise TypeError(f"Unsupported sort: {sort}")
+        raise TypeError(f"Unsupported sort: {sort}")
 
     def _convert_abs(self, child):
         assert child.get_type().is_int_type()

--- a/tests/python/available_solvers.py
+++ b/tests/python/available_solvers.py
@@ -16,7 +16,6 @@
 
 import smt_switch as ss
 
-
 termiter_support_solvers = {k: v for k, v in ss.solvers.items() if k != "yices2"}
 int_support_solvers = {
     k: v for k, v in ss.solvers.items() if k != "btor" and k != "bitwuzla"

--- a/tests/python/test_arrays.py
+++ b/tests/python/test_arrays.py
@@ -15,10 +15,10 @@
 #
 
 import pytest
-import smt_switch as ss
-from smt_switch.primops import Distinct, Equal, Select, Store
 
+import smt_switch as ss
 from available_solvers import int_support_solvers
+from smt_switch.primops import Distinct, Equal, Select, Store
 
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())

--- a/tests/python/test_bv.py
+++ b/tests/python/test_bv.py
@@ -15,8 +15,9 @@
 #
 
 import pytest
-import smt_switch as ss
+
 import available_solvers
+import smt_switch as ss
 
 
 # @pytest.mark.parametrize("create_solver", ss.solvers.values())
@@ -177,4 +178,4 @@ def test_bv_ops(create_solver):
     constraint = solver.make_term(ss.primops.Distinct, one, t)
     solver.assert_formula(constraint)
     r = solver.check_sat()
-    assert r.is_unsat(), "{} and {} should be identical".format(one, t)
+    assert r.is_unsat(), f"{one} and {t} should be identical"

--- a/tests/python/test_enums.py
+++ b/tests/python/test_enums.py
@@ -14,8 +14,8 @@
 #
 
 import pytest
-import smt_switch as ss
 
+import smt_switch as ss
 from available_solvers import int_support_solvers
 
 

--- a/tests/python/test_itp.py
+++ b/tests/python/test_itp.py
@@ -14,9 +14,11 @@
 #
 #
 
-import pytest
-import smt_switch as ss
 from typing import Set
+
+import pytest
+
+import smt_switch as ss
 
 
 def get_free_vars(t: ss.Term) -> Set[ss.Term]:
@@ -31,12 +33,11 @@ def get_free_vars(t: ss.Term) -> Set[ss.Term]:
 
         if t in visited:
             continue
-        else:
-            for tt in t:
-                to_visit.append(tt)
+        for tt in t:
+            to_visit.append(tt)
 
-            if t.is_symbolic_const():
-                free_vars.add(t)
+        if t.is_symbolic_const():
+            free_vars.add(t)
 
     return free_vars
 
@@ -49,7 +50,7 @@ def test_simple_itp(itp_name):
     try:
         itp = eval(f"ss.create_{itp_name}_interpolator()")
     except:
-        raise NotImplementedError("Haven't handled interpolator {}".format(itp_name))
+        raise NotImplementedError(f"Haven't handled interpolator {itp_name}")
 
     intsort = itp.make_sort(ss.sortkinds.INT)
     x = itp.make_symbol("x", intsort)

--- a/tests/python/test_lia.py
+++ b/tests/python/test_lia.py
@@ -15,8 +15,8 @@
 #
 
 import pytest
-import smt_switch as ss
 
+import smt_switch as ss
 from available_solvers import int_support_solvers
 
 

--- a/tests/python/test_push_pop.py
+++ b/tests/python/test_push_pop.py
@@ -15,6 +15,7 @@
 #
 
 import pytest
+
 import smt_switch as ss
 
 

--- a/tests/python/test_pysmt.py
+++ b/tests/python/test_pysmt.py
@@ -1,10 +1,10 @@
 import pytest
-import smt_switch as ss
 
 pysmt = pytest.importorskip("pysmt")
+from pysmt import logics as sl
 from pysmt import shortcuts as sc
 from pysmt import typing as st
-from pysmt import logics as sl
+
 import smt_switch.pysmt_frontend as fe
 
 

--- a/tests/python/test_reals.py
+++ b/tests/python/test_reals.py
@@ -15,12 +15,12 @@
 #
 
 import pytest
-import smt_switch as ss
-from smt_switch.sortkinds import REAL
-from smt_switch.primops import Equal, Ge, Lt, Minus, Mult, Plus
 
 import available_solvers
+import smt_switch as ss
 from available_solvers import int_support_solvers
+from smt_switch.primops import Ge, Lt, Minus, Mult, Plus
+from smt_switch.sortkinds import REAL
 
 termiter_and_int_keys = (
     available_solvers.termiter_support_solvers.keys()

--- a/tests/python/test_sorting_network.py
+++ b/tests/python/test_sorting_network.py
@@ -15,6 +15,7 @@
 #
 
 from itertools import product
+
 import pytest
 
 import smt_switch as ss

--- a/tests/python/test_unit.py
+++ b/tests/python/test_unit.py
@@ -15,8 +15,9 @@
 #
 
 import pytest
-import smt_switch as ss
+
 import available_solvers
+import smt_switch as ss
 
 
 @pytest.mark.parametrize(
@@ -35,7 +36,7 @@ def test_unit_op(create_solver):
     try:
         null_op_x = solver.make_term(null_op, x)
         assert False, "Should get a ValueError"
-    except ValueError as e:
+    except ValueError:
         pass
     except:
         assert False, "Should have gotten a ValueError"

--- a/tests/python/test_unit_vals.py
+++ b/tests/python/test_unit_vals.py
@@ -15,9 +15,9 @@
 #
 
 import pytest
-import smt_switch as ss
-from smt_switch.primops import Distinct, Equal, Select, Store
+
 import available_solvers
+import smt_switch as ss
 
 termiter_and_int_keys = (
     available_solvers.termiter_support_solvers.keys()

--- a/tests/python/test_unsat_core.py
+++ b/tests/python/test_unsat_core.py
@@ -15,6 +15,7 @@
 #
 
 import pytest
+
 import smt_switch as ss
 
 

--- a/tests/python/test_visitor.py
+++ b/tests/python/test_visitor.py
@@ -13,8 +13,9 @@
 #
 
 import pytest
+
 import smt_switch as ss
-from smt_switch.primops import Ite, Equal, BVOr, BVUlt
+from smt_switch.primops import BVOr, BVUlt, Ite
 
 
 @pytest.mark.parametrize(


### PR DESCRIPTION
Run ruff's safe fixes over the Python sources, add the [lint] section to .ruff.toml, and turn on the ruff-check pre-commit hook. 60 findings were fixed mechanically:

    ruff check --select ALL --fix .

The remaining 118 findings, spanning 36 rules, are suppressed by an explicitly marked temporary block in `ignore`, so that the tip of the branch is green and the hook can be enabled now rather than after every last fix. Each entry is to be deleted as its violations are resolved, either by fixing the code or by promoting the rule to a permanent ignore with a justification. The block doubles as the to-do list for that work.

`select` is set explicitly rather than relying on ruff's defaults. As of ruff 0.16 the default selection is a broad curated set of roughly 400 rules, not the narrow E4/E7/E9/F of earlier versions, so what counts as an error with a `select`-less config depends on the ruff version in use. Pinning the selection keeps this repository's notion of green independent of that.

ruff-check is listed before ruff-format, the order ruff recommends, since --fix can leave code that the formatter then rewrites.

The [lint.isort] section governs the import sorting applied here: smt_switch is built by this repository and available_solvers is a helper module in tests/python, but neither sits at the project root, so ruff would otherwise treat both as third-party.

The code fixes are import sorting (I001), removal of genuinely unused imports (F401), dropping `else` after a branch that always returns (RET505/507/508), str.format to f-strings (UP032), and unnecessary parentheses on a bare raise (RSE102).

Verified: `pre-commit run ruff-check --all-files` passes under the pinned v0.16.6, `ruff format --check` is clean, and `python -m compileall` succeeds.