### PR TITLE
fix: Enable shellcheck and clear all findings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,26 +77,24 @@ repos:
       - id: shfmt
         args: [-w, -i, "2", -ci, -s]
 
-  # The hooks below are not enabled yet because the tree does not satisfy them.
-  # Each needs its own pass before it can be turned on:
+  - repo: https://github.com/shellcheck-py/shellcheck-py
+    rev: v0.11.0.1-1
+    hooks:
+      # Configured by .shellcheckrc, which turns on external-sources so that
+      # the `# shellcheck source=` directives in contrib/setup-*.sh resolve
+      # no matter which files a given commit stages.
+      - id: shellcheck
+
+  # The hook below is not enabled yet because the tree does not satisfy it:
   #
   #   clang-format  86 of 229 C/C++ files would be rewritten (~1350 lines).
   #                 Needs a bulk-reformat commit plus a .git-blame-ignore-revs
   #                 entry. Note .clang-format is already committed.
   #
-  #   shellcheck    43 findings in 7 of 22 scripts. Most are missing quotes
-  #                 that can simply be added, but configure.sh accumulates its
-  #                 CMake options in one string that has to word-split, so it
-  #                 needs a rewrite onto positional parameters first.
-  #
-  # Dependabot cannot bump commented-out repos, so re-check these revisions
-  # with `pre-commit autoupdate` when enabling them.
+  # Dependabot cannot bump commented-out repos, so re-check this revision
+  # with `pre-commit autoupdate` when enabling it.
   #
   # - repo: https://github.com/pre-commit/mirrors-clang-format
   #   rev: v23.1.0
   #   hooks:
   #     - id: clang-format
-  # - repo: https://github.com/shellcheck-py/shellcheck-py
-  #   rev: v0.11.0.1-1
-  #   hooks:
-  #     - id: shellcheck

--- a/.shellcheckrc
+++ b/.shellcheckrc
@@ -1,0 +1,16 @@
+# Follow `# shellcheck source=` directives into the sourced contrib/ libraries.
+#
+# Without this, shellcheck only resolves a sourced file when that file also
+# happens to be one of the paths on the command line, so the findings for
+# contrib/setup-*.sh would depend on which files a given commit staged.
+external-sources=true
+
+# Turn on every optional check, then switch off the ones we do not want. New
+# optional checks introduced by a shellcheck upgrade are therefore opt-out
+# rather than opt-in.
+enable=all
+
+# SC2250, from require-variable-braces, asks for ${var} in place of $var
+# everywhere. That is 182 rewrites across 17 files with no correctness benefit,
+# and the tree is consistent in not using braces unless they are needed.
+disable=SC2250

--- a/ci-scripts/cibw-build-before.sh
+++ b/ci-scripts/cibw-build-before.sh
@@ -24,6 +24,6 @@ python_executable=$(command -v python3)
 echo "Using Python_EXECUTABLE: ${python_executable}"
 
 # configure for all solvers with permissive licenses (BSD, MIT, etc..)
-./configure.sh --bitwuzla --cvc5 --z3 --python --python-executable=${python_executable}
+./configure.sh --bitwuzla --cvc5 --z3 --python --python-executable="${python_executable}"
 cd build
 make -j

--- a/ci-scripts/cibw-build-deps.sh
+++ b/ci-scripts/cibw-build-deps.sh
@@ -17,12 +17,14 @@
 set -e
 
 python3 -m venv ./build-deps-env
+# shellcheck source=/dev/null  # created by the venv above, absent at lint time
 source ./build-deps-env/bin/activate
 python3 -m pip install meson pyparsing tomli
 
 ./contrib/setup-bitwuzla.sh
 # the version of ld.gold is too old in manylinux_2_28, remove it so cvc5 falls back on bfd
 rm -f /usr/bin/ld.gold
+# shellcheck source=/dev/null  # created by the venv above, absent at lint time
 source ./build-deps-env/bin/activate
 ./contrib/setup-cvc5.sh
 ./contrib/setup-z3.sh

