### PR TITLE
refactor: Use SPDX headers in the Python sources

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -16,7 +16,6 @@ select = ["ALL"]
 ignore = [
   "ANN",    # the codebase is essentially unannotated; revisit if mypy is enabled
   "COM812", # trailing commas are the formatter's job
-  "CPY001", # the licence header is on most files, but is not required on all
   "D",      # no docstring convention has been adopted
   "EM",     # message literals inline in `raise` are fine
   "TRY003", # see EM
@@ -32,6 +31,13 @@ ignore = [
 "python/gen-smt-solver-declarations.py" = ["E501"]
 # Bare assert is how a pytest test asserts.
 "tests/python/test_*.py" = ["S101"]
+
+# Every Python file carries SPDX tags. Ruff's default pattern wants `Copyright`
+# adjacent to the year, which `SPDX-FileCopyrightText:` does not satisfy, so
+# spell out the one line we accept: only the four-digit year varies. (?m) makes
+# ^ and $ line anchors, since the notice sits below the shebang in some files.
+[lint.flake8-copyright]
+notice-rgx = '(?m)^# SPDX-FileCopyrightText: \d{4} the smt-switch authors$'
 
 # Ruff classifies an import as first-party by finding the module under `src`,
 # and nothing in python/smt_switch is importable from the source tree: the

--- a/examples/python_qf_ufbv.py
+++ b/examples/python_qf_ufbv.py
@@ -1,4 +1,8 @@
 #!/usr/bin/env python3
+# SPDX-FileCopyrightText: 2021 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
+
 import smt_switch as ss
 from smt_switch.primops import Apply, BVAnd, BVUge, Distinct, Equal, Extract
 

--- a/python/gen-smt-solver-declarations.py
+++ b/python/gen-smt-solver-declarations.py
@@ -1,5 +1,7 @@
 #!/usr/bin/env python
-
+# SPDX-FileCopyrightText: 2020 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
 
 # This file generates the declarations and python implementation for creating solvers
 # It needs to be auto-generated because they depend on which solvers it

--- a/python/smt_switch/pysmt_frontend/__init__.py
+++ b/python/smt_switch/pysmt_frontend/__init__.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 the smt-switch authors
+# SPDX-FileContributor: Caleb Donovick
+# SPDX-License-Identifier: BSD-3-Clause
+
 from __future__ import annotations
 
 import typing as tp

--- a/python/smt_switch/pysmt_frontend/pysmt_solver.py
+++ b/python/smt_switch/pysmt_frontend/pysmt_solver.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 the smt-switch authors
+# SPDX-FileContributor: Caleb Donovick
+# SPDX-License-Identifier: BSD-3-Clause
+
 import fractions
 import functools as ft
 import gc

--- a/tests/python/__init__.py
+++ b/tests/python/__init__.py
@@ -1,1 +1,5 @@
+# SPDX-FileCopyrightText: 2026 the smt-switch authors
+# SPDX-FileContributor: Áron Ricardo Perez-Lopez
+# SPDX-License-Identifier: BSD-3-Clause
+
 """Marks this directory as a package so the test modules can import relatively."""

--- a/tests/python/available_solvers.py
+++ b/tests/python/available_solvers.py
@@ -1,18 +1,6 @@
-###############################################################
-# \file available_solvers.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief
-#
-#
-#
+# SPDX-FileCopyrightText: 2020 the smt-switch authors
+# SPDX-FileContributor: Amalee Wilson
+# SPDX-License-Identifier: BSD-3-Clause
 
 import smt_switch as ss
 

--- a/tests/python/test_arrays.py
+++ b/tests/python/test_arrays.py
@@ -1,18 +1,6 @@
-###############################################################
-# \file test_arrays.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief
-#
-#
-#
+# SPDX-FileCopyrightText: 2020 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
 

--- a/tests/python/test_bv.py
+++ b/tests/python/test_bv.py
@@ -1,18 +1,6 @@
-###############################################################
-# \file test_bv.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief
-#
-#
-#
+# SPDX-FileCopyrightText: 2020 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
 

--- a/tests/python/test_enums.py
+++ b/tests/python/test_enums.py
@@ -1,17 +1,8 @@
-###############################################################
-# \file test_enums.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief Test getters for enums (SortKind and PrimOp)
-#
-#
+# SPDX-FileCopyrightText: 2021 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Test getters for enums (SortKind and PrimOp)."""
 
 import pytest
 

--- a/tests/python/test_itp.py
+++ b/tests/python/test_itp.py
@@ -1,18 +1,6 @@
-###############################################################
-# \file test_itp.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief
-#
-#
-#
+# SPDX-FileCopyrightText: 2020 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
 

--- a/tests/python/test_lia.py
+++ b/tests/python/test_lia.py
@@ -1,18 +1,6 @@
-###############################################################
-# \file test_lia.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief
-#
-#
-#
+# SPDX-FileCopyrightText: 2020 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
 

--- a/tests/python/test_push_pop.py
+++ b/tests/python/test_push_pop.py
@@ -1,18 +1,6 @@
-###############################################################
-# \file test_push_pop.py
-# \verbatim
-# Top contributors (to current version):
-#   Po-Chun Chien
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief
-#
-#
-#
+# SPDX-FileCopyrightText: 2026 the smt-switch authors
+# SPDX-FileContributor: Po-Chun Chien
+# SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
 

--- a/tests/python/test_pysmt.py
+++ b/tests/python/test_pysmt.py
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 the smt-switch authors
+# SPDX-FileContributor: Caleb Donovick
+# SPDX-License-Identifier: BSD-3-Clause
+
 import pytest
 
 # pysmt is an optional dependency, so each module is bound through

--- a/tests/python/test_reals.py
+++ b/tests/python/test_reals.py
@@ -1,18 +1,6 @@
-###############################################################
-# \file test_reals.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief
-#
-#
-#
+# SPDX-FileCopyrightText: 2020 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
 

--- a/tests/python/test_sorting_network.py
+++ b/tests/python/test_sorting_network.py
@@ -1,18 +1,11 @@
-###############################################################
-# \file test_sorting_network.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief Test SortingNetwork through Python bindings
-#        see include/sorting_network.h for more information on the
-#        SortingNetwork class
-#
+# SPDX-FileCopyrightText: 2021 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Test SortingNetwork through Python bindings.
+
+See include/sorting_network.h for more information on the SortingNetwork class.
+"""
 
 from itertools import product
 

--- a/tests/python/test_unit.py
+++ b/tests/python/test_unit.py
@@ -1,18 +1,6 @@
-###############################################################
-# \file test_unit.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief
-#
-#
-#
+# SPDX-FileCopyrightText: 2020 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
 

--- a/tests/python/test_unit_vals.py
+++ b/tests/python/test_unit_vals.py
@@ -1,18 +1,6 @@
-###############################################################
-# \file test_unit_vals.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief
-#
-#
-#
+# SPDX-FileCopyrightText: 2020 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
 

--- a/tests/python/test_unsat_core.py
+++ b/tests/python/test_unsat_core.py
@@ -1,18 +1,6 @@
-###############################################################
-# \file test_unsat_core.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief
-#
-#
-#
+# SPDX-FileCopyrightText: 2020 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
 
 import pytest
 

--- a/tests/python/test_visitor.py
+++ b/tests/python/test_visitor.py
@@ -1,16 +1,8 @@
-###############################################################
-# \file test_visitor.py
-# \verbatim
-# Top contributors (to current version):
-#   Makai Mann
-# This file is part of the smt-switch project.
-# Copyright (c) 2020 by the authors listed in the file AUTHORS
-# in the top-level source directory) and their institutional affiliations.
-# All rights reserved.  See the file LICENSE in the top-level source
-# directory for licensing information.\endverbatim
-#
-# \brief Small test of identity visiting
-#
+# SPDX-FileCopyrightText: 2021 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
+
+"""Small test of identity visiting."""
 
 import pytest
 


### PR DESCRIPTION
Replace the 15-line doxygen licence block with the standard SPDX tags, and take CPY001 off the ignore list, leaving five entries there.

    # SPDX-FileCopyrightText: 2021 the smt-switch authors
    # SPDX-FileContributor: Caleb Donovick
    # SPDX-License-Identifier: BSD-3-Clause

The old block had drifted. There is no Doxyfile in the repository, so its \file, \verbatim and \brief markup was inert; \file duplicated the name, so a rename desynced it; and an unbalanced parenthesis in "in the top-level source directory)" is copied into 47 files, which is a fair sign nobody had read it in years. It also never named the licence, which is BSD-3-Clause.

Both fields now come from git rather than from the block, which was stamped on in bulk by "Add license headers" (#62) and is unreliable as a result. Four files were dated 2020 despite being created later, test_push_pop.py by six years, and available_solvers.py credited Makai Mann for a file Amalee Wilson created in #30. Six files had no header at all.

The three files whose \brief said something keep it as a module docstring, which is where Python looks for it. test_sorting_network.py's ran to three lines, including the pointer to include/sorting_network.h.

Ruff's default notice pattern wants `Copyright` adjacent to the year, which `SPDX-FileCopyrightText:` does not satisfy, so notice-rgx spells out the exact line accepted, leaving only the four-digit year variable.