### PR TITLE
refactor: Cut the ruff ignore list from 13 rules to 6

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -18,20 +18,18 @@ ignore = [
   "COM812", # trailing commas are the formatter's job
   "CPY001", # the licence header is on most files, but is not required on all
   "D",      # no docstring convention has been adopted
-  "E501",   # the formatter owns line width; long Cython templates cannot wrap
   "EM",     # message literals inline in `raise` are fine
-  "FBT",    # the generated solver factories take a positional `logging` bool
-  "FIX",    # TODO and HACK comments are allowed
-  "ISC001", # conflicts with the formatter
-  "T20",    # print() is intentional in examples and a few tests
-  "TD002",  # ...without an author
-  "TD003",  # ...or an issue link
   "TRY003", # see EM
 ]
 
 # Only rules that a whole file violates by design belong here. One-off cases
 # carry an inline `# noqa` with the reason instead.
 [lint.per-file-ignores]
+# An example exists to show its output.
+"examples/*" = ["T20"]
+# The Cython `cdef extern` declarations this generator emits are single long
+# lines that neither the formatter nor a human can usefully wrap.
+"python/gen-smt-solver-declarations.py" = ["E501"]
 # Bare assert is how a pytest test asserts.
 "tests/python/test_*.py" = ["S101"]
 

--- a/examples/python_qf_ufbv.py
+++ b/examples/python_qf_ufbv.py
@@ -3,7 +3,7 @@ import smt_switch as ss
 from smt_switch.primops import Apply, BVAnd, BVUge, Distinct, Equal, Extract
 
 if __name__ == "__main__":
-    s = ss.create_btor_solver(True)
+    s = ss.create_btor_solver(logging=True)
     s.set_logic("QF_UFBV")
     s.set_opt("incremental", "true")
     s.set_opt("produce-models", "true")

