### PR TITLE
style: Enable bashate and wrap the long lines

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -85,6 +85,21 @@ repos:
       # no matter which files a given commit stages.
       - id: shellcheck
 
+  - repo: https://github.com/openstack/bashate
+    rev: 2.1.1
+    hooks:
+      # -i E003 drops "indent not a multiple of 4": bashate hardcodes a
+      # 4-space rule with no way to configure the width, which contradicts the
+      # `shfmt -i 2` above.
+      #
+      # -e E promotes every remaining rule to an error. Some of them, E006
+      # among them, are warnings by default, and bashate exits 0 on a warning;
+      # pre-commit hides the output of a hook that passes, so those would
+      # never be seen. The ignore above still wins, since bashate applies it
+      # before the error/warning split.
+      - id: bashate
+        args: [-i, E003, -e, E]
+
   # The hook below is not enabled yet because the tree does not satisfy it:
   #
   #   clang-format  86 of 229 C/C++ files would be rewritten (~1350 lines).

--- a/ci-scripts/cibw-build-before.sh
+++ b/ci-scripts/cibw-build-before.sh
@@ -24,6 +24,7 @@ python_executable=$(command -v python3)
 echo "Using Python_EXECUTABLE: ${python_executable}"
 
 # configure for all solvers with permissive licenses (BSD, MIT, etc..)
-./configure.sh --bitwuzla --cvc5 --z3 --python --python-executable="${python_executable}"
+./configure.sh --bitwuzla --cvc5 --z3 --python \
+  --python-executable="${python_executable}"
 cd build
 make -j

--- a/ci-scripts/compute-solver-hash.sh
+++ b/ci-scripts/compute-solver-hash.sh
@@ -5,7 +5,7 @@ gethash() {
 }
 solver=$1
 solver_hash=$(gethash ci-scripts/setup-"$1".sh)
-if [[ $solver == bitwuzla || $solver == btor || $solver == cvc5 || $solver == z3 ]]; then
+if [[ $solver =~ ^(bitwuzla|btor|cvc5|z3)$ ]]; then
   solver_hash+=$(gethash contrib/common-setup.sh)
   if [[ $solver == bitwuzla ]]; then
     solver_hash+=$(gethash contrib/meson-setup.sh)