--- a/ci-scripts/compute-solver-hash.sh
+++ b/ci-scripts/compute-solver-hash.sh
@@ -21,4 +21,5 @@ fi
 if [[ $solver == btor ]]; then
   solver_hash+=$(gethash contrib/setup-btor2tools.sh)
 fi
-echo "result=$(gethash <(echo "$solver_hash"))" >>"$GITHUB_OUTPUT"
+result=$(gethash <(echo "$solver_hash"))
+echo "result=$result" >>"${GITHUB_OUTPUT:?}"

--- a/ci-scripts/install-packages-macos.sh
+++ b/ci-scripts/install-packages-macos.sh
@@ -9,9 +9,12 @@ brew install \
   meson \
   python-packaging
 
+brew_prefix=$(brew --prefix)
+bison_prefix=$(brew --prefix bison)
+
 {
-  echo "CPATH=$(brew --prefix)/include"
-  echo "LIBRARY_PATH=$(brew --prefix)/lib"
-  echo "PKG_CONFIG_PATH=$(brew --prefix)/lib/pkgconfig"
-  echo "PATH=$(brew --prefix bison)/bin:$(brew --prefix)/bin:$PATH"
-} >>"$GITHUB_ENV"
+  echo "CPATH=$brew_prefix/include"
+  echo "LIBRARY_PATH=$brew_prefix/lib"
+  echo "PKG_CONFIG_PATH=$brew_prefix/lib/pkgconfig"
+  echo "PATH=$bison_prefix/bin:$brew_prefix/bin:$PATH"
+} >>"${GITHUB_ENV:?}"

--- a/ci-scripts/setup-msat.sh
+++ b/ci-scripts/setup-msat.sh
@@ -40,7 +40,7 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 mkdir -p deps && cd deps
 
 if [[ -d mathsat ]]; then
-  echo "$(pwd)/mathsat already exists. If you want to re-download, please remove it manually."
+  echo "$PWD/mathsat already exists. If you want to re-download, please remove it manually."
 else
   release_url=https://mathsat.fbk.eu/release
   if [[ $OSTYPE =~ linux* ]]; then

--- a/ci-scripts/setup-yices2.sh
+++ b/ci-scripts/setup-yices2.sh
@@ -1,4 +1,5 @@
 #!/bin/bash
+set -euo pipefail
 
 # requires autoconf, gperf
 
@@ -7,31 +8,32 @@ yices2_version=98fa2d882d83d32a07d3b8b2c562819e0e0babd0
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)
 deps_dir=$script_dir/../deps
 
-mkdir -p $deps_dir
+mkdir -p "$deps_dir"
 
-if [ "$(uname)" == "Darwin" ]; then
+kernel_name=$(uname -s)
+if [[ $kernel_name == "Darwin" ]]; then
   num_cores=$(sysctl -n hw.logicalcpu)
-elif [ "$(expr substr $(uname -s) 1 5)" == "Linux" ]; then
+elif [[ $kernel_name == "Linux" ]]; then
   num_cores=$(nproc)
 else
   num_cores=1
 fi
 
-if [ ! -d "$deps_dir/yices2" ]; then
-  cd $deps_dir
+if [[ ! -d "$deps_dir/yices2" ]]; then
+  cd "$deps_dir"
   git clone https://github.com/SRI-CSL/yices2.git
   chmod -R 777 yices2
   cd yices2
-  git checkout -f $yices2_version
+  git checkout -f "$yices2_version"
   autoconf
   ./configure --enable-thread-safety
-  make build_dir=build BUILD=build -j$num_cores
-  cd $script_dir
+  make build_dir=build BUILD=build -j"$num_cores"
+  cd "$script_dir"
 else
   echo "$deps_dir/yices2 already exists. If you want to rebuild, please remove it manually."
 fi
 
-if [ -f $deps_dir/yices2/build/lib/libyices.a ]; then
+if [[ -f "$deps_dir/yices2/build/lib/libyices.a" ]]; then
   echo "It appears yices2 was setup successfully into $deps_dir/yices2."
   echo "You may now install it with make ./configure.sh --yices2 && cd build && make"
 else