--- a/python/smt_switch/pysmt_frontend/pysmt_solver.py
+++ b/python/smt_switch/pysmt_frontend/pysmt_solver.py
@@ -116,7 +116,7 @@ class _SwitchSolver(IncrementalTrackingSolver, SmtLibBasicSolver, SmtLibIgnoreMi
         sort = item.get_type()
         c_item = self.converter.convert(item)
         val = self.solver.get_value(c_item)
-        # HACK because smt-switch sometimes loses sorts
+        # HACK because smt-switch sometimes loses sorts  # noqa: FIX004
         # we can't use back
         # should be: `r_val = self.converter.back(val)`
         # hence the private call below
@@ -208,7 +208,7 @@ if "btor" in ss.solvers:
 
     class SwitchBtor(_SwitchSolver):
         LOGICS = _build_logics(logics_params)
-        _create_solver = staticmethod(ft.partial(ss.create_btor_solver, False))
+        _create_solver = staticmethod(ft.partial(ss.create_btor_solver, logging=False))
 
         @clear_pending_pop
         def _reset_assertions(self):
@@ -230,7 +230,9 @@ if "bitwuzla" in ss.solvers:
 
     class SwitchBitwuzla(_SwitchSolver):
         LOGICS = _build_logics(logics_params)
-        _create_solver = staticmethod(ft.partial(ss.create_bitwuzla_solver, False))
+        _create_solver = staticmethod(
+            ft.partial(ss.create_bitwuzla_solver, logging=False)
+        )
 
     SWITCH_SOLVERS["bitwuzla"] = SwitchBitwuzla
 
@@ -250,7 +252,7 @@ if "msat" in ss.solvers:
 
     class SwitchMsat(_SwitchSolver):
         LOGICS = _build_logics(logics_params)
-        _create_solver = staticmethod(ft.partial(ss.create_msat_solver, False))
+        _create_solver = staticmethod(ft.partial(ss.create_msat_solver, logging=False))
 
     SWITCH_SOLVERS["msat"] = SwitchMsat
 
@@ -269,7 +271,7 @@ if "cvc5" in ss.solvers:
 
     class SwitchCvc5(_SwitchSolver):
         LOGICS = _build_logics(logics_params)
-        _create_solver = staticmethod(ft.partial(ss.create_cvc5_solver, False))
+        _create_solver = staticmethod(ft.partial(ss.create_cvc5_solver, logging=False))
 
         def _exit(self):
             super()._exit()

--- a/tests/python/test_arrays.py
+++ b/tests/python/test_arrays.py
@@ -24,7 +24,7 @@ from .available_solvers import int_support_solvers
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_array_read_over_write(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_logic("QF_ABV")
 
     bvsort8 = solver.make_sort(ss.sortkinds.BV, 8)
@@ -48,7 +48,7 @@ def test_array_read_over_write(create_solver):
 
 @pytest.mark.parametrize("create_solver", [f for n, f in int_support_solvers.items()])
 def test_array_lia_extensionality(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_logic("QF_ALIA")
 
     intsort = solver.make_sort(ss.sortkinds.INT)

--- a/tests/python/test_bv.py
+++ b/tests/python/test_bv.py
@@ -27,7 +27,7 @@ from . import available_solvers
     "create_solver", available_solvers.termiter_support_solvers.values()
 )
 def test_bvadd(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_opt("produce-models", "true")
     solver.set_logic("QF_BV")
 
@@ -64,7 +64,7 @@ def test_hackers_delight(create_solver):
     #
     # We want to check that these are correct
 
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_logic("QF_BV")
     solver.set_opt("produce-models", "true")
     solver.set_opt("incremental", "true")
@@ -92,7 +92,6 @@ def test_hackers_delight(create_solver):
         ss.primops.Equal, xn, solver.make_term(ss.primops.Ite, x_eq_a, b, a)
     )
 
-    print("Asserting", ite_assignment)
     solver.assert_formula(ite_assignment)
 
     # Push a context -- all assertions and check-sat calls are in a different context
@@ -126,7 +125,7 @@ def test_hackers_delight(create_solver):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_complex_expr(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     bv128 = solver.make_sort(ss.sortkinds.BV, 128)
     bv32 = solver.make_sort(ss.sortkinds.BV, 32)
 
@@ -170,7 +169,7 @@ def test_complex_expr(create_solver):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_bv_ops(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     bvsort32 = solver.make_sort(ss.sortkinds.BV, 32)
 
     one = solver.make_term(1, bvsort32)

--- a/tests/python/test_enums.py
+++ b/tests/python/test_enums.py
@@ -24,7 +24,7 @@ from .available_solvers import int_support_solvers
     "create_solver", [f for name, f in int_support_solvers.items()]
 )
 def test_sortkind(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     bvsort = solver.make_sort(ss.sortkinds.BV, 8)
     x = solver.make_symbol("x", bvsort)
     sk = x.get_sort().get_sort_kind()
@@ -37,7 +37,7 @@ def test_sortkind(create_solver):
     "create_solver", [f for name, f in int_support_solvers.items()]
 )
 def test_primop(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     bvsort = solver.make_sort(ss.sortkinds.BV, 8)
     x = solver.make_symbol("x", bvsort)
     y = solver.make_symbol("y", bvsort)

--- a/tests/python/test_lia.py
+++ b/tests/python/test_lia.py
@@ -25,7 +25,7 @@ from .available_solvers import int_support_solvers
     "create_solver", [f for name, f in int_support_solvers.items()]
 )
 def test_simple(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_opt("produce-models", "true")
     solver.set_logic("QF_LIA")
 

--- a/tests/python/test_push_pop.py
+++ b/tests/python/test_push_pop.py
@@ -21,7 +21,7 @@ import smt_switch as ss
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_push_pop_levels(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_opt("incremental", "true")
     assert solver.get_context_level() == 0
     solver.push()
@@ -40,7 +40,7 @@ def test_push_pop_levels(create_solver):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_push_pop_solve(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_opt("incremental", "true")
     bool_sort = solver.make_sort(ss.sortkinds.BOOL)
     x = solver.make_symbol("x", bool_sort)

--- a/tests/python/test_reals.py
+++ b/tests/python/test_reals.py
@@ -32,7 +32,7 @@ termiter_and_int_solvers = list({ss.solvers[n] for n in termiter_and_int_keys})
 
 @pytest.mark.parametrize("create_solver", termiter_and_int_solvers)
 def test_reals_simple(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_logic("QF_LRA")
 
     realsort = solver.make_sort(REAL)
@@ -44,7 +44,6 @@ def test_reals_simple(create_solver):
     c2 = solver.make_term("457/32", realsort)
     solver.make_term("1.352968", realsort)
     c4 = solver.make_term("457/64", realsort)
-    print(c4)
 
     solver.assert_formula(
         solver.make_term(
@@ -68,7 +67,7 @@ def test_reals_simple(create_solver):
 
 @pytest.mark.parametrize("create_solver", [f for n, f in int_support_solvers.items()])
 def test_reals_subs_check(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_logic("QF_LRA")
     solver.set_opt("produce-models", "true")
     solver.set_opt("incremental", "true")

--- a/tests/python/test_sorting_network.py
+++ b/tests/python/test_sorting_network.py
@@ -25,7 +25,7 @@ import smt_switch as ss
     ("create_solver", "num_vars"), list(product(ss.solvers.values(), [3, 6, 8]))
 )
 def test_sorting_network(create_solver, num_vars):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_opt("produce-models", "true")
     solver.set_opt("incremental", "true")
 
@@ -49,7 +49,9 @@ def test_sorting_network(create_solver, num_vars):
         res = solver.check_sat()
         assert res.is_sat()
 
-        true_ = solver.make_term(True)
+        # The boolean here is the term's value, not a flag, so there is no
+        # keyword form that would read better.
+        true_ = solver.make_term(True)  # noqa: FBT003
         counted_true = 0
         for bb in boollist:
             val = solver.get_value(bb)

--- a/tests/python/test_unit.py
+++ b/tests/python/test_unit.py
@@ -25,7 +25,7 @@ from . import available_solvers
     "create_solver", available_solvers.termiter_support_solvers.values()
 )
 def test_unit_op(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
 
     null_op = ss.Op()
     ext = ss.Op(ss.primops.Extract, 2, 0)
@@ -44,13 +44,14 @@ def test_unit_op(create_solver):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_sort(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
 
     boolsort = solver.make_sort(ss.sortkinds.BOOL)
     bvsort = solver.make_sort(ss.sortkinds.BV, 8)
     arrsort = solver.make_sort(ss.sortkinds.ARRAY, [bvsort, bvsort])
 
-    # TODO: test functions when boolector supports querying the sort
+    # Functions are not covered here because boolector cannot query a term's
+    # sort; see the Sorts section of issues.md.
 
     names = ["b", "bv", "a"]
     sorts = [boolsort, bvsort, arrsort]
@@ -65,7 +66,7 @@ def test_sort(create_solver):
     "create_solver", available_solvers.termiter_support_solvers.values()
 )
 def test_unit_iter(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
 
     bvsort = solver.make_sort(ss.sortkinds.BV, 4)
     x = solver.make_symbol("x", bvsort)
@@ -80,7 +81,7 @@ def test_unit_iter(create_solver):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_bool(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_opt("produce-models", "true")
 
     boolsort = solver.make_sort(ss.sortkinds.BOOL)
@@ -95,7 +96,6 @@ def test_bool(create_solver):
     yv = solver.get_value(y)
 
     assert bool(xv)
-    print(yv)
     assert not bool(yv)
 
     with pytest.raises(ValueError, match="Cannot call bool on"):
@@ -104,7 +104,7 @@ def test_bool(create_solver):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_check_sat_assuming(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_opt("incremental", "true")
     boolsort = solver.make_sort(ss.sortkinds.BOOL)
     bvsort8 = solver.make_sort(ss.sortkinds.BV, 8)
@@ -126,7 +126,7 @@ def test_check_sat_assuming(create_solver):
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_multi_arg_fun(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     bvsort = solver.make_sort(ss.sortkinds.BV, 8)
     funsort = solver.make_sort(ss.sortkinds.FUNCTION, [bvsort] * 8)
 

--- a/tests/python/test_unit_vals.py
+++ b/tests/python/test_unit_vals.py
@@ -29,7 +29,7 @@ termiter_and_int_solvers = list({ss.solvers[n] for n in termiter_and_int_keys})
 
 @pytest.mark.parametrize("create_solver", termiter_and_int_solvers)
 def test_unit_bigint(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     intsort = solver.make_sort(ss.sortkinds.INT)
 
     bigint = solver.make_term(2**200, intsort)

--- a/tests/python/test_unsat_core.py
+++ b/tests/python/test_unsat_core.py
@@ -21,7 +21,7 @@ import smt_switch as ss
 
 @pytest.mark.parametrize("create_solver", ss.solvers.values())
 def test_unsat_assumptions_simple(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
     solver.set_opt("produce-unsat-assumptions", "true")
 
     boolsort = solver.make_sort(ss.sortkinds.BOOL)

--- a/tests/python/test_visitor.py
+++ b/tests/python/test_visitor.py
@@ -22,7 +22,7 @@ from smt_switch.primops import BVOr, BVUlt, Ite
     "create_solver", [f for name, f in ss.solvers.items() if name != "yices2"]
 )
 def test_identity_visit_basic(create_solver):
-    solver = create_solver(False)
+    solver = create_solver(logging=False)
 
     bv32 = solver.make_sort(ss.sortkinds.BV, 32)
 


### PR DESCRIPTION
Revisit the rules described as deliberate project decisions. Seven were not decisions, just code that had never been cleaned up or rules that only needed a narrower scope.

Fixed outright:

  - FBT, 29 sites, all FBT003. The generated factories are `def create_X_solver(logging)`, so `create_solver(logging=False)` satisfies the rule and reads better than a bare positional flag. The one remaining site is `solver.make_term(True)`, where the boolean is the term's value rather than a flag, and takes an inline directive instead.

  - T20 and E501, by scope rather than by edit. All nine E501 are single long `cdef extern` lines in the generator's Cython templates, and four of the seven prints are an example showing its output; both become per-file entries. The other three prints were debug leftovers in tests and are gone.

  - TD002, TD003 and one FIX, by rewording the TODO in test_sort to say plainly why functions are not covered and to point at the Sorts section of issues.md, which already records the boolector limitation it was waiting on. The HACK in pysmt_solver.py stays, since it documents a live workaround, and carries the one inline FIX004 directive.

  - ISC001, which had no violations and, tested with the rule active, does not destabilise the check-then-format cycle.

Enabling E501 immediately paid for itself: the `logging=` keyword pushed one `ft.partial` line to 91 columns, which the formatter has now wrapped.

Six ignores remain, all genuine decisions: ANN and D are their own projects, at 178 and 69 violations; EM and TRY003 prescribe a `msg = ...` temporary at every raise and bespoke exception subclasses, neither of which suits code that deliberately raises pysmt's own types; CPY001 comes off on a follow-up branch; and COM812 stays because its fix and the formatter do not reach a fixed point in a single pass, in either hook order.

Verified: `ruff check --select E501,FBT,T20,TD002,TD003,FIX` reports nothing, and that flag overrides `ignore`, so it is a real check. Emptying per-file-ignores reports only E501, S101 and T201, so no entry is dead, and RUF100 passing means neither new inline directive is stale. Every pre-commit hook passes, the suite still collects 30 tests, `compileall` succeeds, and the converter's error paths still behave against a real pysmt FormulaManager.