### PR TITLE
refactor: Lowercase the shell-local variables

### DIFF
--- a/ci-scripts/cibw-build-before.sh
+++ b/ci-scripts/cibw-build-before.sh
@@ -20,10 +20,10 @@ set -e
 # Find the Python root directory for the current Python version
 # This is important for the manylinux infrastructure, which is in
 # a nonstandard location that CMake has trouble finding
-PYTHON_EXECUTABLE=$(which python3)
-echo "Using Python_EXECUTABLE: ${PYTHON_EXECUTABLE}"
+python_executable=$(command -v python3)
+echo "Using Python_EXECUTABLE: ${python_executable}"
 
 # configure for all solvers with permissive licenses (BSD, MIT, etc..)
-./configure.sh --bitwuzla --cvc5 --z3 --python --python-executable=${PYTHON_EXECUTABLE}
+./configure.sh --bitwuzla --cvc5 --z3 --python --python-executable=${python_executable}
 cd build
 make -j

--- a/ci-scripts/setup-yices2.sh
+++ b/ci-scripts/setup-yices2.sh
@@ -2,37 +2,37 @@
 
 # requires autoconf, gperf
 
-YICES2_VERSION=98fa2d882d83d32a07d3b8b2c562819e0e0babd0
+yices2_version=98fa2d882d83d32a07d3b8b2c562819e0e0babd0
 
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
-DEPS=$DIR/../deps
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+deps_dir=$script_dir/../deps
 
-mkdir -p $DEPS
+mkdir -p $deps_dir
 
 if [ "$(uname)" == "Darwin" ]; then
-  NUM_CORES=$(sysctl -n hw.logicalcpu)
+  num_cores=$(sysctl -n hw.logicalcpu)
 elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
-  NUM_CORES=$(nproc)
+  num_cores=$(nproc)
 else
-  NUM_CORES=1
+  num_cores=1
 fi
 
-if [ ! -d "$DEPS/yices2" ]; then
-  cd $DEPS
+if [ ! -d "$deps_dir/yices2" ]; then
+  cd $deps_dir
   git clone https://github.com/SRI-CSL/yices2.git
   chmod -R 777 yices2
   cd yices2
-  git checkout -f $YICES2_VERSION
+  git checkout -f $yices2_version
   autoconf
   ./configure --enable-thread-safety
-  make build_dir=build BUILD=build -j$NUM_CORES
-  cd $DIR
+  make build_dir=build BUILD=build -j$num_cores
+  cd $script_dir
 else
-  echo "$DEPS/yices2 already exists. If you want to rebuild, please remove it manually."
+  echo "$deps_dir/yices2 already exists. If you want to rebuild, please remove it manually."
 fi
 
-if [ -f $DEPS/yices2/build/lib/libyices.a ]; then
-  echo "It appears yices2 was setup successfully into $DEPS/yices2."
+if [ -f $deps_dir/yices2/build/lib/libyices.a ]; then
+  echo "It appears yices2 was setup successfully into $deps_dir/yices2."
   echo "You may now install it with make ./configure.sh --yices2 && cd build && make"
 else
   echo "Building yices2 failed."

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # get the absolute path to this directory
-DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
 
 set -e
 
