### PR TITLE
refactor: Scope EM and TRY003 to the pysmt frontend

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -17,8 +17,6 @@ ignore = [
   "ANN",    # the codebase is essentially unannotated; revisit if mypy is enabled
   "COM812", # trailing commas are the formatter's job
   "D",      # no docstring convention has been adopted
-  "EM",     # message literals inline in `raise` are fine
-  "TRY003", # see EM
 ]
 
 # Only rules that a whole file violates by design belong here. One-off cases
@@ -29,6 +27,11 @@ ignore = [
 # The Cython `cdef extern` declarations this generator emits are single long
 # lines that neither the formatter nor a human can usefully wrap.
 "python/gen-smt-solver-declarations.py" = ["E501"]
+# This module raises pysmt's own exception types with a message describing the
+# term or sort at fault, across 17 sites. Bespoke subclasses would not suit
+# borrowed exception types, and hoisting each message to a variable would add a
+# line per raise.
+"python/smt_switch/pysmt_frontend/*" = ["EM", "TRY003"]
 # Bare assert is how a pytest test asserts.
 "tests/python/test_*.py" = ["S101"]
 

--- a/tests/python/test_itp.py
+++ b/tests/python/test_itp.py
@@ -28,15 +28,16 @@ def get_free_vars(t: ss.Term) -> set[ss.Term]:
     return free_vars
 
 
-# Note: Msat is only interpolant producing solver currently
-@pytest.mark.parametrize(
-    "itp_name", [name for name in ss.solvers if name in {"msat", "cvc5"}]
-)
+# Only cvc5 and msat expose an interpolator to Python. Bitwuzla implements one
+# in C++ (BitwuzlaSolverFactory::create_interpolating_solver) but the bindings
+# do not declare it; btor, yices2 and z3 have no interpolation support at all.
+# Every solver is parametrized so the report names the ones it skipped.
+@pytest.mark.parametrize("itp_name", sorted(ss.solvers))
 def test_simple_itp(itp_name):
     try:
         create_interpolator = getattr(ss, f"create_{itp_name}_interpolator")
-    except AttributeError as err:
-        raise NotImplementedError(f"Haven't handled interpolator {itp_name}") from err
+    except AttributeError:
+        pytest.skip(f"{itp_name} exposes no interpolator to Python")
     itp = create_interpolator()
 
     intsort = itp.make_sort(ss.sortkinds.INT)


### PR DESCRIPTION
Neither rule described a project-wide decision. Between them their violations are 18 raise statements, 17 of which are in python/smt_switch/pysmt_frontend, so they become one per-file entry and the global ignore list drops to three. A stray inline exception message elsewhere in the tree is now flagged, which the blanket ignore permitted.

The rationale for leaving the frontend alone is unchanged, and reads better next to the files it covers: that module raises pysmt's own exception types with a message naming the term or sort at fault, so bespoke subclasses do not suit it, and hoisting each message to a variable would add a line per raise.

The eighteenth was test_itp.py's `raise NotImplementedError`, the only raise in the test suite; everything else signals through pytest. It becomes a pytest.skip, which is the mechanism for a configuration a test cannot run in, and the test is now parametrized over every solver rather than a hard-coded pair, so the report names the backends it skipped instead of quietly omitting them. A build with no interpolating solver used to collapse to pytest's "got empty parameter set", which said nothing about interpolation.

Its note claimed msat was the only interpolating solver, which cvc5 in the same parametrization already contradicted. Python exposes interpolators for cvc5 and msat only. Bitwuzla implements one in C++, as BitwuzlaSolverFactory::create_interpolating_solver with a BZLA_INTERPOLATOR enum and coverage in tests/bzla, but neither the generator nor cppenums.pxd declares it, so Python cannot reach it; btor, yices2 and z3 have none. The skip reason says "exposes no interpolator to Python" rather than "has no support", which would be wrong for bitwuzla.