### PR TITLE
style: Apply ruff's unsafe autofixes

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -37,40 +37,26 @@ ignore = [
   # ---------------------------------------------------------------------------
   "ARG001",  # unused-function-argument
   "ARG002",  # unused-method-argument
-  "B011",    # assert-false
   "B904",    # raise-without-from-inside-except
-  "C408",    # unnecessary-collection-call
-  "C416",    # unnecessary-comprehension
   "C901",    # complex-structure
   "E402",    # module-import-not-at-top-of-file
   "E722",    # bare-except
   "E741",    # ambiguous-variable-name
   "F401",    # unused-import
-  "F841",    # unused-variable
-  "FA100",   # future-rewritable-type-annotation
   "N802",    # invalid-function-name
   "N803",    # invalid-argument-name
   "N806",    # non-lowercase-variable-in-function
   "PERF203", # try-except-in-loop
   "PERF401", # manual-list-comprehension
   "PLC0415", # import-outside-top-level
-  "PLR1714", # repeated-equality-comparison
   "PLR2004", # magic-value-comparison
-  "PT006",   # pytest-parametrize-names-wrong-type
-  "PT015",   # pytest-assert-always-false
   "PTH123",  # builtin-open
-  "RET504",  # unnecessary-assign
-  "RSE102",  # unnecessary-paren-on-raise-exception
-  "RUF005",  # collection-literal-concatenation
   "S101",    # assert, in pysmt_frontend; tests and examples are exempt below
   "S110",    # try-except-pass
   "S307",    # suspicious-eval-usage
-  "SIM108",  # if-else-block-instead-of-if-exp
   "SIM117",  # multiple-with-statements
   "SLF001",  # private-member-access
-  "UP006",   # non-pep585-annotation
   "UP031",   # printf-string-formatting
-  "UP035",   # deprecated-import
 ]
 
 [lint.per-file-ignores]

--- a/python/smt_switch/pysmt_frontend/__init__.py
+++ b/python/smt_switch/pysmt_frontend/__init__.py
@@ -1,11 +1,15 @@
+from __future__ import annotations
+
 import typing as tp
 
 from pysmt import logics
 from pysmt.environment import get_env
 from pysmt.exceptions import NoLogicAvailableError, NoSolverAvailableError
-from pysmt.solvers.solver import Solver as SolverT
 
 from .pysmt_solver import SWITCH_SOLVERS
+
+if tp.TYPE_CHECKING:
+    from pysmt.solvers.solver import Solver as SolverT
 
 __ALL__ = ["SWITCH_SOLVERS", "Solver"]
 
@@ -32,7 +36,7 @@ except ImportError:
     pass
 
 
