### PR TITLE
style: Apply shfmt and enable the hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,20 @@ repos:
       # unreliable in CI and broken offline. check-toml covers syntax.
       - id: taplo-format
 
+  - repo: https://github.com/scop/pre-commit-shfmt
+    rev: v3.13.1-1
+    hooks:
+      # -w is one of the hook's default args and must be repeated, because
+      # `args` replaces the defaults rather than extending them.
+      #
+      # -i 2 matches the indentation the majority of these scripts already
+      # use. Deliberately no -ln: the contrib/*-setup.sh libraries have no
+      # shebang, and shfmt's default language detection already parses them
+      # as bash. Deliberately no .editorconfig either, since shfmt would then
+      # take its indentation from that file and ignore these flags.
+      - id: shfmt
+        args: [-w, -i, "2", -ci, -s]
+
   # The hooks below are not enabled yet because the tree does not satisfy them.
   # Each needs its own pass before it can be turned on:
   #
@@ -70,13 +84,10 @@ repos:
   #                 Needs a bulk-reformat commit plus a .git-blame-ignore-revs
   #                 entry. Note .clang-format is already committed.
   #
-  #   shfmt         6 shell files would be rewritten (~570 lines); configure.sh
-  #                 gets reindented from 4-space to 2-space. Needs the CI matrix
-  #                 as proof the reindent was semantics-preserving.
-  #
-  #   shellcheck    43 findings in 7 of 22 scripts, 27 of them SC2086 on option
-  #                 strings that configure.sh intentionally word-splits. Fixing
-  #                 those changes behavior, so each site needs review.
+  #   shellcheck    43 findings in 7 of 22 scripts. Most are missing quotes
+  #                 that can simply be added, but configure.sh accumulates its
+  #                 CMake options in one string that has to word-split, so it
+  #                 needs a rewrite onto positional parameters first.
   #
   # Dependabot cannot bump commented-out repos, so re-check these revisions
   # with `pre-commit autoupdate` when enabling them.
@@ -85,13 +96,6 @@ repos:
   #   rev: v23.1.0
   #   hooks:
   #     - id: clang-format
-  # - repo: https://github.com/scop/pre-commit-shfmt
-  #   rev: v3.13.1-1
-  #   hooks:
-  #     # -w is one of the hook's default args and must be repeated, because
-  #     # `args` replaces the defaults rather than extending them.
-  #     - id: shfmt
-  #       args: [-w, -i, "2", -ci, -s]
   # - repo: https://github.com/shellcheck-py/shellcheck-py
   #   rev: v0.11.0.1-1
   #   hooks:

--- a/ci-scripts/setup-yices2.sh
+++ b/ci-scripts/setup-yices2.sh
@@ -4,39 +4,39 @@
 
 YICES2_VERSION=98fa2d882d83d32a07d3b8b2c562819e0e0babd0
 
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 DEPS=$DIR/../deps
 
 mkdir -p $DEPS
 
 if [ "$(uname)" == "Darwin" ]; then
-    NUM_CORES=$(sysctl -n hw.logicalcpu)
+  NUM_CORES=$(sysctl -n hw.logicalcpu)
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-    NUM_CORES=$(nproc)
+  NUM_CORES=$(nproc)
 else
-    NUM_CORES=1
+  NUM_CORES=1
 fi
 
 if [ ! -d "$DEPS/yices2" ]; then
-    cd $DEPS
-    git clone https://github.com/SRI-CSL/yices2.git
-    chmod -R 777 yices2
-    cd yices2
-    git checkout -f $YICES2_VERSION
-    autoconf
-    ./configure --enable-thread-safety
-    make build_dir=build BUILD=build -j$NUM_CORES
-    cd $DIR
+  cd $DEPS
+  git clone https://github.com/SRI-CSL/yices2.git
+  chmod -R 777 yices2
+  cd yices2
+  git checkout -f $YICES2_VERSION
+  autoconf
+  ./configure --enable-thread-safety
+  make build_dir=build BUILD=build -j$NUM_CORES
+  cd $DIR
 else
