### PR TITLE
build: Add .git-blame-ignore-revs

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -1,0 +1,17 @@
+# Commits that only reformat code, listed so that `git blame` can skip them.
+#
+# GitHub reads this file automatically. To use it locally, run:
+#
+#     git config blame.ignoreRevsFile .git-blame-ignore-revs
+#
+# Add a full commit hash plus its subject line for every bulk-reformat commit,
+# oldest first. Only add a commit whose diff is purely a reformatting: one that
+# changes how the code is laid out but not what it does. Automated lint fixes
+# do not belong here, because they rewrite the code itself and blame should
+# point at them.
+
+# style: Add minimal ruff config and autoformat Python sources (#510)
+dc378fda402df6a068ef267965a1e7d0898ab02d
+
+# style: Apply shfmt and enable the hook (#521)
+f8935125f9812bd70592991629692f2b71f952e6


### PR DESCRIPTION
Two commits so far have rewritten large stretches of the tree without changing what any of it does, which leaves `git blame` pointing at the reformat instead of at whoever wrote the code:

  dc378fd  style: Add minimal ruff config and autoformat Python sources
           (#510), a `ruff format` run over ~800 lines in 20 files
  f893512  style: Apply shfmt and enable the hook (#521), which
           reindented configure.sh and three other scripts

Both were verified semantics-preserving when they landed: #510 by comparing the abstract syntax tree of every reformatted .py file, #521 by reading every non-whitespace change and running the CI matrix.

Checked the effect on both entries. blame for configure.sh:100 moves from #521 back to Makai Mann in 2019, and
python/gen-smt-solver-declarations.py:13 moves from #510 back to makaimann in 2020.

GitHub reads this file with no further setup. Locally it needs an opt-in, which the file documents:

    git config blame.ignoreRevsFile .git-blame-ignore-revs

Deliberately not listed: the ruff autofix commits, 5c240dc (#515, safe fixes) and 0c82ad9 (#516, unsafe fixes). Those rewrite the code rather than its layout, so they are the real origin of the lines they touched and blame should keep pointing at them. The file's header comment says so, to keep the distinction from eroding as entries get added. The same reasoning excludes bc39def (#519), which added SPDX headers.

The pending clang-format rollout will want an entry here too, since it would rewrite 86 of 229 C/C++ files.