-def Solver(name: str, logic: tp.Optional[logics.Logic] = None) -> SolverT:
+def Solver(name: str, logic: logics.Logic | None = None) -> SolverT:
     """
     Convience function for building a pysmt solver object with a switch backend.
     Similar to `pysmt.shortcuts.Solver`.

--- a/python/smt_switch/pysmt_frontend/pysmt_solver.py
+++ b/python/smt_switch/pysmt_frontend/pysmt_solver.py
@@ -148,7 +148,7 @@ class _SwitchSolver(IncrementalTrackingSolver, SmtLibBasicSolver, SmtLibIgnoreMi
             return True
         if res.is_unsat():
             return False
-        raise SolverReturnedUnknownResultError()
+        raise SolverReturnedUnknownResultError
 
     @clear_pending_pop
     def _push(self, levels=1):
@@ -178,12 +178,12 @@ def _build_logics(logics_params):
 
 
 if "btor" in ss.solvers:
-    logics_params = dict(
-        quantifier_free=[True],
-        arrays=[True, False],
-        bit_vectors=[True, False],
-        uninterpreted=[True, False],
-    )
+    logics_params = {
+        "quantifier_free": [True],
+        "arrays": [True, False],
+        "bit_vectors": [True, False],
+        "uninterpreted": [True, False],
+    }
 
     class SwitchBtor(_SwitchSolver):
         LOGICS = _build_logics(logics_params)
@@ -199,13 +199,13 @@ if "btor" in ss.solvers:
 
 
 if "bitwuzla" in ss.solvers:
-    logics_params = dict(
-        quantifier_free=[True],
-        arrays=[True, False],
-        bit_vectors=[True],
-        uninterpreted=[True, False],
-        floating_point=[True, False],
-    )
+    logics_params = {
+        "quantifier_free": [True],
+        "arrays": [True, False],
+        "bit_vectors": [True],
+        "uninterpreted": [True, False],
+        "floating_point": [True, False],
+    }
 
     class SwitchBitwuzla(_SwitchSolver):
         LOGICS = _build_logics(logics_params)
@@ -215,17 +215,17 @@ if "bitwuzla" in ss.solvers:
 
 
 if "msat" in ss.solvers:
-    logics_params = dict(
-        quantifier_free=[True],
-        arrays=[True, False],
-        bit_vectors=[True, False],
-        uninterpreted=[True, False],
-        integer_arithmetic=[True, False],
-        integer_difference=[True, False],
-        real_arithmetic=[True, False],
-        real_difference=[True, False],
-        linear=[True],
-    )
+    logics_params = {
+        "quantifier_free": [True],
+        "arrays": [True, False],
+        "bit_vectors": [True, False],
+        "uninterpreted": [True, False],
+        "integer_arithmetic": [True, False],
+        "integer_difference": [True, False],
+        "real_arithmetic": [True, False],
+        "real_difference": [True, False],
+        "linear": [True],
+    }
 
     class SwitchMsat(_SwitchSolver):
         LOGICS = _build_logics(logics_params)
@@ -234,17 +234,17 @@ if "msat" in ss.solvers:
     SWITCH_SOLVERS["msat"] = SwitchMsat
 
 if "cvc5" in ss.solvers:
-    logics_params = dict(
-        quantifier_free=[True],
-        arrays=[True, False],
-        bit_vectors=[True, False],
-        uninterpreted=[True, False],
-        integer_arithmetic=[True, False],
-        integer_difference=[True, False],
-        real_arithmetic=[True, False],
-        real_difference=[True, False],
-        linear=[True],
-    )
+    logics_params = {
+        "quantifier_free": [True],
+        "arrays": [True, False],
+        "bit_vectors": [True, False],
+        "uninterpreted": [True, False],
+        "integer_arithmetic": [True, False],
+        "integer_difference": [True, False],
+        "real_arithmetic": [True, False],
+        "real_difference": [True, False],
+        "linear": [True],
+    }
 
     class SwitchCvc5(_SwitchSolver):
         LOGICS = _build_logics(logics_params)
@@ -275,8 +275,7 @@ def check_args(cmp, n):
 def make_walk_nary(n, primop):
     @check_args(operator.eq, n)
     def walk_op(self, formula, args, **kwargs):
-        res = self.make_term(primop, *args)
-        return res
+        return self.make_term(primop, *args)
 
     return walk_op
 
@@ -289,8 +288,7 @@ def make_walk_variadic(n, primop):
     @check_args(operator.ge, n)
     def walk_op(self, formula, args, **kwargs):
         builder = ft.partial(self.make_term, primop)
-        res = ft.reduce(builder, args)
-        return res
+        return ft.reduce(builder, args)
 
     return walk_op
 
@@ -390,8 +388,7 @@ class SwitchConverter(Converter, DagWalker):
     def walk_function(self, formula, args, **kwargs):
         name = formula.function_name()
         f = self.walk_symbol(name, name.args())
-        res = self.make_term(ss.primops.Apply, [f, *args])
-        return res
+        return self.make_term(ss.primops.Apply, [f, *args])
 
     # Int / real operatos
     walk_lt = make_walk_binary(ss.primops.Lt)
@@ -418,7 +415,7 @@ class SwitchConverter(Converter, DagWalker):
 
     @check_args(operator.eq, 1)
     def walk_bv_extract(self, formula, args, **kwargs):
-        res = self.make_term(
+        return self.make_term(
             ss.Op(
                 ss.primops.Extract,
                 formula.bv_extract_end(),
@@ -426,7 +423,6 @@ class SwitchConverter(Converter, DagWalker):
             ),
             *args,
         )
-        return res
 
     walk_bv_lshl = make_walk_binary(ss.primops.BVShl)
     walk_bv_lshr = make_walk_binary(ss.primops.BVLshr)
@@ -437,26 +433,23 @@ class SwitchConverter(Converter, DagWalker):
 
     @check_args(operator.eq, 1)
     def walk_bv_rol(self, formula, args, **kwargs):
-        res = self.make_term(
+        return self.make_term(
             ss.Op(ss.primops.Rotate_Left, formula.bv_rotation_step()), *args
         )
-        return res
 
     @check_args(operator.eq, 1)
     def walk_bv_ror(self, formula, args, **kwargs):
-        res = self.make_term(
+        return self.make_term(
             ss.Op(ss.primops.Rotate_Right, formula.bv_rotation_step()), *args
         )
-        return res
 
     walk_bv_sdiv = make_walk_binary(ss.primops.BVSdiv)
 
     @check_args(operator.eq, 1)
     def walk_bv_sext(self, formula, args, **kwargs):
-        res = self.make_term(
+        return self.make_term(
             ss.Op(ss.primops.Sign_Extend, formula.bv_extend_step()), *args
         )
-        return res
 
     walk_bv_sle = make_walk_binary(ss.primops.BVSle)
     walk_bv_slt = make_walk_binary(ss.primops.BVSlt)
@@ -473,10 +466,9 @@ class SwitchConverter(Converter, DagWalker):
 
     @check_args(operator.eq, 1)
     def walk_bv_zext(self, formula, args, **kwargs):
-        res = self.make_term(
+        return self.make_term(
             ss.Op(ss.primops.Zero_Extend, formula.bv_extend_step()), *args
         )
-        return res
 
     # array operators
     walk_array_select = make_walk_binary(ss.primops.Select)
@@ -640,12 +632,12 @@ class BackVisitor(ss.TermDagVisitor):
     def _convert_array_value(self, arr, sort):
         assignment = {}
         while arr.get_op():
-            arr, idx, elem = [x for x in arr]
+            arr, idx, elem = list(arr)
             idx = self._convert_value(idx, sort.index_type)
             val = self._convert_value(elem, sort.elem_type)
             assignment[idx] = val
 
-        children = [x for x in arr]
+        children = list(arr)
         if not children:
             default = self._make_0(sort.elem_type)
         else:
@@ -677,10 +669,7 @@ class BackVisitor(ss.TermDagVisitor):
     def _convert_negate(self, child):
         T = child.get_type()
         assert T.is_int_type() or T.is_real_type()
-        if T.is_int_type():
-            z = self.mgr.Int(0)
-        else:
-            z = self.mgr.Real(0)
+        z = self.mgr.Int(0) if T.is_int_type() else self.mgr.Real(0)
         return self.mgr.Minus(z, child)
 
     def _convert_extract(self, child, end, start):

--- a/tests/python/available_solvers.py
+++ b/tests/python/available_solvers.py
@@ -18,5 +18,5 @@ import smt_switch as ss
 
 termiter_support_solvers = {k: v for k, v in ss.solvers.items() if k != "yices2"}
 int_support_solvers = {
-    k: v for k, v in ss.solvers.items() if k != "btor" and k != "bitwuzla"
+    k: v for k, v in ss.solvers.items() if k not in {"btor", "bitwuzla"}
 }

--- a/tests/python/test_bv.py
+++ b/tests/python/test_bv.py
@@ -164,7 +164,7 @@ def test_complex_expr(create_solver):
 
     t8_sub = solver.substitute(t8, {x: x, y: y, a: a, b: b, c: c, d: d})
     # should be identical
-    assert t8 == t8_sub, "Expecting identical terms but got:\n\t%s\n\t%s" % (t8, t8_sub)
+    assert t8 == t8_sub, f"Expecting identical terms but got:\n\t{t8}\n\t{t8_sub}"
 
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())

--- a/tests/python/test_itp.py
+++ b/tests/python/test_itp.py
@@ -14,14 +14,12 @@
 #
 #
 
-from typing import Set
-
 import pytest
 
 import smt_switch as ss
 
 
-def get_free_vars(t: ss.Term) -> Set[ss.Term]:
+def get_free_vars(t: ss.Term) -> set[ss.Term]:
     to_visit = [t]
     visited = set()
 

--- a/tests/python/test_pysmt.py
+++ b/tests/python/test_pysmt.py
@@ -22,10 +22,7 @@ def test_basic(solver_str, T, logic, implicit):
     x = sc.FreshSymbol(T)
     problem = sc.And(x < 2, x > 0)
     x_val = None
-    if implicit:
-        args = ()
-    else:
-        args = (logic,)
+    args = () if implicit else (logic,)
 
     if logic not in fe.SWITCH_SOLVERS[solver_str].LOGICS:
         with pytest.raises(RuntimeError):

--- a/tests/python/test_reals.py
+++ b/tests/python/test_reals.py
@@ -26,7 +26,7 @@ termiter_and_int_keys = (
     available_solvers.termiter_support_solvers.keys()
     & available_solvers.int_support_solvers.keys()
 )
-termiter_and_int_solvers = [f for f in {ss.solvers[n] for n in termiter_and_int_keys}]
+termiter_and_int_solvers = list({ss.solvers[n] for n in termiter_and_int_keys})
 
 
 @pytest.mark.parametrize("create_solver", termiter_and_int_solvers)
@@ -41,7 +41,7 @@ def test_reals_simple(create_solver):
 
     c1 = solver.make_term(2, realsort)
     c2 = solver.make_term("457/32", realsort)
-    c3 = solver.make_term("1.352968", realsort)
+    solver.make_term("1.352968", realsort)
     c4 = solver.make_term("457/64", realsort)
     print(c4)
 

--- a/tests/python/test_sorting_network.py
+++ b/tests/python/test_sorting_network.py
@@ -22,7 +22,7 @@ import smt_switch as ss
 
 
 @pytest.mark.parametrize(
-    "create_solver,num_vars", product(ss.solvers.values(), [3, 6, 8])
+    ("create_solver", "num_vars"), product(ss.solvers.values(), [3, 6, 8])
 )
 def test_sorting_network(create_solver, num_vars):
     solver = create_solver(False)

--- a/tests/python/test_unit.py
+++ b/tests/python/test_unit.py
@@ -34,12 +34,12 @@ def test_unit_op(create_solver):
     assert not null_op, "null op should return false for bool"
     assert ext, "non-null op should return true for bool"
     try:
-        null_op_x = solver.make_term(null_op, x)
-        assert False, "Should get a ValueError"
+        solver.make_term(null_op, x)
+        raise AssertionError("Should get a ValueError")
     except ValueError:
         pass
     except:
-        assert False, "Should have gotten a ValueError"
+        raise AssertionError("Should have gotten a ValueError")
 
     ext_x = solver.make_term(ext, x)
     assert ext == ext_x.get_op(), "Extraction ops should match"
@@ -70,9 +70,6 @@ def test_sort(create_solver):
 )
 def test_unit_iter(create_solver):
     solver = create_solver(False)
-
-    null_op = ss.Op()
-    ext = ss.Op(ss.primops.Extract, 2, 0)
 
     bvsort = solver.make_sort(ss.sortkinds.BV, 4)
     x = solver.make_symbol("x", bvsort)
@@ -112,8 +109,8 @@ def test_bool(create_solver):
     assert not bool(yv)
 
     try:
-        val = bool(x)
-        assert False, "Shouldn't be able to call bool on non-value"
+        bool(x)
+        raise AssertionError("Shouldn't be able to call bool on non-value")
     except:
         pass
 
@@ -134,7 +131,7 @@ def test_check_sat_assuming(create_solver):
 
     try:
         solver.check_sat_assuming([xeq0])
-        assert False, (
+        raise AssertionError(
             "Expecting a thrown exception for check_sat_assuming with a formula"
         )
     except:
@@ -159,10 +156,10 @@ def test_multi_arg_fun(create_solver):
         vs2.append(solver.make_symbol("y%i" % i, bvsort))
 
     f = solver.make_symbol("f", funsort)
-    res = solver.make_term(ss.primops.Apply, [f] + vs)
+    res = solver.make_term(ss.primops.Apply, [f, *vs])
     assert res == solver.make_term(ss.primops.Apply, f, *vs)
 
     res2 = solver.make_term(ss.primops.Apply, f, *vs2)
     assert res != res2
-    args = [f] + vs2
+    args = [f, *vs2]
     assert res2 == solver.make_term(ss.primops.Apply, args)

--- a/tests/python/test_unit_vals.py
+++ b/tests/python/test_unit_vals.py
@@ -23,7 +23,7 @@ termiter_and_int_keys = (
     available_solvers.termiter_support_solvers.keys()
     & available_solvers.int_support_solvers.keys()
 )
-termiter_and_int_solvers = [f for f in {ss.solvers[n] for n in termiter_and_int_keys}]
+termiter_and_int_solvers = list({ss.solvers[n] for n in termiter_and_int_keys})
 
 
 @pytest.mark.parametrize("create_solver", termiter_and_int_solvers)

--- a/tests/python/test_unsat_core.py
+++ b/tests/python/test_unsat_core.py
@@ -28,7 +28,7 @@ def test_unsat_assumptions_simple(create_solver):
     a = solver.make_symbol("a", boolsort)
     b = solver.make_symbol("b", boolsort)
     notB = solver.make_term(ss.primops.Not, b)
-    r = solver.check_sat_assuming([a, b, notB])
+    solver.check_sat_assuming([a, b, notB])
     core = solver.get_unsat_assumptions()
     assert b in core, "expecting b to be in core"
     assert notB in core, "expecting (not b) to be in core"


### PR DESCRIPTION
Apply the fixes ruff classifies as unsafe, reviewed hunk by hunk, and drop the 14 rules they resolve from the temporary ignore block in .ruff.toml. The block goes from 36 entries to 22, and `ruff check` stays green.

    ruff check --select ALL --fix --unsafe-fixes .

Rules cleared: B011 and PT015 (`assert False` becomes `raise AssertionError`), C408, C416, F841, FA100, PLR1714, PT006, RET504, RSE102, RUF005, SIM108, UP006 and UP035.

test_unit_iter built an `ss.Op()` and an `ss.Op(Extract, 2, 0)` and used neither. Ruff's F841 fix turns those into bare expression statements, which read like dead code. Since test_unit_op already constructs both and asserts on them, the two lines are removed instead.