@@ -22,21 +22,21 @@ elif [[ $# -eq 1 && $1 != "--python" ]]; then
 fi
 
 # go to main repo directory
-cd $DIR/..
+cd $script_dir/..
 
 # configure and build smt-switch with boolector and cvc5 backends
 # set it up to be installed in a directory called example-install in the examples directory
 # also use a build directory in the examples directory
-./configure.sh --btor --cvc5 --prefix=./examples/example-install --build-dir=$DIR/example-build $1
-cd $DIR/example-build
+./configure.sh --btor --cvc5 --prefix=./examples/example-install --build-dir=$script_dir/example-build $1
+cd $script_dir/example-build
 make
 make test
 make install
 
-cd $DIR
+cd $script_dir
 # now make the examples
 make
 
 # install python bindings with pip
 # this line might need to be adjusted depending on your current python environment
-python3 -m pip install -e $DIR/example-build/python
+python3 -m pip install -e $script_dir/example-build/python

--- a/scripts/repack-static-lib.sh
+++ b/scripts/repack-static-lib.sh
@@ -13,17 +13,17 @@ if [[ $OSTYPE == linux* || $OSTYPE == cygwin* ]]; then
     exit
   fi
 
-  TARGET=$1
-  MRI_COMMAND="create $TARGET"
+  target=$1
+  mri_command="create $target"
   for lib in "${@:2}"; do
-    MRI_COMMAND="${MRI_COMMAND}\naddlib $lib"
+    mri_command="${mri_command}\naddlib $lib"
   done
 
-  MRI_COMMAND="${MRI_COMMAND}\nsave\nend"
-  echo -e "$MRI_COMMAND" | ar -M
+  mri_command="${mri_command}\nsave\nend"
+  echo -e "$mri_command" | ar -M
 
-  if [ ! -f "${TARGET}" ]; then
-    echo "It appears ar failed to create ${TARGET}"
+  if [ ! -f "${target}" ]; then
+    echo "It appears ar failed to create ${target}"
     exit 1
   fi
 elif [[ $OSTYPE == darwin* ]]; then


### PR DESCRIPTION
Uppercase names belong to the environment. POSIX.1-2017 Base Definitions section 8.1, Environment Variable Definition, reserves them:

  Environment variable names used by the utilities in the Shell and
  Utilities volume of POSIX.1-2017 consist solely of uppercase letters,
  digits, and the <underscore> ( '_' ) from the characters defined in
  Portable Character Set and do not begin with a digit.

  The name space of environment variable names containing lowercase
  letters is reserved for applications. Applications can define any
  environment variables with names from this name space without
  modifying the behavior of the standard utilities.

  https://pubs.opengroup.org/onlinepubs/9699919799/basedefs/V1_chap08.html

The Google Shell Style Guide draws the same line: variable names are "Lower-case, with underscores to separate words" (section 7.2), while "Constants and anything exported to the environment should be capitalized, separated with underscores, and declared at the top of the file" (section 7.3).

  https://google.github.io/styleguide/shellguide.html#s7-naming-conventions

Lowercase is already the convention here. configure.sh has 54 lowercase assignments and the contrib/ setup framework another 41; only these four older scripts, which predate that framework, still used uppercase for plain locals. Where the framework already has a name for the same thing, this reuses it, so setup-yices2.sh now agrees with contrib/common-setup.sh on deps_dir and num_cores.

- ci-scripts/setup-yices2.sh
  * YICES2_VERSION -> yices2_version
  * DIR -> script_dir
  * DEPS -> deps_dir
  * NUM_CORES -> num_cores
- scripts/repack-static-lib.sh
  * TARGET -> target
  * MRI_COMMAND -> mri_command
- examples/build.sh
  * DIR -> script_dir
- ci-scripts/cibw-build-before.sh
  * PYTHON_EXECUTABLE -> python_executable

Left uppercase deliberately: PKG_CONFIG_PATH, which contrib/common-setup.sh exports for CMake and Meson, and the shell- and CI-provided BASH_SOURCE, OSTYPE, PATH, CPATH, LIBRARY_PATH, GITHUB_ENV, GITHUB_OUTPUT and GITHUB_PATH. configure.sh's CONF_FILE is untouched here because it is dead and gets deleted with the shellcheck fixes.

Also swaps `which python3` for `command -v python3` on a line this commit already rewrites. `which` is not in POSIX and is not guaranteed present; `command -v` is a shell builtin. shellcheck flags the old form as SC2230 under its optional deprecate-which check.

No linter enforces any of this: shellcheck's optional check list has no naming rule, bashate's E001-E044 has none either, and shfmt only formats.

The renames are one-for-one, so shellcheck still reports the same 43 findings and shfmt is still a fixed point. The two PYTHON_EXECUTABLE hits elsewhere in the tree are CMake cache variables in cmake/ and python/, unrelated to this shell local.