### PR TITLE
style: Strip redundant quotes from assignments

### DIFF
--- a/ci-scripts/compute-solver-hash.sh
+++ b/ci-scripts/compute-solver-hash.sh
@@ -3,22 +3,22 @@ set -euo pipefail
 gethash() {
   sha256sum "$1" | cut -d ' ' -f 1
 }
-solver="$1"
-solver_hash="$(gethash ci-scripts/setup-"$1".sh)"
+solver=$1
+solver_hash=$(gethash ci-scripts/setup-"$1".sh)
 if [[ $solver == bitwuzla || $solver == btor || $solver == cvc5 || $solver == z3 ]]; then
-  solver_hash+="$(gethash contrib/common-setup.sh)"
+  solver_hash+=$(gethash contrib/common-setup.sh)
   if [[ $solver == bitwuzla ]]; then
-    solver_hash+="$(gethash contrib/meson-setup.sh)"
+    solver_hash+=$(gethash contrib/meson-setup.sh)
   else
-    solver_hash+="$(gethash contrib/cmake-setup.sh)"
+    solver_hash+=$(gethash contrib/cmake-setup.sh)
   fi
   if [[ $solver != z3 ]]; then
-    solver_hash+="$(gethash contrib/setup-cadical.sh)"
-    solver_hash+="$(gethash contrib/make-setup.sh)"
-    solver_hash+="$(gethash contrib/pkgconfig/cadical.pc.in)"
+    solver_hash+=$(gethash contrib/setup-cadical.sh)
+    solver_hash+=$(gethash contrib/make-setup.sh)
+    solver_hash+=$(gethash contrib/pkgconfig/cadical.pc.in)
   fi
 fi
 if [[ $solver == btor ]]; then
-  solver_hash+="$(gethash contrib/setup-btor2tools.sh)"
+  solver_hash+=$(gethash contrib/setup-btor2tools.sh)
 fi
 echo "result=$(gethash <(echo "$solver_hash"))" >>"$GITHUB_OUTPUT"

--- a/ci-scripts/setup-msat.sh
+++ b/ci-scripts/setup-msat.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 set -euo pipefail
 
-version="5.6.12"
+version=5.6.12
 
 usage() {
   cat <<EOF
@@ -42,7 +42,7 @@ mkdir -p deps && cd deps
 if [[ -d mathsat ]]; then
   echo "$(pwd)/mathsat already exists. If you want to re-download, please remove it manually."
 else
-  release_url="https://mathsat.fbk.eu/release"
+  release_url=https://mathsat.fbk.eu/release
   if [[ $OSTYPE =~ linux* ]]; then
     wget -O mathsat.tar.gz "${release_url}/mathsat-${version}-linux-x86_64.tar.gz"
   elif [[ $OSTYPE =~ darwin* ]]; then

--- a/ci-scripts/setup-yices2.sh
+++ b/ci-scripts/setup-yices2.sh
@@ -4,7 +4,7 @@
 
 yices2_version=98fa2d882d83d32a07d3b8b2c562819e0e0babd0
 
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)
 deps_dir=$script_dir/../deps
 
 mkdir -p $deps_dir

--- a/configure.sh
+++ b/configure.sh
@@ -71,7 +71,7 @@ z3_install_dir=default
 
 build_type=Release
 
-cmake_opts=""
+cmake_opts=
 
 while [ $# -gt 0 ]; do
   case $1 in
@@ -201,15 +201,15 @@ while [ $# -gt 0 ]; do
       ;;
     --bitwuzla-dir) die "missing argument to $1 (see -h)" ;;
     --bitwuzla-dir=*)
-      bitwuzla_dir="${1##*=}"
+      bitwuzla_dir=${1##*=}
       # Make relative paths absolute
-      bitwuzla_dir="$(cd -- "$bitwuzla_dir" && pwd)"
+      bitwuzla_dir=$(cd -- "$bitwuzla_dir" && pwd)
       ;;
     --z3-install-dir) die "missing argument to $1 (see -h)" ;;
     --z3-install-dir=*)
       z3_install_dir=${1##*=}
       # Make relative paths absolute
-      z3_install_dir="$(cd -- "$z3_install_dir" && pwd)"
+      z3_install_dir=$(cd -- "$z3_install_dir" && pwd)
       ;;
     -D*) cmake_opts="${cmake_opts} $1" ;;
     *) die "unexpected argument: $1" ;;

--- a/contrib/common-setup.sh
+++ b/contrib/common-setup.sh
@@ -4,30 +4,30 @@ set -u          # unset variable raises error
 set -o pipefail # exit if an intermediate command in a pipe fails
 
 # Set up paths needed for the rest of the script.
-setup_script_path="$(realpath "$0")"
-setup_script_name="$(basename "$setup_script_path" .sh)"
+setup_script_path=$(realpath "$0")
+setup_script_name=$(basename "$setup_script_path" .sh)
 dep_name="${setup_script_name##*setup-}" # remove "setup-" from script name