--- a/ci-scripts/setup-msat.sh
+++ b/ci-scripts/setup-msat.sh
@@ -26,8 +26,10 @@ while (($# > 0)); do
 done
 
 if [[ $get_msat == default ]]; then
-  printf "%s\n" "MathSAT is distributed under a custom (non-BSD-compliant) license." \
-    "By continuing, you acknowledge this and assume responsibility for meeting the license conditions."
+  printf "%s\n" \
+    "MathSAT is distributed under a custom (non-BSD-compliant) license." \
+    "By continuing, you acknowledge this and assume responsibility for" \
+    "meeting the license conditions."
   read -rp "Continue? [y]es/[n]o: " get_msat
 fi
 
@@ -40,11 +42,13 @@ cd "$(dirname "${BASH_SOURCE[0]}")/.."
 mkdir -p deps && cd deps
 
 if [[ -d mathsat ]]; then
-  echo "$PWD/mathsat already exists. If you want to re-download, please remove it manually."
+  echo "$PWD/mathsat already exists." \
+    "If you want to re-download, please remove it manually."
 else
   release_url=https://mathsat.fbk.eu/release
   if [[ $OSTYPE =~ linux* ]]; then
-    wget -O mathsat.tar.gz "${release_url}/mathsat-${version}-linux-x86_64.tar.gz"
+    wget -O mathsat.tar.gz \
+      "${release_url}/mathsat-${version}-linux-x86_64.tar.gz"
   elif [[ $OSTYPE =~ darwin* ]]; then
     wget -O mathsat.tar.gz "${release_url}/mathsat-${version}-macos.tar.gz"
   else

--- a/ci-scripts/setup-yices2.sh
+++ b/ci-scripts/setup-yices2.sh
@@ -30,15 +30,18 @@ if [[ ! -d "$deps_dir/yices2" ]]; then
   make build_dir=build BUILD=build -j"$num_cores"
   cd "$script_dir"
 else
-  echo "$deps_dir/yices2 already exists. If you want to rebuild, please remove it manually."
+  echo "$deps_dir/yices2 already exists." \
+    "If you want to rebuild, please remove it manually."
 fi
 
 if [[ -f "$deps_dir/yices2/build/lib/libyices.a" ]]; then
   echo "It appears yices2 was setup successfully into $deps_dir/yices2."
-  echo "You may now install it with make ./configure.sh --yices2 && cd build && make"
+  echo "You may now install it with" \
+    "./configure.sh --yices2 && cd build && make"
 else
   echo "Building yices2 failed."
   echo "You might be missing some dependencies."
-  echo "Please see their github page for installation instructions: https://github.com/SRI-CSL/yices2"
+  echo "Please see their github page for installation instructions:" \
+    "https://github.com/SRI-CSL/yices2"
   exit 1
 fi

--- a/contrib/common-setup.sh
+++ b/contrib/common-setup.sh
@@ -48,7 +48,8 @@ fi
 # Check if dependency has already been downloaded.
 mkdir -p "$deps_dir" && cd "$deps_dir"
 if [[ -d $dep_name ]]; then
-  echo "$deps_dir/$dep_name already exists, remove it manually if you want to rebuild $dep_name"
+  echo "$deps_dir/$dep_name already exists," \
+    "remove it manually if you want to rebuild $dep_name"
   exit
 fi
 

--- a/contrib/meson-setup.sh
+++ b/contrib/meson-setup.sh
@@ -12,7 +12,8 @@ if ! declare -F configure_step >/dev/null; then
 fi
 
 build_step() {
-  meson compile -C build ${meson_compile_options[@]+"${meson_compile_options[@]}"}
+  meson compile -C build \
+    ${meson_compile_options[@]+"${meson_compile_options[@]}"}
 }
 
 install_step() {

--- a/contrib/setup-cadical.sh
+++ b/contrib/setup-cadical.sh
@@ -20,7 +20,9 @@ install_step() {
   export install_dir _version
   mkdir -p "$install_pkgconfigdir"
   # shellcheck disable=SC2016
-  envsubst '$install_dir $_version' <"$pkg_config_dir/cadical.pc.in" >"$install_pkgconfigdir/cadical.pc"
+  envsubst '$install_dir $_version' \
+    <"$pkg_config_dir/cadical.pc.in" \
+    >"$install_pkgconfigdir/cadical.pc"
   export -n install_dir _version
 }
 

--- a/contrib/setup-flex.sh
+++ b/contrib/setup-flex.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 version=2.6.4
-source_url=https://github.com/westes/flex/releases/download/v$version/flex-$version.tar.gz
+release_base=https://github.com/westes/flex/releases/download
+source_url=$release_base/v$version/flex-$version.tar.gz
 
 # shellcheck source=contrib/make-setup.sh
 source "$(dirname "$0")/make-setup.sh"

--- a/examples/build.sh
+++ b/examples/build.sh
@@ -22,7 +22,8 @@ cd "$script_dir/.."
 # configure and build smt-switch with boolector and cvc5 backends
 # set it up to be installed in a directory called example-install in the examples directory
 # also use a build directory in the examples directory
-./configure.sh --btor --cvc5 --prefix=./examples/example-install --build-dir="$script_dir/example-build" "$@"
+./configure.sh --btor --cvc5 --prefix=./examples/example-install \
+  --build-dir="$script_dir/example-build" "$@"
 cd "$script_dir/example-build"
 make
 make test


### PR DESCRIPTION
Adds the bashate hook and wraps the 14 lines over its 79-column limit. bashate covers some layout things shellcheck does not: line length, trailing whitespace, tab indents, `do`/`then` placement and `$[ ]` arithmetic.

Two arguments make it useful here:

- `-i E003` drops "indent not a multiple of 4". bashate hardcodes a 4-space rule with no way to set the width, so it contradicts the `shfmt -i 2` already in this config, and 2-space is what most of these scripts use. It was 91 of the 106 findings.
- `-e E` promotes every remaining rule to an error. E006 and a few others are warnings by default, and bashate exits 0 when only warnings are found; since pre-commit shows nothing for a hook that passes, long lines would have gone in unnoticed. The ignore still wins, as bashate applies it before splitting errors from warnings. This also covers E005, E042 and E043, none of which fire today.

The 79-column default is kept. Every line wraps cleanly, and the wraps are stable under shfmt so the formatter does not undo them. Most became backslash continuations or multi-argument `echo` calls, which the shell joins with a single space, leaving the output unchanged. Two are worth calling out:

- `contrib/setup-flex.sh` had a 90-character URL, and a URL cannot be broken across lines, so the release path moves into a `release_base` variable.
- `ci-scripts/compute-solver-hash.sh` had a four-way `||` chain, now `[[ $solver =~ ^(bitwuzla|btor|cvc5|z3)$ ]]`, which is shorter and needs no continuation. Checked against the old form for the four solver names plus msat, yices2, the empty string and bitwuzla-extra; the anchors are what keep that last one from matching.

Two user-visible strings change. The MathSAT license prompt now prints on three lines instead of two, each under 70 columns. And `ci-scripts/setup-yices2.sh` suggested installing "with make ./configure.sh --yices2 && cd build && make", which had a stray leading "make"; dropped while rewrapping that line.

With this the tree is clean under all three shell linters.