--- a/configure.sh
+++ b/configure.sh
@@ -2,8 +2,6 @@
 
 # Syntax and structure borrowed from CVC5's configure.sh script
 
-CONF_FILE=Makefile.conf
-
 usage() {
   cat <<EOF
 Usage: $0 [<option> ...]
@@ -71,14 +69,20 @@ z3_install_dir=default
 
 build_type=Release
 
-cmake_opts=
-
-while [ $# -gt 0 ]; do
-  case $1 in
+# Rotate once through the arguments. Each flag is consumed here; anything that
+# has to reach CMake is pushed back onto "$@", so that after the loop "$@"
+# holds exactly the CMake options, each one still a single word.
+argc=$#
+i=0
+while [ "$i" -lt "$argc" ]; do
+  arg=$1
+  shift
+  i=$((i + 1))
+  case $arg in
     -h | --help) usage ;;
-    --prefix) die "missing argument to $1 (see -h)" ;;
+    --prefix) die "missing argument to $arg (see -h)" ;;
     --prefix=*)
-      install_prefix=${1##*=}
+      install_prefix=${arg##*=}
       # Check if install_prefix is an absolute path and if not, make it
       # absolute.
       case $install_prefix in
@@ -104,9 +108,9 @@ while [ $# -gt 0 ]; do
     --z3)
       build_z3=ON
       ;;
-    --btor-home) die "missing argument to $1 (see -h)" ;;
+    --btor-home) die "missing argument to $arg (see -h)" ;;
     --btor-home=*)
-      btor_home=${1##*=}
+      btor_home=${arg##*=}
       # Check if btor_home is an absolute path and if not, make it
       # absolute.
       case $btor_home in
@@ -114,9 +118,9 @@ while [ $# -gt 0 ]; do
         *) btor_home=$(pwd)/$btor_home ;; # make absolute path
       esac
       ;;
-    --cvc5-home) die "missing argument to $1 (see -h)" ;;
+    --cvc5-home) die "missing argument to $arg (see -h)" ;;
     --cvc5-home=*)
-      cvc5_home=${1##*=}
+      cvc5_home=${arg##*=}
       # Check if cvc5_home is an absolute path and if not, make it
       # absolute.
       case $cvc5_home in
@@ -124,9 +128,9 @@ while [ $# -gt 0 ]; do
         *) cvc5_home=$(pwd)/$cvc5_home ;; # make absolute path
       esac
       ;;
-    --msat-home) die "missing argument to $1 (see -h)" ;;
+    --msat-home) die "missing argument to $arg (see -h)" ;;
     --msat-home=*)
-      msat_home=${1##*=}
+      msat_home=${arg##*=}
       # Check if msat_home is an absolute path and if not, make it
       # absolute.
       case $msat_home in
@@ -134,9 +138,9 @@ while [ $# -gt 0 ]; do
         *) msat_home=$(pwd)/$msat_home ;; # make absolute path
       esac
       ;;
-    --yices2-home) die "missing argument to $1 (see -h)" ;;
+    --yices2-home) die "missing argument to $arg (see -h)" ;;
     --yices2-home=*)
-      yices2_home=${1##*=}
+      yices2_home=${arg##*=}
       # Check if yices2_home is an absolute path and if not, make it
       # absolute.
       case $yices2_home in
@@ -144,9 +148,9 @@ while [ $# -gt 0 ]; do
         *) yices2_home=$(pwd)/$yices2_home ;; # make absolute path
       esac
       ;;
-    --build-dir) die "missing argument to $1 (see -h)" ;;
+    --build-dir) die "missing argument to $arg (see -h)" ;;
     --build-dir=*)