-    echo "$DEPS/yices2 already exists. If you want to rebuild, please remove it manually."
+  echo "$DEPS/yices2 already exists. If you want to rebuild, please remove it manually."
 fi
 
-if [ -f $DEPS/yices2/build/lib/libyices.a ] ; then \
-    echo "It appears yices2 was setup successfully into $DEPS/yices2."
-    echo "You may now install it with make ./configure.sh --yices2 && cd build && make"
+if [ -f $DEPS/yices2/build/lib/libyices.a ]; then
+  echo "It appears yices2 was setup successfully into $DEPS/yices2."
+  echo "You may now install it with make ./configure.sh --yices2 && cd build && make"
 else
-    echo "Building yices2 failed."
-    echo "You might be missing some dependencies."
-    echo "Please see their github page for installation instructions: https://github.com/SRI-CSL/yices2"
-    exit 1
+  echo "Building yices2 failed."
+  echo "You might be missing some dependencies."
+  echo "Please see their github page for installation instructions: https://github.com/SRI-CSL/yices2"
+  exit 1
 fi

--- a/configure.sh
+++ b/configure.sh
@@ -4,8 +4,8 @@
 
 CONF_FILE=Makefile.conf
 
-usage () {
-cat <<EOF
+usage() {
+  cat <<EOF
 Usage: $0 [<option> ...]
 
 Configures the CMAKE build environment.
@@ -41,9 +41,9 @@ EOF
   exit 0
 }
 
-die () {
-    echo "*** $0: $*" 1>&2
-    exit 1
+die() {
+  echo "*** $0: $*" 1>&2
+  exit 1
 }
 
 build_dir=build
@@ -73,232 +73,231 @@ build_type=Release
 
 cmake_opts=""
 
-while [ $# -gt 0 ]
-do
-    case $1 in
-        -h|--help) usage;;
-        --prefix) die "missing argument to $1 (see -h)" ;;
-        --prefix=*)
-            install_prefix=${1##*=}
-            # Check if install_prefix is an absolute path and if not, make it
-            # absolute.
-            case $install_prefix in
-                /*) ;;                                      # absolute path
-                *) install_prefix=$(pwd)/$install_prefix ;; # make absolute path
-            esac
-            ;;
-        --btor)
-            build_btor=ON
-            ;;
-        --bitwuzla)
-            build_bitwuzla=ON
-            ;;
-        --yices2)
-            build_yices2=ON
-            ;;
-        --cvc5)
-            build_cvc5=ON
-            ;;
-        --msat)
-            build_msat=ON
-            ;;
-        --z3)
-            build_z3=ON
-            ;;
-            --btor-home) die "missing argument to $1 (see -h)" ;;
-            --btor-home=*)
-                btor_home=${1##*=}
-                # Check if btor_home is an absolute path and if not, make it
-                # absolute.
-                case $btor_home in
-                    /*) ;;                                      # absolute path
-                    *) btor_home=$(pwd)/$btor_home ;; # make absolute path
-                esac
-                ;;
-        --cvc5-home) die "missing argument to $1 (see -h)" ;;
-        --cvc5-home=*)
-            cvc5_home=${1##*=}
-            # Check if cvc5_home is an absolute path and if not, make it
-            # absolute.
-            case $cvc5_home in
-                /*) ;;                                      # absolute path
-                *) cvc5_home=$(pwd)/$cvc5_home ;; # make absolute path
-            esac
-            ;;
-        --msat-home) die "missing argument to $1 (see -h)" ;;
-        --msat-home=*)
-            msat_home=${1##*=}
-            # Check if msat_home is an absolute path and if not, make it
-            # absolute.
-            case $msat_home in
-                /*) ;;                                      # absolute path
-                *) msat_home=$(pwd)/$msat_home ;; # make absolute path
-            esac
-            ;;
-        --yices2-home) die "missing argument to $1 (see -h)" ;;
-        --yices2-home=*)
-            yices2_home=${1##*=}
-            # Check if yices2_home is an absolute path and if not, make it
-            # absolute.
-            case $yices2_home in
-                /*) ;;                                      # absolute path
-                *) yices2_home=$(pwd)/$yices2_home ;; # make absolute path
-            esac
-            ;;
-        --build-dir) die "missing argument to $1 (see -h)" ;;
-        --build-dir=*)
-            build_dir=${1##*=}
-            # Check if build_dir is an absolute path and if not, make it
-            # absolute.
-            case $build_dir in
-                /*) ;;                                      # absolute path
-                *) build_dir=$(pwd)/$build_dir ;; # make absolute path
-            esac
-            ;;
-        --debug)
-            build_type=Debug;
-            ;;
-        --static)
-            static=yes
-            ;;
-        --without-tests)
-            build_tests=no
-            ;;
-        --no-system-gtest)
-            system_gtest=no
-            ;;
-        --python)
-            python=yes
-            ;;
-        --python-executable=*)
-            python_executable=${1##*=}
-            # Check if python_executable is an absolute path and if not, make it
-            # absolute.
-            case $python_executable in
-                /*) ;;                            # absolute path
-                *) python_executable=$(pwd)/$python_executable ;; # make absolute path
-            esac
-            ;;
-        --smtlib-reader)
-            smtlib_reader=yes
-            ;;
-        --bison-dir=*)
-            bison_dir=${1##*=}
-            # Check if bison_dir is an absolute path and if not, make it
-            # absolute.
-            case $bison_dir in
-                /*) ;;                            # absolute path
-                *) bison_dir=$(pwd)/$bison_dir ;; # make absolute path
-            esac
-            ;;
-        --flex-dir=*)
-            flex_dir=${1##*=}
-            # Check if flex_dir is an absolute path and if not, make it
-            # absolute.
-            case $flex_dir in
-                /*) ;;                            # absolute path
-                *) flex_dir=$(pwd)/$flex_dir ;; # make absolute path
-            esac
-            ;;
-        --bitwuzla-dir) die "missing argument to $1 (see -h)" ;;
-        --bitwuzla-dir=*)
-            bitwuzla_dir="${1##*=}"
-            # Make relative paths absolute
-            bitwuzla_dir="$(cd -- "$bitwuzla_dir" && pwd)"
-            ;;
-        --z3-install-dir) die "missing argument to $1 (see -h)" ;;
-        --z3-install-dir=*)
-            z3_install_dir=${1##*=}
-            # Make relative paths absolute
-            z3_install_dir="$(cd -- "$z3_install_dir" && pwd)"
-            ;;
-        -D*) cmake_opts="${cmake_opts} $1" ;;
-        *) die "unexpected argument: $1";;
-    esac
-    shift
+while [ $# -gt 0 ]; do
+  case $1 in
+    -h | --help) usage ;;
+    --prefix) die "missing argument to $1 (see -h)" ;;
+    --prefix=*)
+      install_prefix=${1##*=}
+      # Check if install_prefix is an absolute path and if not, make it
+      # absolute.
+      case $install_prefix in
+        /*) ;;                                      # absolute path
+        *) install_prefix=$(pwd)/$install_prefix ;; # make absolute path
+      esac
+      ;;
+    --btor)
+      build_btor=ON
+      ;;
+    --bitwuzla)
+      build_bitwuzla=ON
+      ;;
+    --yices2)
+      build_yices2=ON
+      ;;
+    --cvc5)
+      build_cvc5=ON
+      ;;
+    --msat)
+      build_msat=ON
+      ;;
+    --z3)
+      build_z3=ON
+      ;;
+    --btor-home) die "missing argument to $1 (see -h)" ;;
+    --btor-home=*)
+      btor_home=${1##*=}
+      # Check if btor_home is an absolute path and if not, make it
+      # absolute.
+      case $btor_home in
+        /*) ;;                            # absolute path
+        *) btor_home=$(pwd)/$btor_home ;; # make absolute path
+      esac
+      ;;
+    --cvc5-home) die "missing argument to $1 (see -h)" ;;
+    --cvc5-home=*)
+      cvc5_home=${1##*=}
+      # Check if cvc5_home is an absolute path and if not, make it
+      # absolute.
+      case $cvc5_home in
+        /*) ;;                            # absolute path
+        *) cvc5_home=$(pwd)/$cvc5_home ;; # make absolute path
+      esac
+      ;;
+    --msat-home) die "missing argument to $1 (see -h)" ;;
+    --msat-home=*)
+      msat_home=${1##*=}
+      # Check if msat_home is an absolute path and if not, make it
+      # absolute.
+      case $msat_home in
+        /*) ;;                            # absolute path
+        *) msat_home=$(pwd)/$msat_home ;; # make absolute path
+      esac
+      ;;
+    --yices2-home) die "missing argument to $1 (see -h)" ;;
+    --yices2-home=*)
+      yices2_home=${1##*=}
+      # Check if yices2_home is an absolute path and if not, make it
+      # absolute.
+      case $yices2_home in
+        /*) ;;                                # absolute path
+        *) yices2_home=$(pwd)/$yices2_home ;; # make absolute path
+      esac
+      ;;
+    --build-dir) die "missing argument to $1 (see -h)" ;;
+    --build-dir=*)
+      build_dir=${1##*=}
+      # Check if build_dir is an absolute path and if not, make it
+      # absolute.
+      case $build_dir in
+        /*) ;;                            # absolute path
+        *) build_dir=$(pwd)/$build_dir ;; # make absolute path
+      esac
+      ;;
+    --debug)
+      build_type=Debug
+      ;;
+    --static)
+      static=yes
+      ;;
+    --without-tests)
+      build_tests=no
+      ;;
+    --no-system-gtest)
+      system_gtest=no
+      ;;
+    --python)
+      python=yes
+      ;;
+    --python-executable=*)
+      python_executable=${1##*=}
+      # Check if python_executable is an absolute path and if not, make it
+      # absolute.
+      case $python_executable in
+        /*) ;;                                            # absolute path
+        *) python_executable=$(pwd)/$python_executable ;; # make absolute path
+      esac
+      ;;
+    --smtlib-reader)
+      smtlib_reader=yes
+      ;;
+    --bison-dir=*)
+      bison_dir=${1##*=}
+      # Check if bison_dir is an absolute path and if not, make it
+      # absolute.
+      case $bison_dir in
+        /*) ;;                            # absolute path
+        *) bison_dir=$(pwd)/$bison_dir ;; # make absolute path
+      esac
+      ;;
+    --flex-dir=*)
+      flex_dir=${1##*=}
+      # Check if flex_dir is an absolute path and if not, make it
+      # absolute.
+      case $flex_dir in
+        /*) ;;                          # absolute path
+        *) flex_dir=$(pwd)/$flex_dir ;; # make absolute path
+      esac
+      ;;
+    --bitwuzla-dir) die "missing argument to $1 (see -h)" ;;
+    --bitwuzla-dir=*)
+      bitwuzla_dir="${1##*=}"
+      # Make relative paths absolute
+      bitwuzla_dir="$(cd -- "$bitwuzla_dir" && pwd)"
+      ;;
+    --z3-install-dir) die "missing argument to $1 (see -h)" ;;
+    --z3-install-dir=*)
+      z3_install_dir=${1##*=}
+      # Make relative paths absolute
+      z3_install_dir="$(cd -- "$z3_install_dir" && pwd)"
+      ;;
+    -D*) cmake_opts="${cmake_opts} $1" ;;
+    *) die "unexpected argument: $1" ;;
+  esac
+  shift
 done
 
 # enable solvers automatically if a custom home is provided
 if [ $btor_home != default -a $build_btor = default ]; then
-    build_btor=ON
+  build_btor=ON
 fi
 
 if [ $cvc5_home != default -a $build_cvc5 = default ]; then
-    build_cvc5=ON
+  build_cvc5=ON
 fi
 
 if [ $msat_home != default -a $build_msat = default ]; then
-    build_msat=ON
+  build_msat=ON
 fi
 
 if [ $yices2_home != default -a $build_yices2 = default ]; then
-    build_yices2=ON
+  build_yices2=ON
 fi
 
 cmake_opts="$cmake_opts -DCMAKE_BUILD_TYPE=$build_type"
 
-[ $install_prefix != default ] \
-    && cmake_opts="$cmake_opts -DCMAKE_INSTALL_PREFIX=$install_prefix"
+[ $install_prefix != default ] &&
+  cmake_opts="$cmake_opts -DCMAKE_INSTALL_PREFIX=$install_prefix"
 
-[ $build_btor != default ] \
-    && cmake_opts="$cmake_opts -DBUILD_BTOR=$build_btor"
+[ $build_btor != default ] &&
+  cmake_opts="$cmake_opts -DBUILD_BTOR=$build_btor"
 
-[ $build_bitwuzla != default ] \
-    && cmake_opts="$cmake_opts -DBUILD_BITWUZLA=$build_bitwuzla"
+[ $build_bitwuzla != default ] &&
+  cmake_opts="$cmake_opts -DBUILD_BITWUZLA=$build_bitwuzla"
 
-[ $build_cvc5 != default ] \
-    && cmake_opts="$cmake_opts -DBUILD_CVC5=$build_cvc5"
+[ $build_cvc5 != default ] &&
+  cmake_opts="$cmake_opts -DBUILD_CVC5=$build_cvc5"
 
-[ $build_msat != default ] \
-    && cmake_opts="$cmake_opts -DBUILD_MSAT=$build_msat"
+[ $build_msat != default ] &&
+  cmake_opts="$cmake_opts -DBUILD_MSAT=$build_msat"
 
-[ $build_yices2 != default ] \
-    && cmake_opts="$cmake_opts -DBUILD_YICES2=$build_yices2"
+[ $build_yices2 != default ] &&
+  cmake_opts="$cmake_opts -DBUILD_YICES2=$build_yices2"
 
-[ $build_z3 != default ] \
-    && cmake_opts="$cmake_opts -DBUILD_Z3=$build_z3"
+[ $build_z3 != default ] &&
+  cmake_opts="$cmake_opts -DBUILD_Z3=$build_z3"
 
-[ $btor_home != default ] \
-    && cmake_opts="$cmake_opts -DBTOR_HOME=$btor_home"
+[ $btor_home != default ] &&
+  cmake_opts="$cmake_opts -DBTOR_HOME=$btor_home"
 
-[ $cvc5_home != default ] \
-    && cmake_opts="$cmake_opts -DCVC5_HOME=$cvc5_home"
+[ $cvc5_home != default ] &&
+  cmake_opts="$cmake_opts -DCVC5_HOME=$cvc5_home"
 
-[ $msat_home != default ] \
-    && cmake_opts="$cmake_opts -DMSAT_HOME=$msat_home"
+[ $msat_home != default ] &&
+  cmake_opts="$cmake_opts -DMSAT_HOME=$msat_home"
 
-[ $yices2_home != default ] \
-    && cmake_opts="$cmake_opts -DYICES2_HOME=$yices2_home"
+[ $yices2_home != default ] &&
+  cmake_opts="$cmake_opts -DYICES2_HOME=$yices2_home"
 
-[ $static != default ] \
-    && cmake_opts="$cmake_opts -DSMT_SWITCH_LIB_TYPE=STATIC"
+[ $static != default ] &&
+  cmake_opts="$cmake_opts -DSMT_SWITCH_LIB_TYPE=STATIC"
 
-[ $build_tests != default ] \
-    && cmake_opts="$cmake_opts -DBUILD_TESTS=$build_tests"
+[ $build_tests != default ] &&
+  cmake_opts="$cmake_opts -DBUILD_TESTS=$build_tests"
 
-[ $system_gtest != default ] \
-    && cmake_opts="$cmake_opts -DSYSTEM_GTEST=$system_gtest"
+[ $system_gtest != default ] &&
+  cmake_opts="$cmake_opts -DSYSTEM_GTEST=$system_gtest"
 
-[ $python != default ] \
-    && cmake_opts="$cmake_opts -DBUILD_PYTHON_BINDINGS=ON"
+[ $python != default ] &&
+  cmake_opts="$cmake_opts -DBUILD_PYTHON_BINDINGS=ON"
 
-[ $python_executable != default ] \
-    && cmake_opts="$cmake_opts -DPython_EXECUTABLE=$python_executable"
+[ $python_executable != default ] &&
+  cmake_opts="$cmake_opts -DPython_EXECUTABLE=$python_executable"
 
-[ $smtlib_reader != default ] \
-    && cmake_opts="$cmake_opts -DSMTLIB_READER=ON"
+[ $smtlib_reader != default ] &&
+  cmake_opts="$cmake_opts -DSMTLIB_READER=ON"
 
-[ $bison_dir != default ] \
-    && cmake_opts="$cmake_opts -DBISON_DIR=$bison_dir"
+[ $bison_dir != default ] &&
+  cmake_opts="$cmake_opts -DBISON_DIR=$bison_dir"
 
-[ $flex_dir != default ] \
-    && cmake_opts="$cmake_opts -DFLEX_DIR=$flex_dir"
+[ $flex_dir != default ] &&
+  cmake_opts="$cmake_opts -DFLEX_DIR=$flex_dir"
 
-[ $bitwuzla_dir != default ] \
-    && cmake_opts="$cmake_opts -DBITWUZLA_DIR=$bitwuzla_dir"
+[ $bitwuzla_dir != default ] &&
+  cmake_opts="$cmake_opts -DBITWUZLA_DIR=$bitwuzla_dir"
 
-[ $z3_install_dir != default ] \
-    && cmake_opts="$cmake_opts -DZ3_INSTALL_DIR=$z3_install_dir"
+[ $z3_install_dir != default ] &&
+  cmake_opts="$cmake_opts -DZ3_INSTALL_DIR=$z3_install_dir"
 
 mkdir -p "$build_dir"
 cd "$build_dir" || exit 1

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -1,27 +1,25 @@
 #!/usr/bin/env bash
 # get the absolute path to this directory
-DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null 2>&1 && pwd )"
+DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 set -e
 
-help_message()
-{
-    echo "usage: $0 [--python]"
-    echo "this script builds smt-switch and the C++ examples"
-    echo "it also builds and installs the python bindings if run with --python"
-    exit 0
+help_message() {
+  echo "usage: $0 [--python]"
+  echo "this script builds smt-switch and the C++ examples"
+  echo "it also builds and installs the python bindings if run with --python"
+  exit 0
 }
 
-if [[ "$1" == "--help" ]]; then
-    help_message
+if [[ $1 == "--help" ]]; then
+  help_message
 fi
 
 if [ $# -gt 2 ]; then
-    help_message
-elif [[ $# -eq 1 && "$1" != "--python" ]]; then
-    help_message
+  help_message
+elif [[ $# -eq 1 && $1 != "--python" ]]; then
+  help_message
 fi
-
 
 # go to main repo directory
 cd $DIR/..

--- a/scripts/repack-static-lib.sh
+++ b/scripts/repack-static-lib.sh
@@ -1,45 +1,43 @@
 #!/bin/bash
 
 if [ $# -lt 2 ]; then
-    echo "usage: $0 <libname> [...libs to combine]"
-    exit 1
+  echo "usage: $0 <libname> [...libs to combine]"
+  exit 1
 fi
 
-if [[ "$OSTYPE" == linux* || "$OSTYPE" == cygwin* ]]; then
-    # use a GNU ar MRI script on Linux-like systems
-    if ! command -v ar &> /dev/null
-    then
-        echo "ar could not be found"
-        echo "required for repacking static libraries on Linux"
-        exit
-    fi
+if [[ $OSTYPE == linux* || $OSTYPE == cygwin* ]]; then
+  # use a GNU ar MRI script on Linux-like systems
+  if ! command -v ar &>/dev/null; then
+    echo "ar could not be found"
+    echo "required for repacking static libraries on Linux"
+    exit
+  fi
 
-    TARGET=$1
-    MRI_COMMAND="create $TARGET"
-    for lib in "${@:2}"; do
-        MRI_COMMAND="${MRI_COMMAND}\naddlib $lib"
-    done
+  TARGET=$1
+  MRI_COMMAND="create $TARGET"
+  for lib in "${@:2}"; do
+    MRI_COMMAND="${MRI_COMMAND}\naddlib $lib"
+  done
 
-    MRI_COMMAND="${MRI_COMMAND}\nsave\nend"
-    echo -e "$MRI_COMMAND" | ar -M
+  MRI_COMMAND="${MRI_COMMAND}\nsave\nend"
+  echo -e "$MRI_COMMAND" | ar -M
 
-    if [ ! -f "${TARGET}" ]; then
-        echo "It appears ar failed to create ${TARGET}"
-        exit 1
-    fi
-elif [[ "$OSTYPE" == darwin* ]]; then
-    # use libtool (note: not the same as GNU libtool) on OSX
-    if ! command -v libtool &> /dev/null
-    then
-        echo "libtool could not be found"
-        echo "required for repacking static libraries on Mac"
-        exit
-    fi
-
-    libtool -static -o $@
-elif [[ "$OSTYPE" == msys* ]]; then
-    echo "$0 does not support repacking static libs on Windows yet"
-else
-    echo "Unrecognized OSTYPE=$OSTYPE"
+  if [ ! -f "${TARGET}" ]; then
+    echo "It appears ar failed to create ${TARGET}"
     exit 1
+  fi
+elif [[ $OSTYPE == darwin* ]]; then
+  # use libtool (note: not the same as GNU libtool) on OSX
+  if ! command -v libtool &>/dev/null; then
+    echo "libtool could not be found"
+    echo "required for repacking static libraries on Mac"
+    exit
+  fi
+
+  libtool -static -o $@
+elif [[ $OSTYPE == msys* ]]; then
+  echo "$0 does not support repacking static libs on Windows yet"
+else
+  echo "Unrecognized OSTYPE=$OSTYPE"
+  exit 1
 fi


### PR DESCRIPTION
Enable the shfmt pre-commit hook with -i 2 -ci -s and reformat the four scripts that did not already match it.

-i 2 was chosen because it is what most of these scripts already use: with -i 4 shfmt would rewrite 16 files instead of 4. configure.sh, examples/build.sh, ci-scripts/setup-yices2.sh and
scripts/repack-static-lib.sh are the four that were still on 4-space indentation.

Every non-whitespace change is semantics-preserving:

  - `while [ $# -gt 0 ]` with a bare `do` on the next line becomes `; do`, and a stray trailing backslash after `then` is dropped
  - `[ x ] \` + `&& y` becomes `[ x ] &&` + `y`, the same AND-list
  - `build_type=Debug;` loses its redundant semicolon
  - `help_message()` + `{` on the next line is joined
  - -s removes quotes on the left of `==` inside `[[ ]]`, where no word splitting or globbing happens; the right-hand glob patterns (`linux*`, `darwin*`) are left unquoted so they still match as patterns
  - `&> /dev/null` becomes `&>/dev/null`

Verified that shfmt is now a fixed point over the tree, that shellcheck reports the same 43 findings as before (none introduced, none hidden), and that the reformat clears the one bashate E010 in configure.sh.

Deliberately no -ln flag: the contrib/*-setup.sh libraries have no shebang, and shfmt's default detection already parses them as bash, producing byte-identical output to -ln bash. Deliberately no .editorconfig either, since shfmt would then read its indentation from that file and ignore the flags set here.

contrib/ is untouched, so the solver build caches keyed on ci-scripts/compute-solver-hash.sh are not invalidated.