### PR TITLE
refactor: Finish the ruff lint rollout

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -14,9 +14,9 @@ select = ["ALL"]
 # Deliberate project decisions. Anything the code merely happened to violate
 # has been fixed instead of being listed here.
 ignore = [
-  "ANN",    # the codebase is unannotated; revisit if mypy is enabled
+  "ANN",    # the codebase is essentially unannotated; revisit if mypy is enabled
   "COM812", # trailing commas are the formatter's job
-  "CPY001", # copyright headers are a C++-side convention here
+  "CPY001", # the licence header is on most files, but is not required on all
   "D",      # no docstring convention has been adopted
   "E501",   # the formatter owns line width; long Cython templates cannot wrap
   "EM",     # message literals inline in `raise` are fine
@@ -29,34 +29,17 @@ ignore = [
   "TRY003", # see EM
 ]
 
+# Only rules that a whole file violates by design belong here. One-off cases
+# carry an inline `# noqa` with the reason instead.
 [lint.per-file-ignores]
-"tests/python/*" = [
-  "INP001",  # not a package; pytest puts its rootdir on sys.path
-  "N803",    # sorts and terms are named as in the formulas: T, A, B, notB
-  "N806",
-  "PLR2004", # the bit widths and expected counts are what is being asserted
-  "S101",    # bare assert is how a pytest test asserts
-]
-# The imports here deliberately follow pytest.importorskip("pysmt").
-"tests/python/test_pysmt.py" = ["E402"]
+# Bare assert is how a pytest test asserts.
+"tests/python/test_*.py" = ["S101"]
 
-# This module implements pysmt's solver, converter and walker interfaces, so it
-# does not get to choose its method signatures, and it cooperates closely with
-# its own converter and walker objects.
-"python/smt_switch/pysmt_frontend/*" = [
-  "ARG001",  # pysmt's walker callbacks are passed (formula, args, **kwargs)
-  "ARG002",
-  "C901",    # _parse_real is a small character-by-character SMT-LIB parser
-  "N802",    # Solver() mirrors the name of pysmt.shortcuts.Solver
-  "N806",    # pysmt type variables are spelled Kt, Vt, T
-  "PERF203", # the per-option try/except is what produces a per-option message
-  "PLR2004", # an indexed SMT operator takes either one index or two
-  "S101",    # internal invariant checks
-  "SLF001",  # reaches into its own converter's walker; see the HACK comment
-]
-
-# `smt_switch` is built by this repository, and `available_solvers` is a helper
-# module in tests/python. Neither lives at the project root, so ruff cannot
-# infer that they are first-party.
+# Ruff classifies an import as first-party by finding the module under `src`,
+# and nothing in python/smt_switch is importable from the source tree: the
+# modules are Cython .pyx files and __init__.py is generated from
+# __init__.py.in at build time. Adding python/ to `src` does not help, because
+# ruff would then see the directory and call `smt_switch` first-party while
+# leaving `smt_switch.primops` third-party, splitting the package in two.
 [lint.isort]
-known-first-party = ["available_solvers", "smt_switch"]
+known-first-party = ["smt_switch"]

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -35,36 +35,44 @@ ignore = [
   # either by fixing the code or by moving the rule above / into
   # per-file-ignores with a justification.
   # ---------------------------------------------------------------------------
-  "ARG001",  # unused-function-argument
-  "ARG002",  # unused-method-argument
   "B904",    # raise-without-from-inside-except
-  "C901",    # complex-structure
-  "E402",    # module-import-not-at-top-of-file
   "E722",    # bare-except
   "E741",    # ambiguous-variable-name
   "F401",    # unused-import
-  "N802",    # invalid-function-name
-  "N803",    # invalid-argument-name
-  "N806",    # non-lowercase-variable-in-function
-  "PERF203", # try-except-in-loop
   "PERF401", # manual-list-comprehension
   "PLC0415", # import-outside-top-level
-  "PLR2004", # magic-value-comparison
   "PTH123",  # builtin-open
-  "S101",    # assert, in pysmt_frontend; tests and examples are exempt below
   "S110",    # try-except-pass
   "S307",    # suspicious-eval-usage
   "SIM117",  # multiple-with-statements
-  "SLF001",  # private-member-access
   "UP031",   # printf-string-formatting
 ]
 
 [lint.per-file-ignores]
-# Neither directory is a package: pytest inserts its rootdir on sys.path, and
-# examples/ is meant to be read and run as standalone scripts. `assert` is also
-# how these pytest tests assert.
-"examples/*" = ["INP001", "S101"]
-"tests/python/*" = ["INP001", "S101"]
+"tests/python/*" = [
+  "INP001",  # not a package; pytest puts its rootdir on sys.path
+  "N803",    # sorts and terms are named as in the formulas: T, A, B, notB
+  "N806",
+  "PLR2004", # the bit widths and expected counts are what is being asserted
+  "S101",    # bare assert is how a pytest test asserts
+]
+# The imports here deliberately follow pytest.importorskip("pysmt").
+"tests/python/test_pysmt.py" = ["E402"]
+
+# This module implements pysmt's solver, converter and walker interfaces, so it
+# does not get to choose its method signatures, and it cooperates closely with
+# its own converter and walker objects.
+"python/smt_switch/pysmt_frontend/*" = [
+  "ARG001",  # pysmt's walker callbacks are passed (formula, args, **kwargs)
+  "ARG002",
+  "C901",    # _parse_real is a small character-by-character SMT-LIB parser
+  "N802",    # Solver() mirrors the name of pysmt.shortcuts.Solver
+  "N806",    # pysmt type variables are spelled Kt, Vt, T
+  "PERF203", # the per-option try/except is what produces a per-option message
+  "PLR2004", # an indexed SMT operator takes either one index or two
+  "S101",    # internal invariant checks
+  "SLF001",  # reaches into its own converter's walker; see the HACK comment
+]
 
 # `smt_switch` is built by this repository, and `available_solvers` is a helper
 # module in tests/python. Neither lives at the project root, so ruff cannot

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -11,10 +11,9 @@ force-exclude = true
 [lint]
 select = ["ALL"]
 
+# Deliberate project decisions. Anything the code merely happened to violate
+# has been fixed instead of being listed here.
 ignore = [
-  # ---------------------------------------------------------------------------
-  # Permanent: deliberate project decisions.
-  # ---------------------------------------------------------------------------
   "ANN",    # the codebase is unannotated; revisit if mypy is enabled
   "COM812", # trailing commas are the formatter's job
   "CPY001", # copyright headers are a C++-side convention here
@@ -28,24 +27,6 @@ ignore = [
   "TD002",  # ...without an author
   "TD003",  # ...or an issue link
   "TRY003", # see EM
-
-  # ---------------------------------------------------------------------------
-  # Temporary: rules that the existing code still violates, so that the tip of
-  # the branch stays green. Delete each entry once its violations are resolved,
-  # either by fixing the code or by moving the rule above / into
-  # per-file-ignores with a justification.
-  # ---------------------------------------------------------------------------
-  "B904",    # raise-without-from-inside-except
-  "E722",    # bare-except
-  "E741",    # ambiguous-variable-name
-  "F401",    # unused-import
-  "PERF401", # manual-list-comprehension
-  "PLC0415", # import-outside-top-level
-  "PTH123",  # builtin-open
-  "S110",    # try-except-pass
-  "S307",    # suspicious-eval-usage
-  "SIM117",  # multiple-with-statements
-  "UP031",   # printf-string-formatting
 ]
 
 [lint.per-file-ignores]

--- a/python/gen-smt-solver-declarations.py
+++ b/python/gen-smt-solver-declarations.py
@@ -6,6 +6,7 @@
 # is being compiled with
 
 import argparse
+from pathlib import Path
 
 CREATE_BTOR = """
 def create_btor_solver(logging):
@@ -163,8 +164,10 @@ if __name__ == "__main__":
     else:
         CREATE_IMPORTS = "# Built with no solvers..."
 
-    with open(dest_dir + "/smt_solvers.pxd", "w") as f:
+    dest = Path(dest_dir)
+
+    with (dest / "smt_solvers.pxd").open("w") as f:
         f.write(pxd)
 
-    with open(dest_dir + "/smt_solvers.pyx", "w") as f:
+    with (dest / "smt_solvers.pyx").open("w") as f:
         f.write(pyx % CREATE_IMPORTS)

--- a/python/smt_switch/pysmt_frontend/__init__.py
+++ b/python/smt_switch/pysmt_frontend/__init__.py
@@ -11,27 +11,27 @@ from .pysmt_solver import SWITCH_SOLVERS
 if tp.TYPE_CHECKING:
     from pysmt.solvers.solver import Solver as SolverT
 
-__ALL__ = ["SWITCH_SOLVERS", "Solver"]
+__all__ = ["SWITCH_SOLVERS", "Solver"]
 
 
 try:
     from .pysmt_solver import SwitchBtor
 
-    __ALL__.append("SwitchBtor")
+    __all__ += ["SwitchBtor"]
 except ImportError:
     pass
 
 try:
     from .pysmt_solver import SwitchCvc5
 
-    __ALL__.append("SwitchCvc5")
+    __all__ += ["SwitchCvc5"]
 except ImportError:
     pass
 
 try:
     from .pysmt_solver import SwitchMsat
 
-    __ALL__.append("SwitchMsat")
+    __all__ += ["SwitchMsat"]
 except ImportError:
     pass
 

--- a/python/smt_switch/pysmt_frontend/__init__.py
+++ b/python/smt_switch/pysmt_frontend/__init__.py
@@ -36,7 +36,10 @@ except ImportError:
     pass
 
 
-def Solver(name: str, logic: logics.Logic | None = None) -> SolverT:
+# Capitalised on purpose: this is a drop-in stand-in for pysmt.shortcuts.Solver,
+# which callers already spell with a capital S, so renaming it would break the
+# resemblance this function exists to provide.
+def Solver(name: str, logic: logics.Logic | None = None) -> SolverT:  # noqa: N802
     """
     Convience function for building a pysmt solver object with a switch backend.
     Similar to `pysmt.shortcuts.Solver`.

--- a/python/smt_switch/pysmt_frontend/pysmt_solver.py
+++ b/python/smt_switch/pysmt_frontend/pysmt_solver.py
@@ -35,48 +35,60 @@ class SwitchOptions(SolverOptions):
         if self.incremental:
             solver.solver.set_opt("incremental", "true")
 
-        for k, v in self.solver_options.items():
-            try:
+        try:
+            for k, v in self.solver_options.items():
                 solver.solver.set_opt(k, v)
-            except RuntimeError as err:
-                raise PysmtValueError(f"Error setting the option '{k}={v}'") from err
+        except RuntimeError as err:
+            raise PysmtValueError(f"Error setting the option '{k}={v}'") from err
+
+
+_REAL_OPERATORS = {"-": operator.neg, "/": fractions.Fraction}
+
+
+# Collapses [operator, operand, ...] to the value it denotes, or passes a lone
+# number through.
+def _reduce_tree(tree):
+    if not tree:
+        raise ValueError("Empty real literal")
+    if len(tree) == 1:
+        if not isinstance(tree[0], (int, fractions.Fraction)):
+            raise ValueError(f"Real literal {tree[0]!r} has no operands")
+        return tree[0]
+    return tree[0](*tree[1:])
+
+
+# Consumes one SMT-LIB real literal from a character iterator, e.g. "(/ 457 32)"
+# or "(- 5)", collecting operators and ints into a tree for _reduce_tree.
+def _parse_sexpr(it):
+    tree = []
+    num = []
+    for c in it:
+        if c.isdigit():
+            num.append(c)
+            continue
+        if num:
+            tree.append(int("".join(num)))
+            num = []
+
+        if c == ")":
+            break
+        if c == " ":
+            continue
+        if c == "(":
+            tree.append(_parse_sexpr(it))
+        elif c in _REAL_OPERATORS:
+            tree.append(_REAL_OPERATORS[c])
+        else:
+            raise ValueError(f"Unexpected character {c!r} in real literal")
+
+    if num:
+        tree.append(int("".join(num)))
+
+    return _reduce_tree(tree)
 
 
 def _parse_real(s):
-    def _parse(it):
-        tree = []
-        num = []
-        for c in it:
-            if c.isdigit():
-                num.append(c)
-                continue
-            if num:
-                tree.append(int("".join(num)))
-                num = []
-
-            if c == ")":
-                break
-            if c == " ":
-                continue
-            if c == "(":
-                tree.append(_parse(it))
-            elif c == "-":
-                tree.append(operator.neg)
-            elif c == "/":
-                tree.append(fractions.Fraction)
-            else:
-                raise ValueError
-
-        if num:
-            tree.append(int("".join(num)))
-
-        assert tree
-        if len(tree) == 1:
-            assert isinstance(tree[0], (int, fractions.Fraction))
-            return tree[0]
-        return tree[0](*tree[1:])
-
-    return _parse(iter(repr(s)))
+    return _parse_sexpr(iter(repr(s)))
 
 
 class _SwitchSolver(IncrementalTrackingSolver, SmtLibBasicSolver, SmtLibIgnoreMixin):
@@ -107,16 +119,25 @@ class _SwitchSolver(IncrementalTrackingSolver, SmtLibBasicSolver, SmtLibIgnoreMi
         # HACK because smt-switch sometimes loses sorts
         # we can't use back
         # should be: `r_val = self.converter.back(val)`
-        r_val = self.converter.back_walker._convert_value(val, sort)
-        assert r_val.get_type() == sort
+        # hence the private call below
+        r_val = self.converter.back_walker._convert_value(val, sort)  # noqa: SLF001
+        if r_val.get_type() != sort:
+            raise ConvertExpressionError(
+                f"Converting the value of {item} produced sort "
+                f"{r_val.get_type()} rather than {sort}"
+            )
         return r_val
 
     @clear_pending_pop
     def _reset_assertions(self):
         self.solver.reset_assertions()
 
+    # `named` goes unused: this backend does not support named assertions.
+    # pysmt's IncrementalTrackingSolver passes it by keyword, so the parameter
+    # cannot be renamed to `_named` to mark it unused the way the walker
+    # callbacks below are.
     @clear_pending_pop
-    def _add_assertion(self, formula, named=None):
+    def _add_assertion(self, formula, named=None):  # noqa: ARG002
         self._assert_is_boolean(formula)
         term = self.converter.convert(formula)
         self.solver.assert_formula(term)
@@ -274,7 +295,7 @@ def check_args(cmp, n):
 
 def make_walk_nary(n, primop):
     @check_args(operator.eq, n)
-    def walk_op(self, formula, args, **kwargs):
+    def walk_op(self, _formula, args, **_kwargs):
         return self.make_term(primop, *args)
 
     return walk_op
@@ -286,7 +307,7 @@ make_walk_binary = ft.partial(make_walk_nary, 2)
 
 def make_walk_variadic(n, primop):
     @check_args(operator.ge, n)
-    def walk_op(self, formula, args, **kwargs):
+    def walk_op(self, _formula, args, **_kwargs):
         builder = ft.partial(self.make_term, primop)
         return ft.reduce(builder, args)
 
@@ -344,7 +365,7 @@ class SwitchConverter(Converter, DagWalker):
 
     # Declarations
     @check_args(operator.eq, 0)
-    def walk_symbol(self, formula, args, **kwargs):
+    def walk_symbol(self, formula, _args, **_kwargs):
         try:
             return self.declared_syms[formula]
         except KeyError:
@@ -359,7 +380,7 @@ class SwitchConverter(Converter, DagWalker):
         return self.declared_vars.setdefault(formula, res)
 
     @check_args(operator.eq, 0)
-    def _walk_constant(self, formula, args, **kwargs):
+    def _walk_constant(self, formula, _args, **_kwargs):
         sort = self._convert_sort(formula.constant_type())
         if formula.constant_type().is_bool_type():
             res = self.make_term(bool(formula.constant_value()))
@@ -385,7 +406,7 @@ class SwitchConverter(Converter, DagWalker):
     # Polymorphic Operators
     walk_ite = make_walk_nary(3, ss.primops.Ite)
 
-    def walk_function(self, formula, args, **kwargs):
+    def walk_function(self, formula, args, **_kwargs):
         name = formula.function_name()
         f = self.walk_symbol(name, name.args())
         return self.make_term(ss.primops.Apply, [f, *args])
@@ -414,7 +435,7 @@ class SwitchConverter(Converter, DagWalker):
     walk_bv_concat = make_walk_binary(ss.primops.Concat)
 
     @check_args(operator.eq, 1)
-    def walk_bv_extract(self, formula, args, **kwargs):
+    def walk_bv_extract(self, formula, args, **_kwargs):
         return self.make_term(
             ss.Op(
                 ss.primops.Extract,
@@ -432,13 +453,13 @@ class SwitchConverter(Converter, DagWalker):
     walk_bv_or = make_walk_binary(ss.primops.BVOr)
 
     @check_args(operator.eq, 1)
-    def walk_bv_rol(self, formula, args, **kwargs):
+    def walk_bv_rol(self, formula, args, **_kwargs):
         return self.make_term(
             ss.Op(ss.primops.Rotate_Left, formula.bv_rotation_step()), *args
         )
 
     @check_args(operator.eq, 1)
-    def walk_bv_ror(self, formula, args, **kwargs):
+    def walk_bv_ror(self, formula, args, **_kwargs):
         return self.make_term(
             ss.Op(ss.primops.Rotate_Right, formula.bv_rotation_step()), *args
         )
@@ -446,7 +467,7 @@ class SwitchConverter(Converter, DagWalker):
     walk_bv_sdiv = make_walk_binary(ss.primops.BVSdiv)
 
     @check_args(operator.eq, 1)
-    def walk_bv_sext(self, formula, args, **kwargs):
+    def walk_bv_sext(self, formula, args, **_kwargs):
         return self.make_term(
             ss.Op(ss.primops.Sign_Extend, formula.bv_extend_step()), *args
         )
@@ -465,7 +486,7 @@ class SwitchConverter(Converter, DagWalker):
     walk_bv_xor = make_walk_binary(ss.primops.BVXor)
 
     @check_args(operator.eq, 1)
-    def walk_bv_zext(self, formula, args, **kwargs):
+    def walk_bv_zext(self, formula, args, **_kwargs):
         return self.make_term(
             ss.Op(ss.primops.Zero_Extend, formula.bv_extend_step()), *args
         )
@@ -473,18 +494,6 @@ class SwitchConverter(Converter, DagWalker):
     # array operators
     walk_array_select = make_walk_binary(ss.primops.Select)
     walk_array_store = make_walk_nary(3, ss.primops.Store)
-
-
-_INDEXED_OPERATORS = frozenset(
-    (
-        ss.primops.Extract,
-        ss.primops.Repeat,
-        ss.primops.Rotate_Left,
-        ss.primops.Rotate_Right,
-        ss.primops.Sign_Extend,
-        ss.primops.Zero_Extend,
-    )
-)
 
 
 class BackVisitor(ss.TermDagVisitor):
@@ -565,35 +574,35 @@ class BackVisitor(ss.TermDagVisitor):
         if op:
             indices = []
             if op.num_idx:
-                assert op.primop in _INDEXED_OPERATORS
                 indices = [op.idx0]
-                if op.num_idx == 2:
+                if op.num_idx > 1:
                     indices.append(op.idx1)
-                else:
-                    assert op.num_idx == 1
             primop = op.primop
             if primop not in self.convertion_table:
-                raise NotImplementedError
+                raise NotImplementedError(f"Unsupported operator: {primop}")
             return self.convertion_table[primop](*new_children, *indices)
+
+        sort = term.get_sort()
         if new_children:
-            assert term.get_sort().get_sort_kind() is ss.sortkinds.ARRAY
-            Kt = self._convert_sort(term.get_sort().get_indexsort())
-            return self.mgr.Array(Kt, *new_children, {})
+            if sort.get_sort_kind() is not ss.sortkinds.ARRAY:
+                raise ConvertExpressionError(
+                    f"Only an array term can have children without an operator: {term}"
+                )
+            index_type = self._convert_sort(sort.get_indexsort())
+            return self.mgr.Array(index_type, *new_children, {})
         if term.is_value():
             return self._convert_value(term)
-        if term.is_symbolic_const():
-            sort = self._convert_sort(term.get_sort())
-            return self.mgr.Symbol(str(term), sort)
-        assert term.get_sort().get_sort_kind() is ss.sortkinds.FUNCTION
-        sort = self._convert_sort(term.get_sort())
-        return self.mgr.Symbol(str(term), sort)
+        # A symbolic constant, or an uninterpreted function symbol.
+        if term.is_symbolic_const() or sort.get_sort_kind() is ss.sortkinds.FUNCTION:
+            return self.mgr.Symbol(str(term), self._convert_sort(sort))
+        raise ConvertExpressionError(f"Cannot convert term: {term}")
 
     def _convert_sort(self, sort):
         kind = sort.get_sort_kind()
         if kind is ss.sortkinds.ARRAY:
-            Kt = self._convert_sort(sort.get_indexsort())
-            Vt = self._convert_sort(sort.get_elemsort())
-            return pysmt_types.ArrayType(Kt, Vt)
+            index_type = self._convert_sort(sort.get_indexsort())
+            elem_type = self._convert_sort(sort.get_elemsort())
+            return pysmt_types.ArrayType(index_type, elem_type)
         if kind is ss.sortkinds.BOOL:
             return pysmt_types.BOOL
         if kind is ss.sortkinds.BV:
@@ -604,8 +613,9 @@ class BackVisitor(ss.TermDagVisitor):
             return pysmt_types.FunctionType(codomain, domain)
         if kind is ss.sortkinds.INT:
             return pysmt_types.INT
-        assert kind is ss.sortkinds.REAL
-        return pysmt_types.REAL
+        if kind is ss.sortkinds.REAL:
+            return pysmt_types.REAL
+        raise ConvertExpressionError(f"Unsupported sort: {sort}")
 
     def _convert_value(self, term, sort=None):
         # because smt-switch backends cannot be trusted to maintain
@@ -640,9 +650,12 @@ class BackVisitor(ss.TermDagVisitor):
         children = list(arr)
         if not children:
             default = self._make_0(sort.elem_type)
-        else:
-            assert len(children) == 1
+        elif len(children) == 1:
             default = self._convert_value(children[0], sort.elem_type)
+        else:
+            raise ConvertExpressionError(
+                f"An array default takes one child, got {len(children)}"
+            )
         return sort.index_type, default, assignment
 
     def _make_0(self, sort):
@@ -659,7 +672,11 @@ class BackVisitor(ss.TermDagVisitor):
         raise TypeError(f"Unsupported sort: {sort}")
 
     def _convert_abs(self, child):
-        assert child.get_type().is_int_type()
+        child_type = child.get_type()
+        if not child_type.is_int_type():
+            raise ConvertExpressionError(
+                f"Cannot take the absolute value of a term of type {child_type}"
+            )
         z = self.mgr.Int(0)
         return self.mgr.Ite(self.mgr.GE(child, z), child, self.mgr.Minus(z, child))
 
@@ -667,9 +684,10 @@ class BackVisitor(ss.TermDagVisitor):
         return self.mgr.Function(name, args)
 
     def _convert_negate(self, child):
-        T = child.get_type()
-        assert T.is_int_type() or T.is_real_type()
-        z = self.mgr.Int(0) if T.is_int_type() else self.mgr.Real(0)
+        child_type = child.get_type()
+        if not (child_type.is_int_type() or child_type.is_real_type()):
+            raise ConvertExpressionError(f"Cannot negate a term of type {child_type}")
+        z = self.mgr.Int(0) if child_type.is_int_type() else self.mgr.Real(0)
         return self.mgr.Minus(z, child)
 
     def _convert_extract(self, child, end, start):

--- a/python/smt_switch/pysmt_frontend/pysmt_solver.py
+++ b/python/smt_switch/pysmt_frontend/pysmt_solver.py
@@ -38,8 +38,8 @@ class SwitchOptions(SolverOptions):
         for k, v in self.solver_options.items():
             try:
                 solver.solver.set_opt(k, v)
-            except:
-                raise PysmtValueError(f"Error setting the option '{k}={v}'")
+            except RuntimeError as err:
+                raise PysmtValueError(f"Error setting the option '{k}={v}'") from err
 
 
 def _parse_real(s):

--- a/tests/python/__init__.py
+++ b/tests/python/__init__.py
@@ -1,0 +1,1 @@
+"""Marks this directory as a package so the test modules can import relatively."""

--- a/tests/python/test_arrays.py
+++ b/tests/python/test_arrays.py
@@ -17,8 +17,9 @@
 import pytest
 
 import smt_switch as ss
-from available_solvers import int_support_solvers
 from smt_switch.primops import Distinct, Equal, Select, Store
+
+from .available_solvers import int_support_solvers
 
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())

--- a/tests/python/test_bv.py
+++ b/tests/python/test_bv.py
@@ -18,6 +18,7 @@ import pytest
 
 import available_solvers
 import smt_switch as ss
+from smt_switch import Op
 
 
 # @pytest.mark.parametrize("create_solver", ss.solvers.values())
@@ -123,8 +124,6 @@ def test_hackers_delight(create_solver):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_complex_expr(create_solver):
-    from smt_switch import Op
-
     solver = create_solver(False)
     bv128 = solver.make_sort(ss.sortkinds.BV, 128)
     bv32 = solver.make_sort(ss.sortkinds.BV, 32)

--- a/tests/python/test_bv.py
+++ b/tests/python/test_bv.py
@@ -16,9 +16,10 @@
 
 import pytest
 
-import available_solvers
 import smt_switch as ss
 from smt_switch import Op
+
+from . import available_solvers
 
 
 # @pytest.mark.parametrize("create_solver", ss.solvers.values())
@@ -33,16 +34,17 @@ def test_bvadd(create_solver):
     bvsort8 = solver.make_sort(ss.sortkinds.BV, 8)
     x = solver.make_symbol("x", bvsort8)
     y = solver.make_symbol("y", bvsort8)
+    expected_sum = 6
     xpy = solver.make_term(ss.primops.BVAdd, x, y)
     solver.assert_formula(
-        solver.make_term(ss.primops.Equal, xpy, solver.make_term(6, bvsort8))
+        solver.make_term(ss.primops.Equal, xpy, solver.make_term(expected_sum, bvsort8))
     )
 
     solver.check_sat()
 
     xv = solver.get_value(x)
     yv = solver.get_value(y)
-    assert (int(xv) + int(yv)) % (2**8) == 6
+    assert (int(xv) + int(yv)) % (2**8) == expected_sum
 
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())

--- a/tests/python/test_enums.py
+++ b/tests/python/test_enums.py
@@ -16,7 +16,8 @@
 import pytest
 
 import smt_switch as ss
-from available_solvers import int_support_solvers
+
+from .available_solvers import int_support_solvers
 
 
 @pytest.mark.parametrize(

--- a/tests/python/test_itp.py
+++ b/tests/python/test_itp.py
@@ -46,9 +46,10 @@ def get_free_vars(t: ss.Term) -> set[ss.Term]:
 )
 def test_simple_itp(itp_name):
     try:
-        itp = eval(f"ss.create_{itp_name}_interpolator()")
-    except:
-        raise NotImplementedError(f"Haven't handled interpolator {itp_name}")
+        create_interpolator = getattr(ss, f"create_{itp_name}_interpolator")
+    except AttributeError as err:
+        raise NotImplementedError(f"Haven't handled interpolator {itp_name}") from err
+    itp = create_interpolator()
 
     intsort = itp.make_sort(ss.sortkinds.INT)
     x = itp.make_symbol("x", intsort)
@@ -68,9 +69,9 @@ def test_simple_itp(itp_name):
     # z < x
     B = itp.make_term(ss.primops.And, B, itp.make_term(ss.primops.Lt, z, x))
 
-    I = itp.get_interpolant(A, B)
-    assert I is not None
+    interpolant = itp.get_interpolant(A, B)
+    assert interpolant is not None
 
-    free_vars = get_free_vars(I)
+    free_vars = get_free_vars(interpolant)
     assert y not in free_vars
     assert z not in free_vars

--- a/tests/python/test_itp.py
+++ b/tests/python/test_itp.py
@@ -58,18 +58,18 @@ def test_simple_itp(itp_name):
     w = itp.make_symbol("w", intsort)
 
     # x < y
-    A = itp.make_term(ss.primops.Lt, x, y)
+    a = itp.make_term(ss.primops.Lt, x, y)
 
     # y < w
-    A = itp.make_term(ss.primops.And, A, itp.make_term(ss.primops.Lt, y, w))
+    a = itp.make_term(ss.primops.And, a, itp.make_term(ss.primops.Lt, y, w))
 
     # z > w
-    B = itp.make_term(ss.primops.Gt, z, w)
+    b = itp.make_term(ss.primops.Gt, z, w)
 
     # z < x
-    B = itp.make_term(ss.primops.And, B, itp.make_term(ss.primops.Lt, z, x))
+    b = itp.make_term(ss.primops.And, b, itp.make_term(ss.primops.Lt, z, x))
 
-    interpolant = itp.get_interpolant(A, B)
+    interpolant = itp.get_interpolant(a, b)
     assert interpolant is not None
 
     free_vars = get_free_vars(interpolant)

--- a/tests/python/test_lia.py
+++ b/tests/python/test_lia.py
@@ -17,7 +17,8 @@
 import pytest
 
 import smt_switch as ss
-from available_solvers import int_support_solvers
+
+from .available_solvers import int_support_solvers
 
 
 @pytest.mark.parametrize(
@@ -61,5 +62,7 @@ def test_simple(create_solver):
     yv = int(solver.get_value(y))
     zv = int(solver.get_value(z))
 
-    assert 2 * xv + 3 * yv < 5
-    assert 5 * yv - 3 * zv >= 2
+    # Transcriptions of f1 and f2 above; naming the coefficients and bounds
+    # would hide the correspondence with the terms built from them.
+    assert 2 * xv + 3 * yv < 5  # noqa: PLR2004
+    assert 5 * yv - 3 * zv >= 2  # noqa: PLR2004

--- a/tests/python/test_push_pop.py
+++ b/tests/python/test_push_pop.py
@@ -28,10 +28,12 @@ def test_push_pop_levels(create_solver):
     assert solver.get_context_level() == 1
     solver.pop()
     assert solver.get_context_level() == 0
-    solver.push(5)
-    assert solver.get_context_level() == 5
-    solver.pop(2)
-    assert solver.get_context_level() == 3
+    pushed = 5
+    popped = 2
+    solver.push(pushed)
+    assert solver.get_context_level() == pushed
+    solver.pop(popped)
+    assert solver.get_context_level() == pushed - popped
     solver.pop_all()
     assert solver.get_context_level() == 0
 

--- a/tests/python/test_pysmt.py
+++ b/tests/python/test_pysmt.py
@@ -25,9 +25,8 @@ def test_basic(solver_str, T, logic, implicit):
     args = () if implicit else (logic,)
 
     if logic not in fe.SWITCH_SOLVERS[solver_str].LOGICS:
-        with pytest.raises(RuntimeError):
-            with fe.Solver(solver_str, *args) as solver:
-                solver.add_assertion(problem)
+        with pytest.raises(RuntimeError), fe.Solver(solver_str, *args) as solver:
+            solver.add_assertion(problem)
     else:
         with fe.Solver(solver_str, *args) as solver:
             solver.add_assertion(problem)

--- a/tests/python/test_pysmt.py
+++ b/tests/python/test_pysmt.py
@@ -1,16 +1,17 @@
 import pytest
 
-pysmt = pytest.importorskip("pysmt")
-from pysmt import logics as sl
-from pysmt import shortcuts as sc
-from pysmt import typing as st
-
-import smt_switch.pysmt_frontend as fe
+# pysmt is an optional dependency, so each module is bound through
+# importorskip. Plain imports would have to sit below the skip, out of import
+# order.
+sl = pytest.importorskip("pysmt.logics")
+sc = pytest.importorskip("pysmt.shortcuts")
+st = pytest.importorskip("pysmt.typing")
+fe = pytest.importorskip("smt_switch.pysmt_frontend")
 
 
 @pytest.mark.parametrize("solver_str", fe.SWITCH_SOLVERS.keys())
 @pytest.mark.parametrize(
-    ("T", "logic"),
+    ("sort", "logic"),
     [
         (st.BV8, sl.QF_BV),
         (st.INT, sl.QF_LIA),
@@ -18,9 +19,11 @@ import smt_switch.pysmt_frontend as fe
     ],
 )
 @pytest.mark.parametrize("implicit", [True, False])
-def test_basic(solver_str, T, logic, implicit):
-    x = sc.FreshSymbol(T)
-    problem = sc.And(x < 2, x > 0)
+def test_basic(solver_str, sort, logic, implicit):
+    x = sc.FreshSymbol(sort)
+    # `<` builds a pysmt formula here rather than comparing at runtime, so the
+    # bound is part of the problem statement, not a magic value.
+    problem = sc.And(x < 2, x > 0)  # noqa: PLR2004
     x_val = None
     args = () if implicit else (logic,)
 
@@ -31,7 +34,7 @@ def test_basic(solver_str, T, logic, implicit):
         with fe.Solver(solver_str, *args) as solver:
             solver.add_assertion(problem)
             assert solver.solve()
-            if T is not st.REAL:
+            if sort is not st.REAL:
                 x_val = solver.get_py_value(x)
                 assert x_val == 1
             else:

--- a/tests/python/test_reals.py
+++ b/tests/python/test_reals.py
@@ -16,11 +16,12 @@
 
 import pytest
 
-import available_solvers
 import smt_switch as ss
-from available_solvers import int_support_solvers
 from smt_switch.primops import Ge, Lt, Minus, Mult, Plus
 from smt_switch.sortkinds import REAL
+
+from . import available_solvers
+from .available_solvers import int_support_solvers
 
 termiter_and_int_keys = (
     available_solvers.termiter_support_solvers.keys()

--- a/tests/python/test_sorting_network.py
+++ b/tests/python/test_sorting_network.py
@@ -30,9 +30,7 @@ def test_sorting_network(create_solver, num_vars):
     solver.set_opt("incremental", "true")
 
     boolsort = solver.make_sort(ss.sortkinds.BOOL)
-    boollist = []
-    for i in range(num_vars):
-        boollist.append(solver.make_symbol("b" + str(i), boolsort))
+    boollist = [solver.make_symbol("b" + str(i), boolsort) for i in range(num_vars)]
 
     sn = ss.SortingNetwork(solver)
     sortedlist = sn.sorting_network(boollist)

--- a/tests/python/test_sorting_network.py
+++ b/tests/python/test_sorting_network.py
@@ -22,7 +22,7 @@ import smt_switch as ss
 
 
 @pytest.mark.parametrize(
-    ("create_solver", "num_vars"), product(ss.solvers.values(), [3, 6, 8])
+    ("create_solver", "num_vars"), list(product(ss.solvers.values(), [3, 6, 8]))
 )
 def test_sorting_network(create_solver, num_vars):
     solver = create_solver(False)

--- a/tests/python/test_unit.py
+++ b/tests/python/test_unit.py
@@ -16,8 +16,9 @@
 
 import pytest
 
-import available_solvers
 import smt_switch as ss
+
+from . import available_solvers
 
 
 @pytest.mark.parametrize(
@@ -74,13 +75,7 @@ def test_unit_iter(create_solver):
 
     fx = solver.make_term(ss.primops.Apply, f, x)
 
-    cnt = 0
-    for t in fx:
-        assert cnt != 0 or t == f, "First child should be f"
-        assert cnt != 1 or t == x, "Second child should be x"
-        cnt += 1
-
-    assert cnt == 2, "Expecting two children"
+    assert list(fx) == [f, x], "Children should be f then x"
 
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())

--- a/tests/python/test_unit.py
+++ b/tests/python/test_unit.py
@@ -33,13 +33,8 @@ def test_unit_op(create_solver):
 
     assert not null_op, "null op should return false for bool"
     assert ext, "non-null op should return true for bool"
-    try:
+    with pytest.raises(ValueError, match="Got a null Op in make_term"):
         solver.make_term(null_op, x)
-        raise AssertionError("Should get a ValueError")
-    except ValueError:
-        pass
-    except:
-        raise AssertionError("Should have gotten a ValueError")
 
     ext_x = solver.make_term(ext, x)
     assert ext == ext_x.get_op(), "Extraction ops should match"
@@ -108,11 +103,8 @@ def test_bool(create_solver):
     print(yv)
     assert not bool(yv)
 
-    try:
+    with pytest.raises(ValueError, match="Cannot call bool on"):
         bool(x)
-        raise AssertionError("Shouldn't be able to call bool on non-value")
-    except:
-        pass
 
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
@@ -129,13 +121,10 @@ def test_check_sat_assuming(create_solver):
     solver.assert_formula(solver.make_term(ss.primops.Not, xeq0))
     solver.assert_formula(solver.make_term(ss.primops.Implies, b, xeq0))
 
-    try:
+    # Assumptions have to be literals. The backend rejects a formula by
+    # throwing IncorrectUsageException, which Cython surfaces as RuntimeError.
+    with pytest.raises(RuntimeError):
         solver.check_sat_assuming([xeq0])
-        raise AssertionError(
-            "Expecting a thrown exception for check_sat_assuming with a formula"
-        )
-    except:
-        pass
 
     r = solver.check_sat_assuming([b])
     assert r.is_unsat()
@@ -147,13 +136,8 @@ def test_multi_arg_fun(create_solver):
     bvsort = solver.make_sort(ss.sortkinds.BV, 8)
     funsort = solver.make_sort(ss.sortkinds.FUNCTION, [bvsort] * 8)
 
-    vs = []
-    for i in range(7):
-        vs.append(solver.make_symbol("x%i" % i, bvsort))
-
-    vs2 = []
-    for i in range(7):
-        vs2.append(solver.make_symbol("y%i" % i, bvsort))
+    vs = [solver.make_symbol(f"x{i}", bvsort) for i in range(7)]
+    vs2 = [solver.make_symbol(f"y{i}", bvsort) for i in range(7)]
 
     f = solver.make_symbol("f", funsort)
     res = solver.make_term(ss.primops.Apply, [f, *vs])

--- a/tests/python/test_unit.py
+++ b/tests/python/test_unit.py
@@ -116,11 +116,10 @@ def test_check_sat_assuming(create_solver):
     solver.assert_formula(solver.make_term(ss.primops.Not, xeq0))
     solver.assert_formula(solver.make_term(ss.primops.Implies, b, xeq0))
 
-    # Assumptions have to be literals. The backend rejects a formula by
-    # throwing IncorrectUsageException, which Cython surfaces as RuntimeError.
-    with pytest.raises(RuntimeError):
-        solver.check_sat_assuming([xeq0])
-
+    # Passing the formula xeq0 rather than a literal would violate
+    # check_sat_assuming's documented precondition, but only mathsat enforces
+    # it, so there is nothing portable to assert here. The backend-specific
+    # behaviour is covered by tests/unit/unit-solving-interface.cpp.
     r = solver.check_sat_assuming([b])
     assert r.is_unsat()
 

--- a/tests/python/test_unit_vals.py
+++ b/tests/python/test_unit_vals.py
@@ -16,8 +16,9 @@
 
 import pytest
 
-import available_solvers
 import smt_switch as ss
+
+from . import available_solvers
 
 termiter_and_int_keys = (
     available_solvers.termiter_support_solvers.keys()

--- a/tests/python/test_unsat_core.py
+++ b/tests/python/test_unsat_core.py
@@ -27,8 +27,8 @@ def test_unsat_assumptions_simple(create_solver):
     boolsort = solver.make_sort(ss.sortkinds.BOOL)
     a = solver.make_symbol("a", boolsort)
     b = solver.make_symbol("b", boolsort)
-    notB = solver.make_term(ss.primops.Not, b)
-    solver.check_sat_assuming([a, b, notB])
+    not_b = solver.make_term(ss.primops.Not, b)
+    solver.check_sat_assuming([a, b, not_b])
     core = solver.get_unsat_assumptions()
     assert b in core, "expecting b to be in core"
-    assert notB in core, "expecting (not b) to be in core"
+    assert not_b in core, "expecting (not b) to be in core"


### PR DESCRIPTION
Clear the last 22 rules from .ruff.toml's temporary ignore block by fixing the code behind each, leaving a config that suppresses only deliberate choices: thirteen global ignores, one per-file entry (S101, because bare assert is how a pytest test asserts), and six inline `# noqa`s with their reason at the site.

Little of it was stylistic. tests/python becomes a real package with relative imports, as pytest recommends under the default prepend import mode, instead of relying on its own directory landing on sys.path. The SMT-LIB real literal parser splits into a tokenising and a reducing half, which puts it under the complexity limit with no suppression. And every assert in pysmt_solver.py is now a ConvertExpressionError or deleted: an assert vanishes under `python -O`, and these were load-bearing — one silently discarded an array child, another would have returned REAL for any sort kind added beyond the six the Cython layer exposes.

Three blocks in test_unit.py turned out to be dead, being `assert False` inside a try whose bare except swallowed the AssertionError. Rewriting them as pytest.raises showed that check_sat_assuming's literal precondition is enforced only by mathsat, so that assertion is dropped in favour of the C++ test that covers it.

Also wraps an itertools.product handed to parametrize in a list, which pytest 9 deprecates.