-      build_dir=${1##*=}
+      build_dir=${arg##*=}
       # Check if build_dir is an absolute path and if not, make it
       # absolute.
       case $build_dir in
@@ -170,7 +174,7 @@ while [ $# -gt 0 ]; do
       python=yes
       ;;
     --python-executable=*)
-      python_executable=${1##*=}
+      python_executable=${arg##*=}
       # Check if python_executable is an absolute path and if not, make it
       # absolute.
       case $python_executable in
@@ -182,7 +186,7 @@ while [ $# -gt 0 ]; do
       smtlib_reader=yes
       ;;
     --bison-dir=*)
-      bison_dir=${1##*=}
+      bison_dir=${arg##*=}
       # Check if bison_dir is an absolute path and if not, make it
       # absolute.
       case $bison_dir in
@@ -191,7 +195,7 @@ while [ $# -gt 0 ]; do
       esac
       ;;
     --flex-dir=*)
-      flex_dir=${1##*=}
+      flex_dir=${arg##*=}
       # Check if flex_dir is an absolute path and if not, make it
       # absolute.
       case $flex_dir in
@@ -199,105 +203,107 @@ while [ $# -gt 0 ]; do
         *) flex_dir=$(pwd)/$flex_dir ;; # make absolute path
       esac
       ;;
-    --bitwuzla-dir) die "missing argument to $1 (see -h)" ;;
+    --bitwuzla-dir) die "missing argument to $arg (see -h)" ;;
     --bitwuzla-dir=*)
-      bitwuzla_dir=${1##*=}
+      bitwuzla_dir=${arg##*=}
       # Make relative paths absolute
       bitwuzla_dir=$(cd -- "$bitwuzla_dir" && pwd)
       ;;
-    --z3-install-dir) die "missing argument to $1 (see -h)" ;;
+    --z3-install-dir) die "missing argument to $arg (see -h)" ;;
     --z3-install-dir=*)
-      z3_install_dir=${1##*=}
+      z3_install_dir=${arg##*=}
       # Make relative paths absolute
       z3_install_dir=$(cd -- "$z3_install_dir" && pwd)
       ;;
-    -D*) cmake_opts="${cmake_opts} $1" ;;
-    *) die "unexpected argument: $1" ;;
+    -D*) set -- "$@" "$arg" ;;
+    *) die "unexpected argument: $arg" ;;
   esac
-  shift
 done
 
 # enable solvers automatically if a custom home is provided
-if [ $btor_home != default -a $build_btor = default ]; then
+if [ "$btor_home" != default ] && [ "$build_btor" = default ]; then
   build_btor=ON
 fi
 
-if [ $cvc5_home != default -a $build_cvc5 = default ]; then
+if [ "$cvc5_home" != default ] && [ "$build_cvc5" = default ]; then
   build_cvc5=ON
 fi
 
-if [ $msat_home != default -a $build_msat = default ]; then
+if [ "$msat_home" != default ] && [ "$build_msat" = default ]; then
   build_msat=ON
 fi
 
-if [ $yices2_home != default -a $build_yices2 = default ]; then
+if [ "$yices2_home" != default ] && [ "$build_yices2" = default ]; then
   build_yices2=ON
 fi
 
-cmake_opts="$cmake_opts -DCMAKE_BUILD_TYPE=$build_type"
+# "$@" already holds any -D options given on the command line. Append the
+# options derived from the flags above, so that an explicit -D comes first and
+# the derived value wins if both set the same variable.
+set -- "$@" "-DCMAKE_BUILD_TYPE=$build_type"
 
-[ $install_prefix != default ] &&
-  cmake_opts="$cmake_opts -DCMAKE_INSTALL_PREFIX=$install_prefix"
+[ "$install_prefix" != default ] &&
+  set -- "$@" "-DCMAKE_INSTALL_PREFIX=$install_prefix"
 
-[ $build_btor != default ] &&
-  cmake_opts="$cmake_opts -DBUILD_BTOR=$build_btor"
+[ "$build_btor" != default ] &&
+  set -- "$@" "-DBUILD_BTOR=$build_btor"
 
-[ $build_bitwuzla != default ] &&
-  cmake_opts="$cmake_opts -DBUILD_BITWUZLA=$build_bitwuzla"
+[ "$build_bitwuzla" != default ] &&
+  set -- "$@" "-DBUILD_BITWUZLA=$build_bitwuzla"
 
-[ $build_cvc5 != default ] &&
-  cmake_opts="$cmake_opts -DBUILD_CVC5=$build_cvc5"
+[ "$build_cvc5" != default ] &&
+  set -- "$@" "-DBUILD_CVC5=$build_cvc5"
 
-[ $build_msat != default ] &&
-  cmake_opts="$cmake_opts -DBUILD_MSAT=$build_msat"
+[ "$build_msat" != default ] &&
+  set -- "$@" "-DBUILD_MSAT=$build_msat"
 
-[ $build_yices2 != default ] &&
-  cmake_opts="$cmake_opts -DBUILD_YICES2=$build_yices2"
+[ "$build_yices2" != default ] &&
+  set -- "$@" "-DBUILD_YICES2=$build_yices2"
 
-[ $build_z3 != default ] &&
-  cmake_opts="$cmake_opts -DBUILD_Z3=$build_z3"
+[ "$build_z3" != default ] &&
+  set -- "$@" "-DBUILD_Z3=$build_z3"
 
-[ $btor_home != default ] &&
-  cmake_opts="$cmake_opts -DBTOR_HOME=$btor_home"
+[ "$btor_home" != default ] &&
+  set -- "$@" "-DBTOR_HOME=$btor_home"
 
-[ $cvc5_home != default ] &&
-  cmake_opts="$cmake_opts -DCVC5_HOME=$cvc5_home"
+[ "$cvc5_home" != default ] &&
+  set -- "$@" "-DCVC5_HOME=$cvc5_home"
 
-[ $msat_home != default ] &&
-  cmake_opts="$cmake_opts -DMSAT_HOME=$msat_home"
+[ "$msat_home" != default ] &&
+  set -- "$@" "-DMSAT_HOME=$msat_home"
 
-[ $yices2_home != default ] &&
-  cmake_opts="$cmake_opts -DYICES2_HOME=$yices2_home"
+[ "$yices2_home" != default ] &&
+  set -- "$@" "-DYICES2_HOME=$yices2_home"
 
-[ $static != default ] &&
-  cmake_opts="$cmake_opts -DSMT_SWITCH_LIB_TYPE=STATIC"
+[ "$static" != default ] &&
+  set -- "$@" "-DSMT_SWITCH_LIB_TYPE=STATIC"
 
-[ $build_tests != default ] &&
-  cmake_opts="$cmake_opts -DBUILD_TESTS=$build_tests"
+[ "$build_tests" != default ] &&
+  set -- "$@" "-DBUILD_TESTS=$build_tests"
 
-[ $system_gtest != default ] &&
-  cmake_opts="$cmake_opts -DSYSTEM_GTEST=$system_gtest"
+[ "$system_gtest" != default ] &&
+  set -- "$@" "-DSYSTEM_GTEST=$system_gtest"
 
-[ $python != default ] &&
-  cmake_opts="$cmake_opts -DBUILD_PYTHON_BINDINGS=ON"
+[ "$python" != default ] &&
+  set -- "$@" "-DBUILD_PYTHON_BINDINGS=ON"
 
-[ $python_executable != default ] &&
-  cmake_opts="$cmake_opts -DPython_EXECUTABLE=$python_executable"
+[ "$python_executable" != default ] &&
+  set -- "$@" "-DPython_EXECUTABLE=$python_executable"
 
-[ $smtlib_reader != default ] &&
-  cmake_opts="$cmake_opts -DSMTLIB_READER=ON"
+[ "$smtlib_reader" != default ] &&
+  set -- "$@" "-DSMTLIB_READER=ON"
 
-[ $bison_dir != default ] &&
-  cmake_opts="$cmake_opts -DBISON_DIR=$bison_dir"
+[ "$bison_dir" != default ] &&
+  set -- "$@" "-DBISON_DIR=$bison_dir"
 
-[ $flex_dir != default ] &&
-  cmake_opts="$cmake_opts -DFLEX_DIR=$flex_dir"
+[ "$flex_dir" != default ] &&
+  set -- "$@" "-DFLEX_DIR=$flex_dir"
 
-[ $bitwuzla_dir != default ] &&
-  cmake_opts="$cmake_opts -DBITWUZLA_DIR=$bitwuzla_dir"
+[ "$bitwuzla_dir" != default ] &&
+  set -- "$@" "-DBITWUZLA_DIR=$bitwuzla_dir"
 
-[ $z3_install_dir != default ] &&
-  cmake_opts="$cmake_opts -DZ3_INSTALL_DIR=$z3_install_dir"
+[ "$z3_install_dir" != default ] &&
+  set -- "$@" "-DZ3_INSTALL_DIR=$z3_install_dir"
 
 mkdir -p "$build_dir"
 cd "$build_dir" || exit 1
@@ -305,5 +311,5 @@ cd "$build_dir" || exit 1
 # Reset build configuration.
 [ -e CMakeCache.txt ] && rm CMakeCache.txt
 
-echo "Running with cmake options: $cmake_opts"
-cmake .. $cmake_opts 2>&1
+echo "Running with cmake options: $*"
+cmake .. "$@" 2>&1

--- a/contrib/cmake-setup.sh
+++ b/contrib/cmake-setup.sh
@@ -21,5 +21,6 @@ install_step() {
   cmake --install build
 }
 
+_setup_script_path=$(realpath "$0")
 # shellcheck source=contrib/common-setup.sh
-source "$(dirname "$(realpath "$0")")/common-setup.sh"
+source "$(dirname "$_setup_script_path")/common-setup.sh"

--- a/contrib/common-setup.sh
+++ b/contrib/common-setup.sh
@@ -1,4 +1,16 @@
 # shellcheck shell=bash
+#
+# Several of the variables set below are not read here but by the
+# contrib/setup-*.sh front-ends that source this file. shellcheck only looks
+# forward from a `source` directive, so it cannot see those uses.
+# shellcheck disable=SC2034
+#
+# Every script in this directory resolves $0 through realpath before taking
+# its dirname, both here and in the front-ends that source their library that
+# way. That is because ci-scripts/setup-{bitwuzla,btor,cvc5,z3}.sh are symlinks
+# into this directory: `dirname "$0"` on its own yields ci-scripts/ and would
+# not find the library. realpath is assigned to a variable rather than nested
+# inside the source command so that a failure is not swallowed (SC2312).
 set -e          # exit on error
 set -u          # unset variable raises error
 set -o pipefail # exit if an intermediate command in a pipe fails
@@ -24,9 +36,10 @@ else
 fi
 
 # Get the number of CPUs for parallel builds.
-if [[ $(uname) == Darwin ]]; then
+kernel_name=$(uname -s)
+if [[ $kernel_name == Darwin ]]; then
   num_cores=$(sysctl -n hw.logicalcpu)
-elif [[ $(uname -s) =~ Linux* ]]; then
+elif [[ $kernel_name =~ Linux* ]]; then
   num_cores=$(nproc)
 else
   num_cores=1

--- a/contrib/meson-setup.sh
+++ b/contrib/meson-setup.sh
@@ -19,5 +19,6 @@ install_step() {
   meson install -C build
 }
 
+_setup_script_path=$(realpath "$0")
 # shellcheck source=contrib/common-setup.sh
-source "$(dirname "$(realpath "$0")")/common-setup.sh"
+source "$(dirname "$_setup_script_path")/common-setup.sh"

--- a/contrib/setup-bitwuzla.sh
+++ b/contrib/setup-bitwuzla.sh
@@ -9,5 +9,6 @@ configure_step() {
   ./configure.py --prefix "$install_dir"
 }
 
+_setup_script_path=$(realpath "$0")
 # shellcheck source=contrib/meson-setup.sh
-source "$(dirname "$(realpath "$0")")/meson-setup.sh"
+source "$(dirname "$_setup_script_path")/meson-setup.sh"

--- a/contrib/setup-boolector.sh
+++ b/contrib/setup-boolector.sh
@@ -7,5 +7,6 @@ prepare_step() {
   "$contrib_dir/setup-btor2tools.sh"
 }
 
+_setup_script_path=$(realpath "$0")
 # shellcheck source=contrib/cmake-setup.sh
-source "$(dirname "$(realpath "$0")")/cmake-setup.sh"
+source "$(dirname "$_setup_script_path")/cmake-setup.sh"

--- a/contrib/setup-btor2tools.sh
+++ b/contrib/setup-btor2tools.sh
@@ -2,5 +2,6 @@
 git_commit=fb69ee3b95e8baa5f0a9a6b0b19ee8beaad52932
 github_owner=hwmcc
 
+_setup_script_path=$(realpath "$0")
 # shellcheck source=contrib/cmake-setup.sh
-source "$(dirname "$(realpath "$0")")/cmake-setup.sh"
+source "$(dirname "$_setup_script_path")/cmake-setup.sh"

--- a/contrib/setup-cvc5.sh
+++ b/contrib/setup-cvc5.sh
@@ -6,5 +6,6 @@ prepare_step() {
   "$contrib_dir/setup-cadical.sh"
 }
 
+_setup_script_path=$(realpath "$0")
 # shellcheck source=contrib/cmake-setup.sh
-source "$(dirname "$(realpath "$0")")/cmake-setup.sh"
+source "$(dirname "$_setup_script_path")/cmake-setup.sh"

--- a/contrib/setup-z3.sh
+++ b/contrib/setup-z3.sh
@@ -3,5 +3,6 @@ git_tag=z3-4.14.1
 github_owner=Z3Prover
 cmake_options=(-DZ3_BUILD_LIBZ3_SHARED=Off)
 
+_setup_script_path=$(realpath "$0")
 # shellcheck source=contrib/cmake-setup.sh
-source "$(dirname "$(realpath "$0")")/cmake-setup.sh"
+source "$(dirname "$_setup_script_path")/cmake-setup.sh"

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -2,7 +2,7 @@
 # get the absolute path to this directory
 script_dir=$(cd "$(dirname "${BASH_SOURCE[0]}")" >/dev/null 2>&1 && pwd)
 
-set -e
+set -euo pipefail
 
 help_message() {
   echo "usage: $0 [--python]"
@@ -11,32 +11,27 @@ help_message() {
   exit 0
 }
 
-if [[ $1 == "--help" ]]; then
-  help_message
-fi
-
-if [ $# -gt 2 ]; then
-  help_message
-elif [[ $# -eq 1 && $1 != "--python" ]]; then
+# The only accepted invocations are no arguments at all, or exactly --python.
+if [[ $# -ne 0 && $* != "--python" ]]; then
   help_message
 fi
 
 # go to main repo directory
-cd $script_dir/..
+cd "$script_dir/.."
 
 # configure and build smt-switch with boolector and cvc5 backends
 # set it up to be installed in a directory called example-install in the examples directory
 # also use a build directory in the examples directory
-./configure.sh --btor --cvc5 --prefix=./examples/example-install --build-dir=$script_dir/example-build $1
-cd $script_dir/example-build
+./configure.sh --btor --cvc5 --prefix=./examples/example-install --build-dir="$script_dir/example-build" "$@"
+cd "$script_dir/example-build"
 make
 make test
 make install
 
-cd $script_dir
+cd "$script_dir"
 # now make the examples
 make
 
 # install python bindings with pip
 # this line might need to be adjusted depending on your current python environment
-python3 -m pip install -e $script_dir/example-build/python
+python3 -m pip install -e "$script_dir/example-build/python"

--- a/scripts/repack-static-lib.sh
+++ b/scripts/repack-static-lib.sh
@@ -1,6 +1,6 @@
 #!/bin/bash
 
-if [ $# -lt 2 ]; then
+if [[ $# -lt 2 ]]; then
   echo "usage: $0 <libname> [...libs to combine]"
   exit 1
 fi
@@ -22,7 +22,7 @@ if [[ $OSTYPE == linux* || $OSTYPE == cygwin* ]]; then
   mri_command="${mri_command}\nsave\nend"
   echo -e "$mri_command" | ar -M
 
-  if [ ! -f "${target}" ]; then
+  if [[ ! -f ${target} ]]; then
     echo "It appears ar failed to create ${target}"
     exit 1
   fi
@@ -34,7 +34,7 @@ elif [[ $OSTYPE == darwin* ]]; then
     exit
   fi
 
-  libtool -static -o $@
+  libtool -static -o "$@"
 elif [[ $OSTYPE == msys* ]]; then
   echo "$0 does not support repacking static libs on Windows yet"
 else


### PR DESCRIPTION
Turns on the shellcheck hook and adds `.shellcheckrc`: 43 findings from
the default rules and 27 from the optional ones, all fixed rather than
suppressed except for the two noted at the end.

The config lives in a file, not in the hook's args, so that editors and
CI agree. It sets:

- `external-sources=true`, so `# shellcheck source=` is followed into
  `contrib/`. Without it the findings for `contrib/setup-*.sh` depend on
  which files a commit happens to stage, since the hook passes only
  those.
- `enable=all`, opting into the 11 checks that are off by default so
  that anything a future release adds is not silently unenforced.
- `disable=SC2250`, declining `${var}` everywhere: 182 rewrites, no
  correctness benefit.

`configure.sh` was 20 of the findings and the reason this hook stayed
off. Of its 15 SC2086 hits, 14 were unquoted `$var` in `[ ]` tests,
which quote cleanly. The last, `cmake .. $cmake_opts`, built up a string
and relied on the shell to split it back into words. It now uses
positional parameters: the argument loop rotates through `"$@"`, pushing
anything bound for CMake back onto it, the option blocks append with
`set -- "$@" "-DFOO=$foo"`, and the call is `cmake .. "$@"`. That fixes
a latent bug, since an option holding whitespace used to be split apart,
so `--prefix="/tmp/my path"` reached CMake as two arguments. Checked
over 25 flag combinations and 9 error paths that nothing else moved; the
only visible difference is a stray double space gone from the "Running
with cmake options:" line. Also dropped the dead `CONF_FILE` assignment
and replaced `[ p -a q ]` with `[ p ] && [ q ]`, since `-a` is not well
defined.

The rest:

- `scripts/repack-static-lib.sh` held the only error-severity finding,
  SC2068, and a real macOS bug: `libtool -static -o $@` re-split each
  path on whitespace, so two quoted paths arrived as four arguments.
- `ci-scripts/setup-yices2.sh` gets `set -euo pipefail` rather than the
  `cd ... || exit 1` that SC2164 asks for. Both satisfy the check, but
  the former guards every command, and this was the only script under
  `ci-scripts/` without it. Given a `git` that fails on clone, the
  script used to carry on and run `git checkout -f`, autoconf and make
  from the wrong directory. The trade is that its "Building yices2
  failed" block is no longer reached when a build step fails, since the
  script now exits at the failure; the block still covers a build that
  reports success without producing `libyices.a`.
- `examples/build.sh` gets `set -euo pipefail`, and its three argument
  checks collapse to `[[ $# -ne 0 && $* != "--python" ]]`. Both halves
  are needed: `$#` alone cannot tell `--python` from `--python extra`,
  and `$*` alone reads a single empty argument as none. The count has to
  come first, because under `set -u` testing `$1` before knowing there
  is one makes a plain `build.sh` die.
- `contrib/*.sh` hoist `$(realpath "$0")` and `$(uname -s)` into
  variables for SC2312, and use `[[ ]]` for SC2292. The realpath calls
  have to stay: `ci-scripts/setup-{bitwuzla,btor,cvc5,z3}.sh` are
  symlinks into `contrib/`, where a plain `dirname "$0"` would yield
  `ci-scripts/`. The new variable is `_setup_script_path`, since
  `common-setup.sh` already owns `setup_script_path`.
- `GITHUB_ENV` and `GITHUB_OUTPUT` become `"${GITHUB_ENV:?}"`, which
  satisfies check-unassigned-uppercase and, unlike a suppression, fails
  with a named variable if the script is run outside Actions.

Two findings are suppressed as limits of static analysis:
`contrib/common-setup.sh` sets three variables for the front-ends that
source it, which shellcheck cannot see, and
`ci-scripts/cibw-build-deps.sh` sources a virtualenv activate script
created on the preceding line.