-this_script_path="$(realpath "${BASH_SOURCE[0]}")"
-contrib_dir="$(dirname "$this_script_path")"
-pkg_config_dir="$contrib_dir/pkgconfig"
-deps_dir="$(dirname "$contrib_dir")/deps"
-install_dir="$deps_dir/install"
-install_includedir="$install_dir/include"
-install_libdir="$install_dir/lib"
-install_pkgconfigdir="$install_libdir/pkgconfig"
+this_script_path=$(realpath "${BASH_SOURCE[0]}")
+contrib_dir=$(dirname "$this_script_path")
+pkg_config_dir=$contrib_dir/pkgconfig
+deps_dir=$(dirname "$contrib_dir")/deps
+install_dir=$deps_dir/install
+install_includedir=$install_dir/include
+install_libdir=$install_dir/lib
+install_pkgconfigdir=$install_libdir/pkgconfig
 
 # Tell CMake/Meson where the pkg-config files are.
 if [[ -z ${PKG_CONFIG_PATH-} ]]; then
-  export PKG_CONFIG_PATH="$install_pkgconfigdir"
+  export PKG_CONFIG_PATH=$install_pkgconfigdir
 else
-  export PKG_CONFIG_PATH="$install_pkgconfigdir:$PKG_CONFIG_PATH"
+  export PKG_CONFIG_PATH=$install_pkgconfigdir:$PKG_CONFIG_PATH
 fi
 
 # Get the number of CPUs for parallel builds.
 if [[ $(uname) == Darwin ]]; then
   num_cores=$(sysctl -n hw.logicalcpu)
 elif [[ $(uname -s) =~ Linux* ]]; then
-  num_cores="$(nproc)"
+  num_cores=$(nproc)
 else
   num_cores=1
 fi
@@ -44,18 +44,18 @@ if ! declare -F download_step >/dev/null; then
   download_step() {
     # Set download URL to GitHub by default.
     github_owner="${github_owner:=$dep_name}" # default owner is same as repo name
-    github_archive_url="https://github.com/$github_owner/$dep_name/archive"
+    github_archive_url=https://github.com/$github_owner/$dep_name/archive
     if [[ -n ${git_commit-} ]]; then
-      source_url="$github_archive_url/$git_commit.tar.gz"
-      version="$git_commit"
+      source_url=$github_archive_url/$git_commit.tar.gz
+      version=$git_commit
     elif [[ -n ${git_tag-} ]]; then
-      source_url="$github_archive_url/refs/tags/$git_tag.tar.gz"
-      version="$git_tag"
+      source_url=$github_archive_url/refs/tags/$git_tag.tar.gz
+      version=$git_tag
     elif [[ -n ${git_branch-} ]]; then
-      source_url="$github_archive_url/refs/heads/$git_branch.tar.gz"
-      version="$git_branch"
+      source_url=$github_archive_url/refs/heads/$git_branch.tar.gz
+      version=$git_branch
     fi
-    dep_filename="$dep_name-$version"
+    dep_filename=$dep_name-$version
     wget -O "$dep_filename.tar.gz" "$source_url"
     tar -xf "$dep_filename.tar.gz"
     rm "$dep_filename.tar.gz"

--- a/contrib/setup-cadical.sh
+++ b/contrib/setup-cadical.sh
@@ -10,7 +10,7 @@ configure_step() {
 install_step() {
   # Bitwuzla expects the Cadical header to be at include/cadical/cadical.hpp,
   # while Boolector requires include/ccadical.h.
-  install_cadical_includedir="$install_includedir/cadical"
+  install_cadical_includedir=$install_includedir/cadical
   install -d "$install_cadical_includedir" "$install_libdir"
   install -Cm644 src/ccadical.h "$install_includedir"
   install -Cm644 src/cadical.hpp "$install_cadical_includedir"

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 # get the absolute path to this directory
-script_dir="$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)"
+script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)
 
 set -e
 


### PR DESCRIPTION
The right-hand side of an assignment is not subject to word splitting or pathname expansion, so quoting it is unnecessary. POSIX puts this under Shell Command Language, 2.9.1 Simple Commands: the assignment value undergoes tilde, parameter, command and arithmetic expansion, and quote removal, but not field splitting or pathname expansion.

39 lines lose their quotes across 7 files, mostly path joins in contrib/common-setup.sh and the hash accumulation in compute-solver-hash.sh:

    -install_dir="$deps_dir/install"
    +install_dir=$deps_dir/install
    
    -solver_hash+="$(gethash contrib/common-setup.sh)"
    +solver_hash+=$(gethash contrib/common-setup.sh)

Quotes are kept wherever they do something. Three lines in scripts/repack-static-lib.sh keep theirs:

    mri_command="create $target"
    mri_command="${mri_command}\naddlib $lib"
    mri_command="${mri_command}\nsave\nend"

The first two hold a literal space, and the third would lose its backslashes to quote removal and produce "nsavenend". The 21 `cmake_opts="$cmake_opts -D..."` lines in configure.sh keep theirs for the same reason, a literal space. Quotes nested inside a command substitution are also untouched, since those are in argument position and do split: `$(realpath "$0")` keeps the inner pair.

Every assignment that still carries quotes after this therefore needs them.

Each candidate was checked rather than pattern-matched, by evaluating the quoted and unquoted forms with the same inputs and comparing the value and exit status; the three above are exactly the ones that failed that check. Verified afterwards that every script still parses, that shfmt is unchanged, that shellcheck reports the same 43 findings as before, and that configure.sh produces a byte-identical option list across 25 flag combinations and 9 error paths. The four symlinked ci-scripts entry points were run to confirm they still resolve their libraries.

Nothing enforces this. shellcheck has no such rule and its quote-safe-variables check argues the other way for variable references, bashate has no quoting rules at all, and shfmt only removes redundant quotes inside [[ ]]. It is a review convention.