### PR TITLE
style: Apply clang-format and enable the hook

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -100,16 +100,16 @@ repos:
       - id: bashate
         args: [-i, E003, -e, E]
 
-  # The hook below is not enabled yet because the tree does not satisfy it:
-  #
-  #   clang-format  86 of 229 C/C++ files would be rewritten (~1350 lines).
-  #                 Needs a bulk-reformat commit plus a .git-blame-ignore-revs
-  #                 entry. Note .clang-format is already committed.
-  #
-  # Dependabot cannot bump commented-out repos, so re-check this revision
-  # with `pre-commit autoupdate` when enabling it.
-  #
-  # - repo: https://github.com/pre-commit/mirrors-clang-format
-  #   rev: v23.1.0
-  #   hooks:
-  #     - id: clang-format
+  - repo: https://github.com/pre-commit/mirrors-clang-format
+    rev: v23.1.0
+    hooks:
+      # Uses .clang-format: the Google style, with braces on their own line for
+      # functions, classes and control statements, and `Type * name` pointer
+      # alignment. Leave `args` unset to keep the hook's default `-i
+      # -style=file`.
+      #
+      # The mirror's revision is the clang-format version, and its output is
+      # not stable across versions: a bump can reformat files that the
+      # previous version left alone. Reformat the tree in the same commit that
+      # bumps this rev.
+      - id: clang-format

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -24,9 +24,10 @@ To check the whole tree, run `pre-commit run --all-files`. CI runs the same hook
 [prek](https://github.com/j178/prek), a drop-in replacement that reads the same
 configuration, so `prek run --all-files` works too.
 
-C++ formatting (see [.clang-format](./.clang-format)) and shell formatting are configured
-but not yet enforced by a hook, because the tree does not satisfy them yet — see the
-comments at the bottom of [.pre-commit-config.yaml](./.pre-commit-config.yaml).
+C++ formatting follows [.clang-format](./.clang-format) and is enforced by the
+clang-format hook. Note that clang-format's output changes between releases, so the
+version pinned in [.pre-commit-config.yaml](./.pre-commit-config.yaml) is what decides
+the layout; bumping it may reformat files it previously left alone.
 
 ## Design Decisions
 

--- a/bitwuzla/include/bitwuzla_solver.h
+++ b/bitwuzla/include/bitwuzla_solver.h
@@ -41,7 +41,7 @@ class BzlaSolver : public AbsSmtSolver
         options(),
         tm(new bitwuzla::TermManager()),
         bzla(nullptr),
-        context_level(0){};
+        context_level(0) {};
   BzlaSolver(const BzlaSolver &) = delete;
   BzlaSolver & operator=(const BzlaSolver &) = delete;
   ~BzlaSolver()

--- a/bitwuzla/include/bitwuzla_sort.h
+++ b/bitwuzla/include/bitwuzla_sort.h
@@ -31,7 +31,7 @@ class BzlaSolver;
 class BzlaSort : public AbsSort
 {
  public:
-  BzlaSort(const bitwuzla::Sort s) : sort(s){};
+  BzlaSort(const bitwuzla::Sort s) : sort(s) {};
   virtual ~BzlaSort();
   std::size_t hash() const override;
   std::uint64_t get_width() const override;

--- a/bitwuzla/include/bitwuzla_term.h
+++ b/bitwuzla/include/bitwuzla_term.h
@@ -40,7 +40,7 @@ class BzlaTermIter : public TermIterBase
     terms = it.terms;
     idx = it.idx;
   };
-  ~BzlaTermIter(){};
+  ~BzlaTermIter() {};
   BzlaTermIter & operator=(const BzlaTermIter & it);
   void operator++() override;
   const Term operator*() override;

--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -24,7 +24,6 @@
 #include "boolector_extensions.h"
 #include "boolector_sort.h"
 #include "boolector_term.h"
-
 #include "exceptions.h"
 #include "result.h"
 #include "smt.h"
@@ -86,12 +85,18 @@ class BoolectorSolver : public AbsSmtSolver
   DatatypeDecl make_datatype_decl(const std::string & s) override;
   DatatypeConstructorDecl make_datatype_constructor_decl(
       const std::string s) override;
-  void add_constructor(DatatypeDecl & dt, const DatatypeConstructorDecl & con) const override;
-  void add_selector(DatatypeConstructorDecl & dt, const std::string & name, const Sort & s) const override;
-  void add_selector_self(DatatypeConstructorDecl & dt, const std::string & name) const override;
+  void add_constructor(DatatypeDecl & dt,
+                       const DatatypeConstructorDecl & con) const override;
+  void add_selector(DatatypeConstructorDecl & dt,
+                    const std::string & name,
+                    const Sort & s) const override;
+  void add_selector_self(DatatypeConstructorDecl & dt,
+                         const std::string & name) const override;
   Term get_constructor(const Sort & s, std::string name) const override;
   Term get_tester(const Sort & s, std::string name) const override;
-  Term get_selector(const Sort & s, std::string con, std::string name) const override;
+  Term get_selector(const Sort & s,
+                    std::string con,
+                    std::string name) const override;
 
   Term make_term(bool b) const override;
   Term make_term(int64_t i, const Sort & sort) const override;

--- a/btor/include/boolector_sort.h
+++ b/btor/include/boolector_sort.h
@@ -16,11 +16,10 @@
 
 #pragma once
 
+#include "boolector.h"
 #include "exceptions.h"
 #include "sort.h"
 #include "utils.h"
-
-#include "boolector.h"
 
 namespace smt {
 
@@ -31,7 +30,7 @@ class BoolectorSortBase : public AbsSort
 {
  public:
   BoolectorSortBase(SortKind sk, Btor * b, BoolectorSort s)
-      : btor(b), sort(s), sk(sk){};
+      : btor(b), sort(s), sk(sk) {};
   virtual ~BoolectorSortBase();
   std::size_t hash() const override;
   uint64_t get_width() const override;
@@ -70,7 +69,7 @@ class BoolectorBVSort : public BoolectorSortBase
 {
  public:
   BoolectorBVSort(Btor * b, BoolectorSort s, uint64_t w)
-      : BoolectorSortBase(BV, b, s), width(w){};
+      : BoolectorSortBase(BV, b, s), width(w) {};
   uint64_t get_width() const override { return width; };
 
  protected:
@@ -86,7 +85,7 @@ class BoolectorArraySort : public BoolectorSortBase
 {
  public:
   BoolectorArraySort(Btor * b, BoolectorSort s, Sort is, Sort es)
-    : BoolectorSortBase(ARRAY, b, s), indexsort(is), elemsort(es) {};
+      : BoolectorSortBase(ARRAY, b, s), indexsort(is), elemsort(es) {};
   Sort get_indexsort() const override { return indexsort; };
   Sort get_elemsort() const override { return elemsort; };
 
@@ -104,7 +103,7 @@ class BoolectorUFSort : public BoolectorSortBase
       : BoolectorSortBase(FUNCTION, b, s),
         domain_sorts(sorts),
         codomain_sort(sort),
-        complete(true){};
+        complete(true) {};
 
   // this constructor is used by BoolectorTerm::get_sort()
   // more info for flag complete below

--- a/btor/include/boolector_term.h
+++ b/btor/include/boolector_term.h
@@ -25,10 +25,9 @@ extern "C" {
 #include "utils/btornodeiter.h"
 }
 
+#include "boolector_sort.h"
 #include "term.h"
 #include "utils.h"
-
-#include "boolector_sort.h"
 
 namespace smt {
 
@@ -41,7 +40,8 @@ Op lookup_op(Btor * btor, BoolectorNode * n);
 class BoolectorTermIter : public TermIterBase
 {
  public:
-  // IMPORTANT: The correctness of this code depends on the array e being of size 3
+  // IMPORTANT: The correctness of this code depends on the array e being of
+  // size 3
   BoolectorTermIter(Btor * btor, std::vector<BtorNode *> c, int64_t idx)
       : btor(btor), children(c), idx(idx)
   {
@@ -52,7 +52,7 @@ class BoolectorTermIter : public TermIterBase
     children = it.children;
     idx = it.idx;
   };
-  ~BoolectorTermIter(){};
+  ~BoolectorTermIter() {};
   BoolectorTermIter & operator=(const BoolectorTermIter & it);
   void operator++() override;
   const Term operator*() override;

--- a/btor/src/boolector_extensions.cpp
+++ b/btor/src/boolector_extensions.cpp
@@ -14,9 +14,9 @@
 **
 **/
 
-#include "math.h"
-
 #include "boolector_extensions.h"
+
+#include "math.h"
 
 namespace smt {
 BoolectorNode * custom_boolector_rotate_left(Btor * btor,

--- a/btor/src/boolector_factory.cpp
+++ b/btor/src/boolector_factory.cpp
@@ -15,6 +15,7 @@
 **/
 
 #include "boolector_factory.h"
+
 #include "boolector_solver.h"
 #include "logging_solver.h"
 

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -15,6 +15,7 @@
 **/
 
 #include "boolector_solver.h"
+
 #include "solver_utils.h"
 
 extern "C" {
@@ -168,12 +169,13 @@ void BoolectorSolver::set_logic(const std::string logic)
   }
 }
 
-
-Sort BoolectorSolver::make_sort(const DatatypeDecl & d) const {
+Sort BoolectorSolver::make_sort(const DatatypeDecl & d) const
+{
   throw NotImplementedException("BoolectorSolver::make_sort");
 };
-DatatypeDecl BoolectorSolver::make_datatype_decl(const std::string & s)  {
-    throw NotImplementedException("BoolectorSolver::make_datatype_decl");
+DatatypeDecl BoolectorSolver::make_datatype_decl(const std::string & s)
+{
+  throw NotImplementedException("BoolectorSolver::make_datatype_decl");
 }
 DatatypeConstructorDecl BoolectorSolver::make_datatype_constructor_decl(
     const std::string s)
@@ -181,37 +183,48 @@ DatatypeConstructorDecl BoolectorSolver::make_datatype_constructor_decl(
   throw NotImplementedException(
       "BoolectorSolver::make_datatype_constructor_decl");
 };
-void BoolectorSolver::add_constructor(DatatypeDecl & dt, const DatatypeConstructorDecl & con) const {
+void BoolectorSolver::add_constructor(DatatypeDecl & dt,
+                                      const DatatypeConstructorDecl & con) const
+{
   throw NotImplementedException("BoolectorSolver::add_constructor");
 };
-void BoolectorSolver::add_selector(DatatypeConstructorDecl & dt, const std::string & name, const Sort & s) const {
+void BoolectorSolver::add_selector(DatatypeConstructorDecl & dt,
+                                   const std::string & name,
+                                   const Sort & s) const
+{
   throw NotImplementedException("BoolectorSolver::add_selector");
 };
-void BoolectorSolver::add_selector_self(DatatypeConstructorDecl & dt, const std::string & name) const {
+void BoolectorSolver::add_selector_self(DatatypeConstructorDecl & dt,
+                                        const std::string & name) const
+{
   throw NotImplementedException("BoolectorSolver::add_selector_self");
 };
 
-Term BoolectorSolver::get_constructor(const Sort & s, std::string name) const  {
+Term BoolectorSolver::get_constructor(const Sort & s, std::string name) const
+{
   throw NotImplementedException("BoolectorSolver::get_constructor");
 };
-Term BoolectorSolver::get_tester(const Sort & s, std::string name) const  {
+Term BoolectorSolver::get_tester(const Sort & s, std::string name) const
+{
   throw NotImplementedException("BoolectorSolver::get_testeer");
 };
 
-Term BoolectorSolver::get_selector(const Sort & s, std::string con, std::string name) const  {
+Term BoolectorSolver::get_selector(const Sort & s,
+                                   std::string con,
+                                   std::string name) const
+{
   throw NotImplementedException("BoolectorSolver::get_selector");
 };
-
 
 Term BoolectorSolver::make_term(bool b) const
 {
   if (b)
   {
-    return std::make_shared<BoolectorTerm> (btor, boolector_const(btor, "1"));
+    return std::make_shared<BoolectorTerm>(btor, boolector_const(btor, "1"));
   }
   else
   {
-    return std::make_shared<BoolectorTerm> (btor, boolector_const(btor, "0"));
+    return std::make_shared<BoolectorTerm>(btor, boolector_const(btor, "0"));
   }
 }
 
@@ -222,7 +235,8 @@ Term BoolectorSolver::make_term(int64_t i, const Sort & sort) const
     std::shared_ptr<BoolectorSortBase> bs =
         std::static_pointer_cast<BoolectorSortBase>(sort);
     // note: give the constant value a null PrimOp
-    return std::make_shared<BoolectorTerm> (btor, boolector_int(btor, i, bs->sort));
+    return std::make_shared<BoolectorTerm>(btor,
+                                           boolector_int(btor, i, bs->sort));
   }
   catch (InternalSolverException & e)
   {
@@ -260,7 +274,7 @@ Term BoolectorSolver::make_term(std::string val,
           + std::to_string(base));
     }
 
-    return std::make_shared<BoolectorTerm> (btor, node);
+    return std::make_shared<BoolectorTerm>(btor, node);
   }
   catch (InternalSolverException & e)
   {
@@ -277,8 +291,8 @@ Term BoolectorSolver::make_term(const Term & val, const Sort & sort) const
         std::static_pointer_cast<BoolectorTerm>(val);
     std::shared_ptr<BoolectorSortBase> bs =
         std::static_pointer_cast<BoolectorSortBase>(sort);
-    return std::make_shared<BoolectorTerm>
-        (btor, boolector_const_array(btor, bs->sort, bt->node));
+    return std::make_shared<BoolectorTerm>(
+        btor, boolector_const_array(btor, bs->sort, bt->node));
   }
   else
   {
@@ -483,8 +497,8 @@ void BoolectorSolver::get_unsat_assumptions(UnorderedTermSet & out)
   BoolectorNode ** bcore = boolector_get_failed_assumptions(btor);
   while (*bcore)
   {
-    out.insert(std::make_shared<BoolectorTerm>(
-        btor, boolector_copy(btor, *bcore)));
+    out.insert(
+        std::make_shared<BoolectorTerm>(btor, boolector_copy(btor, *bcore)));
     ++bcore;
   }
 }
@@ -498,8 +512,8 @@ Sort BoolectorSolver::make_sort(SortKind sk) const
 {
   if (sk == BOOL)
   {
-    return std::make_shared<BoolectorBVSort>
-        (btor, boolector_bool_sort(btor), 1);
+    return std::make_shared<BoolectorBVSort>(
+        btor, boolector_bool_sort(btor), 1);
   }
   else
   {
@@ -513,8 +527,8 @@ Sort BoolectorSolver::make_sort(SortKind sk, uint64_t size) const
 {
   if (sk == BV)
   {
-    return std::make_shared<BoolectorBVSort>
-        (btor, boolector_bitvec_sort(btor, size), size);
+    return std::make_shared<BoolectorBVSort>(
+        btor, boolector_bitvec_sort(btor, size), size);
   }
   else
   {
@@ -543,7 +557,7 @@ Sort BoolectorSolver::make_sort(SortKind sk,
         std::static_pointer_cast<BoolectorSortBase>(sort2);
     BoolectorSort bs =
         boolector_array_sort(btor, btor_idxsort->sort, btor_elemsort->sort);
-    return std::make_shared<BoolectorArraySort> (btor, bs, sort1, sort2);
+    return std::make_shared<BoolectorArraySort>(btor, bs, sort1, sort2);
   }
   else
   {
@@ -591,8 +605,8 @@ Sort BoolectorSolver::make_sort(SortKind sk, const SortVec & sorts) const
 
     BoolectorSort btor_fun_sort = boolector_fun_sort(
         btor, btor_sorts.data(), arity, btor_return_sort->sort);
-    return std::make_shared<BoolectorUFSort>
-        (btor, btor_fun_sort, sorts, returnsort);
+    return std::make_shared<BoolectorUFSort>(
+        btor, btor_fun_sort, sorts, returnsort);
   }
   else if (sorts.size() == 1)
   {
@@ -651,7 +665,7 @@ Term BoolectorSolver::make_symbol(const std::string name, const Sort & sort)
   }
 
   // note: giving the symbol a null Op
-  Term term = std::make_shared<BoolectorTerm> (btor, n);
+  Term term = std::make_shared<BoolectorTerm>(btor, n);
   symbol_table[name] = term;
   return term;
 }
@@ -720,7 +734,7 @@ Term BoolectorSolver::make_term(Op op, const Term & t) const
       msg += to_string(op.prim_op);
       throw IncorrectUsageException(msg);
     }
-    return std::make_shared<BoolectorTerm> (btor, btor_res);
+    return std::make_shared<BoolectorTerm>(btor, btor_res);
   }
 }
 
@@ -835,7 +849,7 @@ Term BoolectorSolver::substitute(
   // counter
   substituted = boolector_copy(btor, substituted);
   boolector_nodemap_delete(bmap);
-  return std::make_shared<BoolectorTerm> (btor, substituted);
+  return std::make_shared<BoolectorTerm>(btor, substituted);
 }
 
 void BoolectorSolver::dump_smt2(std::string filename) const
@@ -852,7 +866,7 @@ Term BoolectorSolver::apply_prim_op(PrimOp op, Term t) const
     std::shared_ptr<BoolectorTerm> bt =
         std::static_pointer_cast<BoolectorTerm>(t);
     BoolectorNode * result = unary_ops.at(op)(btor, bt->node);
-    return std::make_shared<BoolectorTerm> (btor, result);
+    return std::make_shared<BoolectorTerm>(btor, result);
   }
   catch (std::out_of_range & o)
   {
@@ -906,7 +920,7 @@ Term BoolectorSolver::apply_prim_op(PrimOp op, Term t0, Term t1) const
     {
       result = binary_ops.at(op)(btor, bt0->node, bt1->node);
     }
-    return std::make_shared<BoolectorTerm> (btor, result);
+    return std::make_shared<BoolectorTerm>(btor, result);
   }
   catch (std::out_of_range & o)
   {
@@ -968,7 +982,7 @@ Term BoolectorSolver::apply_prim_op(PrimOp op, Term t0, Term t1, Term t2) const
       result = ternary_ops.at(op)(btor, bt0->node, bt1->node, bt2->node);
     }
 
-    return std::make_shared<BoolectorTerm> (btor, result);
+    return std::make_shared<BoolectorTerm>(btor, result);
   }
   catch (std::out_of_range & o)
   {

--- a/btor/src/boolector_sort.cpp
+++ b/btor/src/boolector_sort.cpp
@@ -14,9 +14,9 @@
 **
 **/
 
-#include <sstream>
-
 #include "boolector_sort.h"
+
+#include <sstream>
 
 namespace smt {
 
@@ -29,18 +29,17 @@ std::size_t BoolectorSortBase::hash() const
   // TODO: come up with better hash function
   std::size_t hash = sk;
 
-  if(sk == BV)
+  if (sk == BV)
   {
     hash ^= get_width();
   }
-  else if(sk == ARRAY)
+  else if (sk == ARRAY)
   {
     hash ^= get_indexsort()->hash();
     hash ^= get_elemsort()->hash();
   }
   return hash;
 }
-
 
 // by default the following get_* methods don't work
 // overloaded in derived classes

--- a/btor/src/boolector_term.cpp
+++ b/btor/src/boolector_term.cpp
@@ -18,28 +18,27 @@
 
 // include standard version of open_memstream
 // for compatability with FreeBSD / Darwin which doesn't support it natively
-extern "C"
-{
+extern "C" {
 #include "memstream.h"
 }
 
-#include "assert.h"
 #include <unordered_map>
+
+#include "assert.h"
 #include "stdio.h"
 
 // defining hash for old compilers
-namespace std
+namespace std {
+// specializing template
+template <>
+struct hash<BtorNodeKind>
 {
-  // specializing template
-  template<>
-  struct hash<BtorNodeKind>
+  size_t operator()(const BtorNodeKind k) const
   {
-    size_t operator()(const BtorNodeKind k) const
-    {
-      return static_cast<size_t>(k);
-    }
-  };
-}
+    return static_cast<size_t>(k);
+  }
+};
+}  // namespace std
 
 namespace smt {
 
@@ -145,7 +144,7 @@ const Term BoolectorTermIter::operator*()
   btor_node_inc_ext_ref_counter(btor, res);
 
   BoolectorNode * node = BTOR_EXPORT_BOOLECTOR_NODE(res);
-  return std::make_shared<BoolectorTerm> (btor, node);
+  return std::make_shared<BoolectorTerm>(btor, node);
 };
 
 TermIterBase * BoolectorTermIter::clone() const
@@ -174,9 +173,7 @@ bool BoolectorTermIter::equal(const TermIterBase & other) const
 /* BoolectorTerm implementation */
 
 BoolectorTerm::BoolectorTerm(Btor * b, BoolectorNode * n)
-    : btor(b),
-      node(n),
-      bn(btor_node_real_addr(BTOR_IMPORT_BOOLECTOR_NODE(n)))
+    : btor(b), node(n), bn(btor_node_real_addr(BTOR_IMPORT_BOOLECTOR_NODE(n)))
 {
   // BTOR_PARAM_NODE is not a symbol
   //  because it's not a symbolic constant, it's a free variable
@@ -190,10 +187,7 @@ BoolectorTerm::BoolectorTerm(Btor * b, BoolectorNode * n)
   negated = (((((uintptr_t)node) % 2) != 0) && bn->kind != BTOR_BV_CONST_NODE);
 }
 
-BoolectorTerm::~BoolectorTerm()
-{
-  boolector_release(btor, node);
-}
+BoolectorTerm::~BoolectorTerm() { boolector_release(btor, node); }
 
 // BoolectorNode * -> id
 

--- a/cvc5/include/cvc5_datatype.h
+++ b/cvc5/include/cvc5_datatype.h
@@ -24,7 +24,7 @@ namespace smt {
 class Cvc5DatatypeDecl : public AbsDatatypeDecl
 {
  public:
-  Cvc5DatatypeDecl(cvc5::DatatypeDecl t) : datatypedecl(t){};
+  Cvc5DatatypeDecl(cvc5::DatatypeDecl t) : datatypedecl(t) {};
 
  protected:
   cvc5::DatatypeDecl datatypedecl;
@@ -36,7 +36,7 @@ class Cvc5DatatypeConstructorDecl : public AbsDatatypeConstructorDecl
 {
  public:
   Cvc5DatatypeConstructorDecl(cvc5::DatatypeConstructorDecl t)
-      : datatypeconstructordecl(t){};
+      : datatypeconstructordecl(t) {};
   bool compare(const DatatypeConstructorDecl &) const override;
 
  protected:
@@ -48,7 +48,7 @@ class Cvc5DatatypeConstructorDecl : public AbsDatatypeConstructorDecl
 class Cvc5Datatype : public AbsDatatype
 {
  public:
-  Cvc5Datatype(cvc5::Datatype t) : datatype(t){};
+  Cvc5Datatype(cvc5::Datatype t) : datatype(t) {};
   std::string get_name() const override { return datatype.getName(); }
   int get_num_constructors() const override
   {

--- a/cvc5/include/cvc5_sort.h
+++ b/cvc5/include/cvc5_sort.h
@@ -30,7 +30,7 @@ class Cvc5Solver;
 class Cvc5Sort : public AbsSort
 {
  public:
-  Cvc5Sort(::cvc5::Sort s) : sort(s){};
+  Cvc5Sort(::cvc5::Sort s) : sort(s) {};
   ~Cvc5Sort() = default;
   std::string to_string() const override;
   std::size_t hash() const override;

--- a/cvc5/include/cvc5_term.h
+++ b/cvc5/include/cvc5_term.h
@@ -27,13 +27,13 @@ class Cvc5Solver;
 class Cvc5TermIter : public TermIterBase
 {
  public:
-  Cvc5TermIter(::cvc5::Term term, uint32_t p = 0) : term(term), pos(p){};
+  Cvc5TermIter(::cvc5::Term term, uint32_t p = 0) : term(term), pos(p) {};
   Cvc5TermIter(const Cvc5TermIter & it)
   {
     term = it.term;
     pos = it.pos;
   };
-  ~Cvc5TermIter(){};
+  ~Cvc5TermIter() {};
   Cvc5TermIter & operator=(const Cvc5TermIter & it);
   void operator++() override;
   const Term operator*() override;
@@ -52,8 +52,8 @@ class Cvc5TermIter : public TermIterBase
 class Cvc5Term : public AbsTerm
 {
  public:
-  Cvc5Term(cvc5::Term t) : term(t){};
-  ~Cvc5Term(){};
+  Cvc5Term(cvc5::Term t) : term(t) {};
+  ~Cvc5Term() {};
   std::size_t hash() const override;
   std::size_t get_id() const override;
   bool compare(const Term & absterm) const override;

--- a/cvc5/src/cvc5_term.cpp
+++ b/cvc5/src/cvc5_term.cpp
@@ -18,8 +18,8 @@
 
 #include <string>
 
-#include "cvc5/cvc5.h"
 #include "assert.h"
+#include "cvc5/cvc5.h"
 #include "cvc5_sort.h"
 #include "exceptions.h"
 
@@ -274,11 +274,15 @@ bool Cvc5Term::is_symbol() const
   return (k == ::cvc5::Kind::CONSTANT || k == ::cvc5::Kind::VARIABLE);
 }
 
-bool Cvc5Term::is_param() const { return (term.getKind() == ::cvc5::Kind::VARIABLE); }
+bool Cvc5Term::is_param() const
+{
+  return (term.getKind() == ::cvc5::Kind::VARIABLE);
+}
 
 bool Cvc5Term::is_symbolic_const() const
 {
-  return (term.getKind() == ::cvc5::Kind::CONSTANT && !term.getSort().isFunction());
+  return (term.getKind() == ::cvc5::Kind::CONSTANT
+          && !term.getSort().isFunction());
 }
 
 bool Cvc5Term::is_value() const

--- a/examples/btor_qf_ufbv.cpp
+++ b/examples/btor_qf_ufbv.cpp
@@ -1,54 +1,52 @@
 #include <iostream>
+
 #include "smt-switch/boolector_factory.h"
 #include "smt-switch/smt.h"
 using namespace smt;
 using namespace std;
 int main()
 {
- // Boolector aliases booleans and bitvectors of size one
- // and also performs on-the-fly rewriting
- // if you'd like to maintain the term structure, you can
- // enable logging by passing true
- SmtSolver s = BoolectorSolverFactory::create(false);
+  // Boolector aliases booleans and bitvectors of size one
+  // and also performs on-the-fly rewriting
+  // if you'd like to maintain the term structure, you can
+  // enable logging by passing true
+  SmtSolver s = BoolectorSolverFactory::create(false);
 
- s->set_logic("QF_UFBV");
- s->set_opt("incremental", "true");
- s->set_opt("produce-models", "true");
- s->set_opt("produce-unsat-assumptions",
-   "true");
- Sort bvs = s->make_sort(BV, 32);
- Sort funs =
-   s->make_sort(FUNCTION, {bvs, bvs});
+  s->set_logic("QF_UFBV");
+  s->set_opt("incremental", "true");
+  s->set_opt("produce-models", "true");
+  s->set_opt("produce-unsat-assumptions", "true");
+  Sort bvs = s->make_sort(BV, 32);
+  Sort funs = s->make_sort(FUNCTION, { bvs, bvs });
 
- Term x = s->make_symbol("x", bvs);
- Term y = s->make_symbol("y", bvs);
- Term f = s->make_symbol("f", funs);
+  Term x = s->make_symbol("x", bvs);
+  Term y = s->make_symbol("y", bvs);
+  Term f = s->make_symbol("f", funs);
 
- Op ext = Op(Extract, 15, 0);
- Term x0 = s->make_term(ext, x);
- Term y0 = s->make_term(ext, y);
+  Op ext = Op(Extract, 15, 0);
+  Term x0 = s->make_term(ext, x);
+  Term y0 = s->make_term(ext, y);
 
- Term fx = s->make_term(Apply, f, x);
- Term fy = s->make_term(Apply, f, y);
- s->assert_formula(
-   s->make_term(Distinct, fx, fy));
+  Term fx = s->make_term(Apply, f, x);
+  Term fy = s->make_term(Apply, f, y);
+  s->assert_formula(s->make_term(Distinct, fx, fy));
 
- s->push(1);
- s->assert_formula(
-   s->make_term(Equal, x0, y0));
- cout <<  s->check_sat() << endl;
+  s->push(1);
+  s->assert_formula(s->make_term(Equal, x0, y0));
+  cout << s->check_sat() << endl;
 
- cout << s->get_value(x) << endl;
- s->pop(1);
+  cout << s->get_value(x) << endl;
+  s->pop(1);
 
- Term xy = s->make_term(BVAnd, x, y);
- Term a1 = s->make_term(BVUge, x0, y0);
- Term a2 = s->make_term(BVUge, xy, x);
- Term a3 = s->make_term(BVUge, xy, y);
- cout <<
-   s->check_sat_assuming({a1, a2, a3})
-   << endl;
- UnorderedTermSet ua;
- s->get_unsat_assumptions(ua);
- for (Term t : ua) { cout << t << endl; }
+  Term xy = s->make_term(BVAnd, x, y);
+  Term a1 = s->make_term(BVUge, x0, y0);
+  Term a2 = s->make_term(BVUge, xy, x);
+  Term a3 = s->make_term(BVUge, xy, y);
+  cout << s->check_sat_assuming({ a1, a2, a3 }) << endl;
+  UnorderedTermSet ua;
+  s->get_unsat_assumptions(ua);
+  for (Term t : ua)
+  {
+    cout << t << endl;
+  }
 }

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -22,12 +22,10 @@
 #include <unordered_set>
 #include <vector>
 
+#include "exceptions.h"
+#include "mathsat.h"
 #include "msat_sort.h"
 #include "msat_term.h"
-
-#include "mathsat.h"
-
-#include "exceptions.h"
 #include "ops.h"
 #include "result.h"
 #include "smt.h"
@@ -48,7 +46,7 @@ class MsatSolver : public AbsSmtSolver
         logic(""),
         num_assump_clauses_(0),
         max_assump_clauses_(10000),
-        last_query_assuming(true){};
+        last_query_assuming(true) {};
   MsatSolver(msat_config c, msat_env e)
       : AbsSmtSolver(MSAT),
         cfg(c),
@@ -57,9 +55,7 @@ class MsatSolver : public AbsSmtSolver
         valid_model(false),
         logic(""),
         num_assump_clauses_(0),
-        max_assump_clauses_(10000)
-    {
-    };
+        max_assump_clauses_(10000) {};
   MsatSolver(const MsatSolver &) = delete;
   MsatSolver & operator=(const MsatSolver &) = delete;
   ~MsatSolver()
@@ -107,12 +103,18 @@ class MsatSolver : public AbsSmtSolver
   DatatypeDecl make_datatype_decl(const std::string & s) override;
   DatatypeConstructorDecl make_datatype_constructor_decl(
       const std::string s) override;
-  void add_constructor(DatatypeDecl & dt, const DatatypeConstructorDecl & con) const override;
-  void add_selector(DatatypeConstructorDecl & dt, const std::string & name, const Sort & s) const override;
-  void add_selector_self(DatatypeConstructorDecl & dt, const std::string & name) const override;
+  void add_constructor(DatatypeDecl & dt,
+                       const DatatypeConstructorDecl & con) const override;
+  void add_selector(DatatypeConstructorDecl & dt,
+                    const std::string & name,
+                    const Sort & s) const override;
+  void add_selector_self(DatatypeConstructorDecl & dt,
+                         const std::string & name) const override;
   Term get_constructor(const Sort & s, std::string name) const override;
   Term get_tester(const Sort & s, std::string name) const override;
-  Term get_selector(const Sort & s, std::string con, std::string name) const override;
+  Term get_selector(const Sort & s,
+                    std::string con,
+                    std::string name) const override;
 
   Term make_term(bool b) const override;
   Term make_term(int64_t i, const Sort & sort) const override;
@@ -151,7 +153,8 @@ class MsatSolver : public AbsSmtSolver
   msat_config cfg;
   // marked mutable because want to stick with const interface for functions
   // but the environment cannot be created before setting options
-  // it will be lazily created when first used (which might be in a const function)
+  // it will be lazily created when first used (which might be in a const
+  // function)
   mutable msat_env env;
   mutable bool env_uninitialized;
   bool valid_model;
@@ -162,9 +165,9 @@ class MsatSolver : public AbsSmtSolver
   std::unordered_map<size_t, msat_term>
       assumption_map_;  ///< maps msat_term labels to assumptions
   std::vector<msat_term>
-      base_assertions_;  ///< assertions at context level 0
-                         ///< to be re-added after resetting to clear old
-                         ///< clauses added for assumptions
+      base_assertions_;        ///< assertions at context level 0
+                               ///< to be re-added after resetting to clear old
+                               ///< clauses added for assumptions
   size_t num_assump_clauses_;  ///< counts how many assumption clauses are added
   size_t max_assump_clauses_;  ///< number of assumption clauses before clearing
                                ///< them

--- a/msat/include/msat_sort.h
+++ b/msat/include/msat_sort.h
@@ -16,9 +16,8 @@
 
 #pragma once
 
-#include "sort.h"
-
 #include "mathsat.h"
+#include "sort.h"
 
 namespace smt {
 // forward declaration
@@ -28,7 +27,8 @@ class MsatSort : public AbsSort
 {
  public:
   MsatSort(msat_env e, msat_type t) : env(e), type(t), is_uf_type(false) {};
-  MsatSort(msat_env e, msat_type t, msat_decl d) : env(e), type(t), uf_decl(d), is_uf_type(true) {};
+  MsatSort(msat_env e, msat_type t, msat_decl d)
+      : env(e), type(t), uf_decl(d), is_uf_type(true) {};
   ~MsatSort() = default;
   std::size_t hash() const override;
   uint64_t get_width() const override;

--- a/msat/include/msat_term.h
+++ b/msat/include/msat_term.h
@@ -16,10 +16,9 @@
 
 #pragma once
 
+#include "mathsat.h"
 #include "term.h"
 #include "utils.h"
-
-#include "mathsat.h"
 
 namespace smt {
 
@@ -32,9 +31,9 @@ class MsatTermIter : public TermIterBase
  public:
   // TODO: consider making env const everywhere
   MsatTermIter(msat_env e, const msat_term t, uint32_t p)
-      : env(e), term(t), pos(p){};
+      : env(e), term(t), pos(p) {};
   MsatTermIter(const MsatTermIter & it);
-  ~MsatTermIter(){};
+  ~MsatTermIter() {};
   MsatTermIter & operator=(const MsatTermIter & it);
   void operator++() override;
   const Term operator*() override;
@@ -64,7 +63,7 @@ class MsatTerm : public AbsTerm
     // should know that term is invalid
     MSAT_MAKE_ERROR_TERM(term);
   };
-  ~MsatTerm(){};
+  ~MsatTerm() {};
   std::size_t hash() const override;
   std::size_t get_id() const override;
   bool compare(const Term & absterm) const override;

--- a/msat/src/msat_extensions.cpp
+++ b/msat/src/msat_extensions.cpp
@@ -19,9 +19,8 @@
 
 #include <vector>
 
-#include "mathsat.h"
-
 #include "exceptions.h"
+#include "mathsat.h"
 
 using namespace std;
 

--- a/msat/src/msat_factory.cpp
+++ b/msat/src/msat_factory.cpp
@@ -15,9 +15,9 @@
 **/
 
 #include "msat_factory.h"
-#include "msat_solver.h"
 
 #include "logging_solver.h"
+#include "msat_solver.h"
 
 namespace smt {
 

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -15,15 +15,15 @@
 **/
 
 #include "msat_solver.h"
-#include "msat_extensions.h"
-#include "msat_sort.h"
-#include "msat_term.h"
 
 #include <sstream>
 #include <unordered_map>
 #include <vector>
 
 #include "exceptions.h"
+#include "msat_extensions.h"
+#include "msat_sort.h"
+#include "msat_term.h"
 #include "result.h"
 #include "solver_utils.h"
 
@@ -31,9 +31,8 @@ using namespace std;
 
 namespace smt {
 
-const unordered_map<string, string> msat_option_map({
-         {"produce-models", "model_generation"}
-  });
+const unordered_map<string, string> msat_option_map({ { "produce-models",
+                                                        "model_generation" } });
 
 /* MathSAT op mappings */
 typedef msat_term (*msat_un_fun)(msat_env, msat_term);
@@ -140,9 +139,9 @@ void MsatSolver::set_opt(const string option, const string value)
   {
     if (value == "false")
     {
-      cout << "Warning: Option "
-           << option
-           << " is always enabled in MathSAT backend -- cannot be disabled" << endl;
+      cout << "Warning: Option " << option
+           << " is always enabled in MathSAT backend -- cannot be disabled"
+           << endl;
     }
     return;
   }
@@ -162,7 +161,8 @@ void MsatSolver::set_opt(const string option, const string value)
   // returns zero on success
   if (msat_set_option(cfg, msat_option.c_str(), value.c_str()))
   {
-    throw InternalSolverException("Option " + msat_option + " unsupported in mathsat.");
+    throw InternalSolverException("Option " + msat_option
+                                  + " unsupported in mathsat.");
   }
 }
 
@@ -340,7 +340,7 @@ Term MsatSolver::get_value(const Term & t) const
     throw IncorrectUsageException(msg);
   }
 
-  return std::make_shared<MsatTerm> (env, val);
+  return std::make_shared<MsatTerm>(env, val);
 }
 
 UnorderedTermMap MsatSolver::get_array_values(const Term & arr,
@@ -391,7 +391,8 @@ void MsatSolver::get_unsat_assumptions(UnorderedTermSet & out)
     {
       throw InternalSolverException("got an error term in the unsat core");
     }
-    out.insert(std::make_shared<MsatTerm>(env, assumption_map_.at(msat_term_id(*mcore_iter))));
+    out.insert(std::make_shared<MsatTerm>(
+        env, assumption_map_.at(msat_term_id(*mcore_iter))));
     ++mcore_iter;
   }
   msat_free(mcore);
@@ -402,8 +403,8 @@ Sort MsatSolver::make_sort(const std::string name, uint64_t arity) const
   initialize_env();
   if (!arity)
   {
-    return std::make_shared<MsatSort> (env,
-                                       msat_get_simple_type(env, name.c_str()));
+    return std::make_shared<MsatSort>(env,
+                                      msat_get_simple_type(env, name.c_str()));
   }
   else
   {
@@ -418,15 +419,15 @@ Sort MsatSolver::make_sort(SortKind sk) const
   initialize_env();
   if (sk == BOOL)
   {
-    return std::make_shared<MsatSort> (env, msat_get_bool_type(env));
+    return std::make_shared<MsatSort>(env, msat_get_bool_type(env));
   }
   else if (sk == INT)
   {
-    return std::make_shared<MsatSort> (env, msat_get_integer_type(env));
+    return std::make_shared<MsatSort>(env, msat_get_integer_type(env));
   }
   else if (sk == REAL)
   {
-    return std::make_shared<MsatSort> (env, msat_get_rational_type(env));
+    return std::make_shared<MsatSort>(env, msat_get_rational_type(env));
   }
   else
   {
@@ -442,7 +443,7 @@ Sort MsatSolver::make_sort(SortKind sk, uint64_t size) const
   initialize_env();
   if (sk == BV)
   {
-    return std::make_shared<MsatSort> (env, msat_get_bv_type(env, size));
+    return std::make_shared<MsatSort>(env, msat_get_bv_type(env, size));
   }
   else
   {
@@ -471,8 +472,8 @@ Sort MsatSolver::make_sort(SortKind sk,
         std::static_pointer_cast<MsatSort>(sort1);
     std::shared_ptr<MsatSort> melemsort =
         std::static_pointer_cast<MsatSort>(sort2);
-    return std::make_shared<MsatSort>
-        (env, msat_get_array_type(env, midxsort->type, melemsort->type));
+    return std::make_shared<MsatSort>(
+        env, msat_get_array_type(env, midxsort->type, melemsort->type));
   }
   else
   {
@@ -534,7 +535,7 @@ Sort MsatSolver::make_sort(SortKind sk, const SortVec & sorts) const
     msat_decl ref_fun_decl =
         msat_declare_function(env, decl_name.c_str(), mfunsort);
 
-    return std::make_shared<MsatSort> (env, mfunsort, ref_fun_decl);
+    return std::make_shared<MsatSort>(env, mfunsort, ref_fun_decl);
   }
   else if (sorts.size() == 1)
   {
@@ -563,12 +564,14 @@ Sort MsatSolver::make_sort(const Sort & sort_con, const SortVec & sorts) const
       "MathSAT does not support uninterpreted sort constructors");
 }
 
-Sort MsatSolver::make_sort(const DatatypeDecl & d) const {
+Sort MsatSolver::make_sort(const DatatypeDecl & d) const
+{
   throw NotImplementedException("MsatSolver::make_sort");
 };
 
-DatatypeDecl MsatSolver::make_datatype_decl(const std::string & s)  {
-    throw NotImplementedException("MsatSolver::make_datatype_decl");
+DatatypeDecl MsatSolver::make_datatype_decl(const std::string & s)
+{
+  throw NotImplementedException("MsatSolver::make_datatype_decl");
 }
 
 DatatypeConstructorDecl MsatSolver::make_datatype_constructor_decl(
@@ -577,27 +580,39 @@ DatatypeConstructorDecl MsatSolver::make_datatype_constructor_decl(
   throw NotImplementedException("MsatSolver::make_datatype_constructor_decl");
 }
 
-void MsatSolver::add_constructor(DatatypeDecl & dt, const DatatypeConstructorDecl & con) const {
+void MsatSolver::add_constructor(DatatypeDecl & dt,
+                                 const DatatypeConstructorDecl & con) const
+{
   throw NotImplementedException("MsatSolver::add_constructor");
 }
 
-void MsatSolver::add_selector(DatatypeConstructorDecl & dt, const std::string & name, const Sort & s) const {
+void MsatSolver::add_selector(DatatypeConstructorDecl & dt,
+                              const std::string & name,
+                              const Sort & s) const
+{
   throw NotImplementedException("MsatSolver::add_selector");
 }
 
-void MsatSolver::add_selector_self(DatatypeConstructorDecl & dt, const std::string & name) const {
+void MsatSolver::add_selector_self(DatatypeConstructorDecl & dt,
+                                   const std::string & name) const
+{
   throw NotImplementedException("MsatSolver::add_selector_self");
 }
 
-Term MsatSolver::get_constructor(const Sort & s, std::string name) const  {
+Term MsatSolver::get_constructor(const Sort & s, std::string name) const
+{
   throw NotImplementedException("MsatSolver::get_constructor");
 }
 
-Term MsatSolver::get_tester(const Sort & s, std::string name) const  {
+Term MsatSolver::get_tester(const Sort & s, std::string name) const
+{
   throw NotImplementedException("MsatSolver::get_testeer");
 }
 
-Term MsatSolver::get_selector(const Sort & s, std::string con, std::string name) const  {
+Term MsatSolver::get_selector(const Sort & s,
+                              std::string con,
+                              std::string name) const
+{
   throw NotImplementedException("MsatSolver::get_selector");
 }
 
@@ -606,11 +621,11 @@ Term MsatSolver::make_term(bool b) const
   initialize_env();
   if (b)
   {
-    return std::make_shared<MsatTerm> (env, msat_make_true(env));
+    return std::make_shared<MsatTerm>(env, msat_make_true(env));
   }
   else
   {
-    return std::make_shared<MsatTerm> (env, msat_make_false(env));
+    return std::make_shared<MsatTerm>(env, msat_make_false(env));
   }
 }
 
@@ -624,12 +639,13 @@ Term MsatSolver::make_term(int64_t i, const Sort & sort) const
     {
       // always use string version for consistency
       std::string sval = std::to_string(i);
-      msat_term mval = ext_msat_make_bv_number(env, sval.c_str(), sort->get_width(), 10);
+      msat_term mval =
+          ext_msat_make_bv_number(env, sval.c_str(), sort->get_width(), 10);
       if (MSAT_ERROR_TERM(mval))
       {
         throw IncorrectUsageException("");
       }
-      return std::make_shared<MsatTerm> (env, mval);
+      return std::make_shared<MsatTerm>(env, mval);
     }
     else if (sk == REAL || sk == INT)
     {
@@ -638,14 +654,14 @@ Term MsatSolver::make_term(int64_t i, const Sort & sort) const
       {
         throw IncorrectUsageException("");
       }
-      return std::make_shared<MsatTerm> (env, mval);
+      return std::make_shared<MsatTerm>(env, mval);
     }
     else
     {
       throw IncorrectUsageException("");
     }
   }
-  catch(IncorrectUsageException & e)
+  catch (IncorrectUsageException & e)
   {
     string msg("Can't create value ");
     msg += i;
@@ -665,19 +681,20 @@ Term MsatSolver::make_term(const std::string val,
     SortKind sk = sort->get_sort_kind();
     if (sk == BV)
     {
-      msat_term mval = ext_msat_make_bv_number(env, val.c_str(), sort->get_width(), base);
+      msat_term mval =
+          ext_msat_make_bv_number(env, val.c_str(), sort->get_width(), base);
       if (MSAT_ERROR_TERM(mval))
       {
         throw IncorrectUsageException("");
       }
-      return std::make_shared<MsatTerm> (env, mval);
+      return std::make_shared<MsatTerm>(env, mval);
     }
     else if (sk == REAL || sk == INT)
     {
       if (base != 10)
       {
         throw NotImplementedException(
-                                      "MathSAT only supports base 10 for real and integer values");
+            "MathSAT only supports base 10 for real and integer values");
       }
 
       msat_term mval = msat_make_number(env, val.c_str());
@@ -685,14 +702,14 @@ Term MsatSolver::make_term(const std::string val,
       {
         throw IncorrectUsageException("");
       }
-      return std::make_shared<MsatTerm> (env, mval);
+      return std::make_shared<MsatTerm>(env, mval);
     }
     else
     {
       throw IncorrectUsageException("");
     }
   }
-  catch(IncorrectUsageException & e)
+  catch (IncorrectUsageException & e)
   {
     string msg("Can't create value ");
     msg += val;
@@ -712,8 +729,8 @@ Term MsatSolver::make_term(const Term & val, const Sort & sort) const
   }
   shared_ptr<MsatSort> msort = static_pointer_cast<MsatSort>(sort);
   shared_ptr<MsatTerm> mval = static_pointer_cast<MsatTerm>(val);
-  return std::make_shared<MsatTerm>
-      (env, msat_make_array_const(env, msort->type, mval->term));
+  return std::make_shared<MsatTerm>(
+      env, msat_make_array_const(env, msort->type, mval->term));
 }
 
 Term MsatSolver::make_symbol(const string name, const Sort & sort)
@@ -743,13 +760,13 @@ Term MsatSolver::make_symbol(const string name, const Sort & sort)
   }
   else if (MSAT_ERROR_DECL(decl))
   {
-    throw SmtException("Got msat error decl when creating " +
-                       name + " of sort " + sort->to_string());
+    throw SmtException("Got msat error decl when creating " + name + " of sort "
+                       + sort->to_string());
   }
 
   if (sort->get_sort_kind() == FUNCTION)
   {
-    return std::make_shared<MsatTerm> (env, decl);
+    return std::make_shared<MsatTerm>(env, decl);
   }
   else
   {
@@ -758,7 +775,7 @@ Term MsatSolver::make_symbol(const string name, const Sort & sort)
     {
       throw InternalSolverException("Got error term.");
     }
-    return std::make_shared<MsatTerm> (env, res);
+    return std::make_shared<MsatTerm>(env, res);
   }
 }
 
@@ -890,7 +907,7 @@ Term MsatSolver::make_term(Op op, const Term & t) const
   }
   else
   {
-    return std::make_shared<MsatTerm> (env, res);
+    return std::make_shared<MsatTerm>(env, res);
   }
 }
 
@@ -910,9 +927,10 @@ Term MsatSolver::make_term(Op op, const Term & t0, const Term & t1) const
     {
       if (!mterm0->is_uf)
       {
-        throw IncorrectUsageException("Expecting UF as first argument to Apply");
+        throw IncorrectUsageException(
+            "Expecting UF as first argument to Apply");
       }
-      vector<msat_term> v({mterm1->term});
+      vector<msat_term> v({ mterm1->term });
       res = ext_msat_make_uf(env, mterm0->decl, v);
     }
     else
@@ -940,7 +958,7 @@ Term MsatSolver::make_term(Op op, const Term & t0, const Term & t1) const
   }
   else
   {
-    return std::make_shared<MsatTerm> (env, res);
+    return std::make_shared<MsatTerm>(env, res);
   }
 }
 
@@ -959,15 +977,16 @@ Term MsatSolver::make_term(Op op,
     if (msat_ternary_ops.find(op.prim_op) != msat_ternary_ops.end())
     {
       res = msat_ternary_ops.at(op.prim_op)(
-                                            env, mterm0->term, mterm1->term, mterm2->term);
+          env, mterm0->term, mterm1->term, mterm2->term);
     }
     else if (op.prim_op == Apply)
     {
       if (!mterm0->is_uf)
       {
-        throw IncorrectUsageException("Expecting UF as first argument to Apply");
+        throw IncorrectUsageException(
+            "Expecting UF as first argument to Apply");
       }
-      vector<msat_term> v({mterm1->term, mterm2->term});
+      vector<msat_term> v({ mterm1->term, mterm2->term });
       res = ext_msat_make_uf(env, mterm0->decl, v);
     }
     else if (op.prim_op == Forall)
@@ -1005,7 +1024,7 @@ Term MsatSolver::make_term(Op op,
   }
   else
   {
-    return std::make_shared<MsatTerm> (env, res);
+    return std::make_shared<MsatTerm>(env, res);
   }
 }
 
@@ -1153,7 +1172,8 @@ void MsatSolver::reset_assertions()
 Term MsatSolver::substitute(const Term term,
                             const UnorderedTermMap & substitution_map) const
 {
-  if (substitution_map.size() == 0) {
+  if (substitution_map.size() == 0)
+  {
     return term;
   }
 
@@ -1219,8 +1239,9 @@ msat_term MsatSolver::label(msat_term p) const
 {
   initialize_env();
 
-  if (msat_term_is_boolean_constant(env, p) ||
-      (msat_term_is_not(env, p) && msat_term_is_boolean_constant(env, msat_term_get_arg(p, 0))))
+  if (msat_term_is_boolean_constant(env, p)
+      || (msat_term_is_not(env, p)
+          && msat_term_is_boolean_constant(env, msat_term_get_arg(p, 0))))
   {
     // if a (negated) boolean constant, don't need a fresh label
     return p;

--- a/msat/src/msat_sort.cpp
+++ b/msat/src/msat_sort.cpp
@@ -50,7 +50,7 @@ Sort MsatSort::get_indexsort() const
   msat_type idx_type;
   if (msat_is_array_type(env, type, &idx_type, nullptr))
   {
-    return std::make_shared<MsatSort> (env, idx_type);
+    return std::make_shared<MsatSort>(env, idx_type);
   }
   else
   {
@@ -63,7 +63,7 @@ Sort MsatSort::get_elemsort() const
   msat_type elem_type;
   if (msat_is_array_type(env, type, nullptr, &elem_type))
   {
-    return std::make_shared<MsatSort> (env, elem_type);
+    return std::make_shared<MsatSort>(env, elem_type);
   }
   else
   {
@@ -75,7 +75,8 @@ SortVec MsatSort::get_domain_sorts() const
 {
   if (!is_uf_type)
   {
-    throw IncorrectUsageException("Can't get domain sorts from non-function sort.");
+    throw IncorrectUsageException(
+        "Can't get domain sorts from non-function sort.");
   }
 
   size_t arity = msat_decl_get_arity(uf_decl);
@@ -90,7 +91,7 @@ SortVec MsatSort::get_domain_sorts() const
       throw InternalSolverException("Got error type");
     }
     // Note: assuming first-order, function can't take function arguments
-    sorts.push_back(std::make_shared<MsatSort> (env, tmp_type));
+    sorts.push_back(std::make_shared<MsatSort>(env, tmp_type));
   }
   return sorts;
 }
@@ -99,7 +100,8 @@ Sort MsatSort::get_codomain_sort() const
 {
   if (!is_uf_type)
   {
-    throw IncorrectUsageException("Can't get codomain sort from non-function sort.");
+    throw IncorrectUsageException(
+        "Can't get codomain sort from non-function sort.");
   }
   msat_type t = msat_decl_get_return_type(uf_decl);
   // Note: assuming first-order, e.g. functions can't return functions
@@ -107,7 +109,7 @@ Sort MsatSort::get_codomain_sort() const
   {
     throw InternalSolverException("Got error type");
   }
-  return std::make_shared<MsatSort> (env, t);
+  return std::make_shared<MsatSort>(env, t);
 }
 
 string MsatSort::get_uninterpreted_name() const

--- a/msat/src/msat_term.cpp
+++ b/msat/src/msat_term.cpp
@@ -14,28 +14,26 @@
 **
 **/
 
-#include "assert.h"
-
 #include "msat_term.h"
-#include "msat_sort.h"
-
-#include "exceptions.h"
-#include "ops.h"
 
 #include <unordered_map>
 
-namespace std
+#include "assert.h"
+#include "exceptions.h"
+#include "msat_sort.h"
+#include "ops.h"
+
+namespace std {
+// defining hash for old compilers
+template <>
+struct hash<msat_symbol_tag>
 {
-  // defining hash for old compilers
-  template<>
-  struct hash<msat_symbol_tag>
+  size_t operator()(const msat_symbol_tag t) const
   {
-    size_t operator()(const msat_symbol_tag t) const
-    {
-      return static_cast<size_t>(t);
-    }
-  };
-}
+    return static_cast<size_t>(t);
+  }
+};
+}  // namespace std
 
 using namespace std;
 
@@ -139,7 +137,7 @@ const Term MsatTermIter::operator*()
 {
   if (!pos && msat_term_is_uf(env, term))
   {
-    return std::make_shared<MsatTerm> (env, msat_term_get_decl(term));
+    return std::make_shared<MsatTerm>(env, msat_term_get_decl(term));
   }
   else
   {
@@ -466,7 +464,7 @@ Sort MsatTerm::get_sort() const
 {
   if (!is_uf)
   {
-    return std::make_shared<MsatSort> (env, msat_term_get_type(term));
+    return std::make_shared<MsatSort>(env, msat_term_get_type(term));
   }
   else
   {
@@ -489,7 +487,7 @@ Sort MsatTerm::get_sort() const
                                                param_types.size(),
                                                msat_decl_get_return_type(decl));
 
-    return std::make_shared<MsatSort> (env, funtype, decl);
+    return std::make_shared<MsatSort>(env, funtype, decl);
   }
 }
 

--- a/tests/btor/btor-array-empty-assignment.cpp
+++ b/tests/btor/btor-array-empty-assignment.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-array-models.cpp
+++ b/tests/btor/btor-array-models.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-arrays.cpp
+++ b/tests/btor/btor-arrays.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-const-arrays.cpp
+++ b/tests/btor/btor-const-arrays.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-data-structures.cpp
+++ b/tests/btor/btor-data-structures.cpp
@@ -16,8 +16,8 @@
 
 #include <iostream>
 #include <string>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation
@@ -104,8 +104,8 @@ int main()
   cout << "Assignments:" << std::endl;
   for (size_t i = 0; i < NUM_TERMS; ++i)
   {
-    cout << "\t " << v[i]->to_string() << " = "
-         << s->get_value(v[i])->to_int() << endl;
+    cout << "\t " << v[i]->to_string() << " = " << s->get_value(v[i])->to_int()
+         << endl;
     cout << "\t " << utm.at(v[i])->to_string() << " = "
          << s->get_value(utm.at(v[i]))->to_int() << endl;
   }

--- a/tests/btor/btor-exceptions.cpp
+++ b/tests/btor/btor-exceptions.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-incremental.cpp
+++ b/tests/btor/btor-incremental.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after full installation

--- a/tests/btor/btor-indexed-op-tests.cpp
+++ b/tests/btor/btor-indexed-op-tests.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-neg-numbers.cpp
+++ b/tests/btor/btor-neg-numbers.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-negation.cpp
+++ b/tests/btor/btor-negation.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-opts.cpp
+++ b/tests/btor/btor-opts.cpp
@@ -17,11 +17,10 @@
 #include <iostream>
 #include <memory>
 #include <vector>
+
 #include "assert.h"
-
-#include "gtest/gtest.h"
-
 #include "boolector_factory.h"
+#include "gtest/gtest.h"
 #include "smt.h"
 
 using namespace smt;

--- a/tests/btor/btor-simple.cpp
+++ b/tests/btor/btor-simple.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-substitute.cpp
+++ b/tests/btor/btor-substitute.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-tests.cpp
+++ b/tests/btor/btor-tests.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-transfer.cpp
+++ b/tests/btor/btor-transfer.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/cvc5/cvc5-str.cpp
+++ b/tests/cvc5/cvc5-str.cpp
@@ -60,46 +60,61 @@ int main()
 
   s->assert_formula(s->make_term(Equal, lenempty, zero));
 
-  //StrLt
+  // StrLt
   s->assert_formula(s->make_term(StrLt, x, y));
   s->assert_formula(s->make_term(StrLt, yx, xy));
-  //StrLeq StrConcat
+  // StrLeq StrConcat
   s->assert_formula(s->make_term(StrLeq, z, xy));
-  //StrLen
+  // StrLen
   s->assert_formula(s->make_term(Lt, zero, lenz));
-  //StrConcat
+  // StrConcat
   s->assert_formula(s->make_term(Not, s->make_term(Equal, xy, yx)));
-  //StrSubstr
+  // StrSubstr
   s->assert_formula(s->make_term(Equal, x, substryx));
   s->assert_formula(s->make_term(Not, s->make_term(Equal, y, substryx)));
-  s->assert_formula(s->make_term(Equal, empty, s->make_term(StrSubstr, x, lenx, lenx)));
-  s->assert_formula(s->make_term(Equal, empty, s->make_term(StrSubstr, x, minusone, lenx)));
-  //StrAt
-  s->assert_formula(s->make_term(Equal, s->make_term(StrLen, s->make_term(StrAt, y, zero)), one));
+  s->assert_formula(
+      s->make_term(Equal, empty, s->make_term(StrSubstr, x, lenx, lenx)));
+  s->assert_formula(
+      s->make_term(Equal, empty, s->make_term(StrSubstr, x, minusone, lenx)));
+  // StrAt
+  s->assert_formula(s->make_term(
+      Equal, s->make_term(StrLen, s->make_term(StrAt, y, zero)), one));
   s->assert_formula(s->make_term(Equal, empty, s->make_term(StrAt, x, lenx)));
-  s->assert_formula(s->make_term(Equal, empty, s->make_term(StrAt, x, minusone)));
-  //StrContains
+  s->assert_formula(
+      s->make_term(Equal, empty, s->make_term(StrAt, x, minusone)));
+  // StrContains
   s->assert_formula(s->make_term(Not, s->make_term(StrContains, x, y)));
   s->assert_formula(s->make_term(StrContains, xy, y));
-  //StrIndexof
-  s->assert_formula(s->make_term(Equal, lenx, s->make_term(StrIndexof, xyy, y, s->make_term(Minus, lenx, one))));
-  s->assert_formula(s->make_term(Equal, zero, s->make_term(StrIndexof, xy, empty, zero)));
-  s->assert_formula(s->make_term(Equal, minusone, s->make_term(StrIndexof, xy, x, minusone)));
-  s->assert_formula(s->make_term(Equal, minusone, s->make_term(StrIndexof, x, y, lenx)));
-  s->assert_formula(s->make_term(Equal, minusone, s->make_term(StrIndexof, x, y, zero)));
-  //StrReplace
-  s->assert_formula(s->make_term(Equal, xx, s->make_term(StrReplace, xy, y, x)));
-  s->assert_formula(s->make_term(Equal, xy, s->make_term(StrReplace, y, empty, x)));
-  //StrReplaceAll
-  s->assert_formula(s->make_term(Equal, xxx, s->make_term(StrReplaceAll, xyy, y, x)));
-  s->assert_formula(s->make_term(Equal, xyy, s->make_term(StrReplaceAll, xyy, empty, x)));
-  //StrPrefixof
+  // StrIndexof
+  s->assert_formula(s->make_term(
+      Equal,
+      lenx,
+      s->make_term(StrIndexof, xyy, y, s->make_term(Minus, lenx, one))));
+  s->assert_formula(
+      s->make_term(Equal, zero, s->make_term(StrIndexof, xy, empty, zero)));
+  s->assert_formula(
+      s->make_term(Equal, minusone, s->make_term(StrIndexof, xy, x, minusone)));
+  s->assert_formula(
+      s->make_term(Equal, minusone, s->make_term(StrIndexof, x, y, lenx)));
+  s->assert_formula(
+      s->make_term(Equal, minusone, s->make_term(StrIndexof, x, y, zero)));
+  // StrReplace
+  s->assert_formula(
+      s->make_term(Equal, xx, s->make_term(StrReplace, xy, y, x)));
+  s->assert_formula(
+      s->make_term(Equal, xy, s->make_term(StrReplace, y, empty, x)));
+  // StrReplaceAll
+  s->assert_formula(
+      s->make_term(Equal, xxx, s->make_term(StrReplaceAll, xyy, y, x)));
+  s->assert_formula(
+      s->make_term(Equal, xyy, s->make_term(StrReplaceAll, xyy, empty, x)));
+  // StrPrefixof
   s->assert_formula(s->make_term(StrPrefixof, x, xyy));
   s->assert_formula(s->make_term(Not, s->make_term(StrPrefixof, str1, A)));
-  //StrSuffixof
+  // StrSuffixof
   s->assert_formula(s->make_term(StrSuffixof, y, xyy));
   s->assert_formula(s->make_term(Not, s->make_term(StrSuffixof, str1, A)));
-  //StrIsDigit
+  // StrIsDigit
   s->assert_formula(s->make_term(StrIsDigit, str1));
   s->assert_formula(s->make_term(Not, s->make_term(StrIsDigit, A)));
   s->assert_formula(s->make_term(Not, s->make_term(StrIsDigit, str10)));
@@ -108,7 +123,7 @@ int main()
   assert(r.is_sat());
 
   cout << "Model Values:" << endl;
-  for (auto t : TermVec({ x, y, z}))
+  for (auto t : TermVec({ x, y, z }))
   {
     cout << "\t" << t << " = " << s->get_value(t) << endl;
   }

--- a/tests/cvc5/cvc5-term-iter.cpp
+++ b/tests/cvc5/cvc5-term-iter.cpp
@@ -16,8 +16,8 @@
 
 #include <vector>
 
-#include "cvc5/cvc5.h"
 #include "assert.h"
+#include "cvc5/cvc5.h"
 #include "cvc5_term.h"
 #include "gtest/gtest.h"
 

--- a/tests/msat/msat-array-models.cpp
+++ b/tests/msat/msat-array-models.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-arrays.cpp
+++ b/tests/msat/msat-arrays.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-arrays2.cpp
+++ b/tests/msat/msat-arrays2.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-const-arrays.cpp
+++ b/tests/msat/msat-const-arrays.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-data-structures.cpp
+++ b/tests/msat/msat-data-structures.cpp
@@ -16,8 +16,8 @@
 
 #include <iostream>
 #include <string>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation
@@ -101,8 +101,8 @@ int main()
   cout << "Assignments:" << std::endl;
   for (size_t i = 0; i < NUM_TERMS; ++i)
   {
-    cout << "\t " << v[i]->to_string() << " = "
-         << s->get_value(v[i])->to_int() << endl;
+    cout << "\t " << v[i]->to_string() << " = " << s->get_value(v[i])->to_int()
+         << endl;
     cout << "\t " << utm.at(v[i])->to_string() << " = "
          << s->get_value(utm.at(v[i]))->to_int() << endl;
   }

--- a/tests/msat/msat-ext-ops.cpp
+++ b/tests/msat/msat-ext-ops.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-indexed-op-tests.cpp
+++ b/tests/msat/msat-indexed-op-tests.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-int-arithmetic.cpp
+++ b/tests/msat/msat-int-arithmetic.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after full installation

--- a/tests/msat/msat-ite-test.cpp
+++ b/tests/msat/msat-ite-test.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-neg-numbers.cpp
+++ b/tests/msat/msat-neg-numbers.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-substitute.cpp
+++ b/tests/msat/msat-substitute.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-tests.cpp
+++ b/tests/msat/msat-tests.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-transfer.cpp
+++ b/tests/msat/msat-transfer.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation
@@ -28,8 +28,8 @@
 using namespace smt;
 using namespace std;
 
-
-void transfer_int_test() {
+void transfer_int_test()
+{
   SmtSolver s = MsatSolverFactory::create(false);
   s->set_opt("produce-models", "true");
   Sort realsort = s->make_sort(REAL);
@@ -67,8 +67,8 @@ void transfer_int_test() {
   assert(s2->check_sat().is_sat());
 }
 
-
-void transfer_bv_test() {
+void transfer_bv_test()
+{
   SmtSolver s = MsatSolverFactory::create(false);
   s->set_opt("produce-models", "true");
   Sort bvsort8 = s->make_sort(BV, 8);

--- a/tests/msat/msat-traversal.cpp
+++ b/tests/msat/msat-traversal.cpp
@@ -17,8 +17,8 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/smtlib_reader_test_inputs.h
+++ b/tests/smtlib_reader_test_inputs.h
@@ -34,13 +34,12 @@ const std::unordered_map<std::string, std::vector<smt::Result>> qf_uflia_tests({
 });
 
 const std::unordered_map<std::string, std::vector<smt::Result>> qf_s_tests({
-    { "test-ops.smt2", { smt::Result(smt::SAT)} },
-    { "test-ops-SLIA.smt2", { smt::Result(smt::SAT)} },
+    { "test-ops.smt2", { smt::Result(smt::SAT) } },
+    { "test-ops-SLIA.smt2", { smt::Result(smt::SAT) } },
 });
 
 const std::unordered_map<std::string, std::vector<smt::Result>> qf_ufbv_tests(
-    { { "test-attr.smt2",
-        { smt::Result(smt::SAT), smt::Result(smt::UNSAT) } },
+    { { "test-attr.smt2", { smt::Result(smt::SAT), smt::Result(smt::UNSAT) } },
       { "test-define-sort.smt2", { smt::Result(smt::UNSAT) } },
       { "test-define-sort-edge-case.smt2", { smt::Result(smt::UNSAT) } } });
 

--- a/tests/test-array.cpp
+++ b/tests/test-array.cpp
@@ -27,8 +27,9 @@ using namespace std;
 namespace smt_tests {
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(ArrayModelTests);
-class ArrayModelTests : public ::testing::Test,
-                        public ::testing::WithParamInterface<SolverConfiguration>
+class ArrayModelTests
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override

--- a/tests/test-bv.cpp
+++ b/tests/test-bv.cpp
@@ -28,7 +28,7 @@ namespace smt_tests {
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(BVTests);
 class BVTests : public ::testing::Test,
-                 public ::testing::WithParamInterface<SolverConfiguration>
+                public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override

--- a/tests/test-dt.cpp
+++ b/tests/test-dt.cpp
@@ -29,7 +29,7 @@ namespace smt_tests {
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(DTTests);
 class DTTests : public ::testing::Test,
-                 public ::testing::WithParamInterface<SolverConfiguration>
+                public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -80,110 +80,112 @@ TEST_P(DTTests, DeclareSimpleListWithForwardRef)
 
 TEST_P(DTTests, DatatypeDecl)
 {
-    SolverConfiguration sc = GetParam();
-    if (sc.is_logging_solver) {
-      return;
-    }
+  SolverConfiguration sc = GetParam();
+  if (sc.is_logging_solver)
+  {
+    return;
+  }
 
-    // Make datatype sort
-    DatatypeDecl consListSpec = s->make_datatype_decl("list");
+  // Make datatype sort
+  DatatypeDecl consListSpec = s->make_datatype_decl("list");
 
-    auto dt_decltest = make_shared<GenericDatatypeDecl>("secondtestdt");
+  auto dt_decltest = make_shared<GenericDatatypeDecl>("secondtestdt");
 
-    std::shared_ptr<GenericDatatype> gdt =
-        make_shared<GenericDatatype>(dt_decltest);
-    assert(gdt->get_num_constructors() == 0);
+  std::shared_ptr<GenericDatatype> gdt =
+      make_shared<GenericDatatype>(dt_decltest);
+  assert(gdt->get_num_constructors() == 0);
 
-    shared_ptr<GenericDatatypeConstructorDecl> cons2test =
-        shared_ptr<GenericDatatypeConstructorDecl>(
-            new GenericDatatypeConstructorDecl("constest"));
-    gdt->add_constructor(cons2test);
-    assert(gdt->get_num_constructors() == 1);
-    assert(gdt->get_num_selectors("constest") == 0);
-    assert(gdt->get_name() == "secondtestdt");
+  shared_ptr<GenericDatatypeConstructorDecl> cons2test =
+      shared_ptr<GenericDatatypeConstructorDecl>(
+          new GenericDatatypeConstructorDecl("constest"));
+  gdt->add_constructor(cons2test);
+  assert(gdt->get_num_constructors() == 1);
+  assert(gdt->get_num_selectors("constest") == 0);
+  assert(gdt->get_name() == "secondtestdt");
 
-    DatatypeConstructorDecl nildecl = s->make_datatype_constructor_decl("nil");
-    DatatypeConstructorDecl consdecl = s->make_datatype_constructor_decl("cons");
+  DatatypeConstructorDecl nildecl = s->make_datatype_constructor_decl("nil");
+  DatatypeConstructorDecl consdecl = s->make_datatype_constructor_decl("cons");
 
-    shared_ptr<GenericDatatypeConstructorDecl> consdeclgen =
-        static_pointer_cast<GenericDatatypeConstructorDecl>(consdecl);
-    DatatypeConstructorDecl cons_copy = consdecl;
-    ASSERT_EQ(cons_copy, consdecl);
+  shared_ptr<GenericDatatypeConstructorDecl> consdeclgen =
+      static_pointer_cast<GenericDatatypeConstructorDecl>(consdecl);
+  DatatypeConstructorDecl cons_copy = consdecl;
+  ASSERT_EQ(cons_copy, consdecl);
 
-    s->add_selector(consdecl, "head", s->make_sort(INT));
-    s->add_constructor(consListSpec, nildecl);
-    s->add_constructor(consListSpec, consdecl);
+  s->add_selector(consdecl, "head", s->make_sort(INT));
+  s->add_constructor(consListSpec, nildecl);
+  s->add_constructor(consListSpec, consdecl);
 
-    s->add_selector_self(consdecl, "tail");
-    Sort listsort = s->make_sort(consListSpec);
+  s->add_selector_self(consdecl, "tail");
+  Sort listsort = s->make_sort(consListSpec);
 
-    DatatypeDecl counterdecl = s->make_datatype_decl("counter");
-    DatatypeConstructorDecl countercons =
-        s->make_datatype_constructor_decl("countercons");
-    s->add_constructor(counterdecl, countercons);
+  DatatypeDecl counterdecl = s->make_datatype_decl("counter");
+  DatatypeConstructorDecl countercons =
+      s->make_datatype_constructor_decl("countercons");
+  s->add_constructor(counterdecl, countercons);
 
-    DatatypeConstructorDecl nonAddCons =
-        s->make_datatype_constructor_decl("nonAddCons");
-    shared_ptr<SelectorComponents> newSelector =
-        make_shared<SelectorComponents>();
-    newSelector->name = "nonaddselector";
-    newSelector->sort = s->make_sort(INT);
-    shared_ptr<GenericDatatype> nonAddDT =
-        make_shared<GenericDatatype>(consListSpec);
-    EXPECT_THROW(nonAddDT->add_selector(nonAddCons, *newSelector),
-                 InternalSolverException);
+  DatatypeConstructorDecl nonAddCons =
+      s->make_datatype_constructor_decl("nonAddCons");
+  shared_ptr<SelectorComponents> newSelector =
+      make_shared<SelectorComponents>();
+  newSelector->name = "nonaddselector";
+  newSelector->sort = s->make_sort(INT);
+  shared_ptr<GenericDatatype> nonAddDT =
+      make_shared<GenericDatatype>(consListSpec);
+  EXPECT_THROW(nonAddDT->add_selector(nonAddCons, *newSelector),
+               InternalSolverException);
 
-    Sort countersort = s->make_sort(counterdecl);
+  Sort countersort = s->make_sort(counterdecl);
 
-    assert(countersort->get_sort_kind() == DATATYPE);
-    assert(listsort->get_sort_kind() == DATATYPE);
-    assert(countersort != listsort);
+  assert(countersort->get_sort_kind() == DATATYPE);
+  assert(listsort->get_sort_kind() == DATATYPE);
+  assert(countersort != listsort);
 
-    Datatype listdt = listsort->get_datatype();
+  Datatype listdt = listsort->get_datatype();
 
-    Term five = s->make_term(5, intsort);
-    // Make datatype terms
-    Term cons = s->get_constructor(listsort, "cons");
-    assert("cons" == cons->to_string());
-    Term nil = s->get_constructor(listsort, "nil");
+  Term five = s->make_term(5, intsort);
+  // Make datatype terms
+  Term cons = s->get_constructor(listsort, "cons");
+  assert("cons" == cons->to_string());
+  Term nil = s->get_constructor(listsort, "nil");
 
-    Term head = s->get_selector(listsort, "cons", "head");
+  Term head = s->get_selector(listsort, "cons", "head");
 
-    Term tail = s->get_selector(listsort, "cons", "tail");
+  Term tail = s->get_selector(listsort, "cons", "tail");
 
-    Term isNil = s->get_tester(listsort, "nil");
+  Term isNil = s->get_tester(listsort, "nil");
 
-    // Datatype ops
-    Term nilterm = s->make_term(Apply_Constructor, nil);
-    Term list5 = s->make_term(Apply_Constructor, cons, five, nilterm);
-    Term five_again = s->make_term(Apply_Selector, head, list5);
+  // Datatype ops
+  Term nilterm = s->make_term(Apply_Constructor, nil);
+  Term list5 = s->make_term(Apply_Constructor, cons, five, nilterm);
+  Term five_again = s->make_term(Apply_Selector, head, list5);
 
-    // Expected booleans
+  // Expected booleans
 
-    s->assert_formula(s->make_term(Equal, five, five_again));
+  s->assert_formula(s->make_term(Equal, five, five_again));
 
-    s->assert_formula(s->make_term(Apply_Tester, isNil, nilterm));
+  s->assert_formula(s->make_term(Apply_Tester, isNil, nilterm));
 
-    s->assert_formula(
-        s->make_term(Not, s->make_term(Apply_Tester, isNil, list5)));
+  s->assert_formula(
+      s->make_term(Not, s->make_term(Apply_Tester, isNil, list5)));
 
-    Result res = s->check_sat();
+  Result res = s->check_sat();
 
-    ASSERT_TRUE(listdt->get_name() == "list");
-    ASSERT_TRUE(listdt->get_num_constructors() == 2);
-    ASSERT_TRUE(listdt->get_num_selectors("cons") == 2);
-    ASSERT_TRUE(listdt->get_num_selectors("nil") == 0);
+  ASSERT_TRUE(listdt->get_name() == "list");
+  ASSERT_TRUE(listdt->get_num_constructors() == 2);
+  ASSERT_TRUE(listdt->get_num_selectors("cons") == 2);
+  ASSERT_TRUE(listdt->get_num_selectors("nil") == 0);
 
-    ASSERT_TRUE(res.is_sat());
-    // Expected exceptions
+  ASSERT_TRUE(res.is_sat());
+  // Expected exceptions
 
-    EXPECT_THROW(s->get_constructor(listsort, "kons"), InternalSolverException);
-    EXPECT_THROW(s->get_tester(listsort, "head"), InternalSolverException);
-    EXPECT_THROW(listdt->get_num_selectors("kons"), InternalSolverException);
+  EXPECT_THROW(s->get_constructor(listsort, "kons"), InternalSolverException);
+  EXPECT_THROW(s->get_tester(listsort, "head"), InternalSolverException);
+  EXPECT_THROW(listdt->get_num_selectors("kons"), InternalSolverException);
 }
 
-INSTANTIATE_TEST_SUITE_P(ParameterizedSolverDTTests,
-                         DTTests,
-                         testing::ValuesIn(filter_solver_configurations({ THEORY_DATATYPE })));
+INSTANTIATE_TEST_SUITE_P(
+    ParameterizedSolverDTTests,
+    DTTests,
+    testing::ValuesIn(filter_solver_configurations({ THEORY_DATATYPE })));
 
-}
+}  // namespace smt_tests

--- a/tests/test-int.cpp
+++ b/tests/test-int.cpp
@@ -51,11 +51,11 @@ TEST_P(IntTests, Mult)
   Term mult;
   try
   {
-    mult = s->make_term(Mult, {two, three, four});
+    mult = s->make_term(Mult, { two, three, four });
   }
-  catch (const IncorrectUsageException &e)
+  catch (const IncorrectUsageException & e)
   {
-    FAIL() <<  "creating mult-term failed: " << e.what();
+    FAIL() << "creating mult-term failed: " << e.what();
   }
   s->assert_formula(s->make_term(Equal, twentyfour, mult));
   auto res = s->check_sat();
@@ -116,10 +116,12 @@ TEST_P(IntTests, Bv2Int)
 
   ASSERT_TRUE(intz);
   EXPECT_EQ(intz->get_sort(), intsort);
-  if (intz->get_op() != SBV_To_Int) {
+  if (intz->get_op() != SBV_To_Int)
+  {
     // Some solvers (e.g., Z3) have different implementations that predate
     // SMT-LIB support for this operation.
-    std::cout << "Got " << intz->get_op().to_string() << " when checking SBV_To_Int" << std::endl;
+    std::cout << "Got " << intz->get_op().to_string()
+              << " when checking SBV_To_Int" << std::endl;
   }
 }
 

--- a/tests/test-logging-solver.cpp
+++ b/tests/test-logging-solver.cpp
@@ -150,9 +150,8 @@ TEST_P(LoggingTests, Compare)
   EXPECT_EQ(fxv, fyv);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    ParameterizedSolverLoggingTests,
-    LoggingTests,
-    testing::ValuesIn(available_solver_configurations()));
+INSTANTIATE_TEST_SUITE_P(ParameterizedSolverLoggingTests,
+                         LoggingTests,
+                         testing::ValuesIn(available_solver_configurations()));
 
 }  // namespace smt_tests

--- a/tests/test-str.cpp
+++ b/tests/test-str.cpp
@@ -20,7 +20,6 @@
 #include "gtest/gtest.h"
 #include "smt.h"
 
-
 using namespace smt;
 using namespace std;
 
@@ -100,7 +99,6 @@ TEST_P(StrTests, EqualStrConsts)
   ASSERT_EQ(strx1, strx2);
 }
 
-
 TEST_P(StrTests, UseEscSequences)
 {
   Sort str_sort = s->make_sort(STRING);
@@ -112,7 +110,8 @@ TEST_P(StrTests, UseEscSequences)
 
   s->check_sat();
 
-  std:wstring wchar_u = L"u";
+std:
+  wstring wchar_u = L"u";
   std::wstring wstrx1 = s->get_value(x1)->getStringValue();
   std::wstring wstrx2 = s->get_value(x2)->getStringValue();
   std::wstring wstrx3 = s->get_value(x3)->getStringValue();
@@ -123,9 +122,6 @@ TEST_P(StrTests, UseEscSequences)
   assert(wstrx3.find(wchar_u) != std::wstring::npos);
   assert(wstrx4.find(wchar_u) != std::wstring::npos);
 }
-
-
-
 
 TEST_P(StrTests, EqualVarStrVals)
 {
@@ -166,9 +162,9 @@ TEST_P(StrTests, EqualVarWStrVals)
   ASSERT_EQ(strx1, strx2);
 }
 
-INSTANTIATE_TEST_SUITE_P(
-    ParameterizedSolverStrTests,
-    StrTests,
-    testing::ValuesIn(filter_solver_configurations({ THEORY_INT, THEORY_STR })));
+INSTANTIATE_TEST_SUITE_P(ParameterizedSolverStrTests,
+                         StrTests,
+                         testing::ValuesIn(filter_solver_configurations(
+                             { THEORY_INT, THEORY_STR })));
 
 }  // namespace smt_tests

--- a/tests/test-unsat-core-reducer.cpp
+++ b/tests/test-unsat-core-reducer.cpp
@@ -107,9 +107,9 @@ TEST_P(UnsatCoreReducerTests, UnsatCoreReducerLinear)
   TermVec red, rem;
 
   uscr.linear_reduce_assump_unsatcore(formula, assump, red, &rem);
-  EXPECT_EQ(red.size() , 1);
-  EXPECT_EQ(rem.size() , 1);
-  EXPECT_NE(rem[0] , red[0]);
+  EXPECT_EQ(red.size(), 1);
+  EXPECT_EQ(rem.size(), 1);
+  EXPECT_NE(rem[0], red[0]);
 }
 
 // The unsat cores reducer module requires the

--- a/tests/test-unsat-core.cpp
+++ b/tests/test-unsat-core.cpp
@@ -28,7 +28,7 @@ namespace smt_tests {
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(UnsatCoreTests);
 class UnsatCoreTests : public ::testing::Test,
-                 public ::testing::WithParamInterface<SolverConfiguration>
+                       public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -81,10 +81,10 @@ TEST_P(UnsatCoreTests, UnsatCoreNonLit)
   Result r = s->check_sat_assuming({ x_lt_y, x_ge_y });
   ASSERT_TRUE(r.is_unsat());
 
-  r = s->check_sat_assuming({x_lt_y});
+  r = s->check_sat_assuming({ x_lt_y });
   ASSERT_TRUE(r.is_sat());
 
-  r = s->check_sat_assuming({x_lt_y, x_ge_y});
+  r = s->check_sat_assuming({ x_lt_y, x_ge_y });
   ASSERT_TRUE(r.is_unsat());
 
   UnorderedTermSet core;

--- a/tests/test-variadic-ops.cpp
+++ b/tests/test-variadic-ops.cpp
@@ -58,7 +58,7 @@ TEST_P(VariadicOpsTests, AND)
   Term reduce_and = s->make_term(And, args);
   s->assert_formula(reduce_and);
   // check that we can pass 3 (and doesn't go to a ternary call)
-  Term reduce_and3 = s->make_term(And, {args[0], args[1], args[2]});
+  Term reduce_and3 = s->make_term(And, { args[0], args[1], args[2] });
   Result r = s->check_sat();
   ASSERT_TRUE(r.is_sat());
 
@@ -90,8 +90,9 @@ TEST_P(VariadicOpsTests, BVADD)
   ASSERT_EQ(s->get_value(term_sum)->to_int(), sum);
 }
 
-INSTANTIATE_TEST_SUITE_P(ParameterizedSolverVariadicOpsTests,
-                         VariadicOpsTests,
-                         testing::ValuesIn(available_non_generic_solver_configurations()));
+INSTANTIATE_TEST_SUITE_P(
+    ParameterizedSolverVariadicOpsTests,
+    VariadicOpsTests,
+    testing::ValuesIn(available_non_generic_solver_configurations()));
 
 }  // namespace smt_tests

--- a/tests/unit/unit-sort-inference.cpp
+++ b/tests/unit/unit-sort-inference.cpp
@@ -25,8 +25,9 @@ using namespace std;
 namespace smt_tests {
 
 GTEST_ALLOW_UNINSTANTIATED_PARAMETERIZED_TEST(UnitSortInferenceTests);
-class UnitSortInferenceTests : public ::testing::Test,
-                               public ::testing::WithParamInterface<SolverConfiguration>
+class UnitSortInferenceTests
+    : public ::testing::Test,
+      public ::testing::WithParamInterface<SolverConfiguration>
 {
  protected:
   void SetUp() override
@@ -135,13 +136,13 @@ TEST_P(UnitSortInferenceTests, SortednessTests)
   EXPECT_FALSE(check_sortedness(Distinct, { p, w }));
 
   /********* Arrays ********/
-  EXPECT_TRUE(check_sortedness(Select, {arr, p}));
-  EXPECT_TRUE(check_sortedness(Store, {arr, p, q}));
+  EXPECT_TRUE(check_sortedness(Select, { arr, p }));
+  EXPECT_TRUE(check_sortedness(Store, { arr, p, q }));
   EXPECT_TRUE(check_sortedness(Equal, { arr, s->make_term(Store, arr, p, q) }));
   // wrong bit-width
-  EXPECT_FALSE(check_sortedness(Select, {arr, w}));
-  EXPECT_FALSE(check_sortedness(Store, {arr, p, w}));
-  EXPECT_FALSE(check_sortedness(Store, {arr, w, p}));
+  EXPECT_FALSE(check_sortedness(Select, { arr, w }));
+  EXPECT_FALSE(check_sortedness(Store, { arr, p, w }));
+  EXPECT_FALSE(check_sortedness(Store, { arr, w, p }));
 
   // BTOR doesn't support getting the sort of a function yet
   if (s->get_solver_enum() != BTOR)
@@ -152,9 +153,9 @@ TEST_P(UnitSortInferenceTests, SortednessTests)
     EXPECT_FALSE(check_sortedness(Apply, { f, p, w }));
     EXPECT_FALSE(check_sortedness(Apply, { f, arr, q }));
     // wrong number of arguments
-    EXPECT_FALSE(check_sortedness(Apply, {f}));
-    EXPECT_FALSE(check_sortedness(Apply, {f, p}));
-    EXPECT_FALSE(check_sortedness(Apply, {f, arr}));
+    EXPECT_FALSE(check_sortedness(Apply, { f }));
+    EXPECT_FALSE(check_sortedness(Apply, { f, p }));
+    EXPECT_FALSE(check_sortedness(Apply, { f, arr }));
   }
 
   /************** Quantifiers (if supported) ******************/
@@ -167,12 +168,13 @@ TEST_P(UnitSortInferenceTests, SortednessTests)
     // e.g. BTOR also returns the type as BV1
     if (!solver_has_attribute(s->get_solver_enum(), BOOL_BV1_ALIASING))
     {
-      EXPECT_TRUE(check_sortedness(Exists, {param, body}));
+      EXPECT_TRUE(check_sortedness(Exists, { param, body }));
     }
     // not a parameter
-    EXPECT_FALSE(check_sortedness(Exists, {q, body}));
+    EXPECT_FALSE(check_sortedness(Exists, { q, body }));
     // not a formula for the body
-    EXPECT_FALSE(check_sortedness(Exists, {param, s->make_term(BVAdd, param, q)}));
+    EXPECT_FALSE(
+        check_sortedness(Exists, { param, s->make_term(BVAdd, param, q) }));
 
     // bind param
     Term forallparam = s->make_term(Forall, param, body);
@@ -225,31 +227,31 @@ TEST_P(UnitSortInferenceTests, SortComputation)
 
 TEST_P(UnitArithmeticSortInferenceTests, ArithmeticSortedness)
 {
-  EXPECT_TRUE(check_sortedness(Gt, {x, y}));
-  EXPECT_TRUE(check_sortedness(Ge, {xint, yint}));
-  EXPECT_TRUE(check_sortedness(Lt, {x, y}));
-  EXPECT_TRUE(check_sortedness(Le, {xint, yint}));
+  EXPECT_TRUE(check_sortedness(Gt, { x, y }));
+  EXPECT_TRUE(check_sortedness(Ge, { xint, yint }));
+  EXPECT_TRUE(check_sortedness(Lt, { x, y }));
+  EXPECT_TRUE(check_sortedness(Le, { xint, yint }));
 
-  EXPECT_TRUE(check_sortedness(Plus, {x, y}));
-  EXPECT_TRUE(check_sortedness(Plus, {xint, yint}));
-  EXPECT_TRUE(check_sortedness(Minus, {x, y}));
-  EXPECT_TRUE(check_sortedness(Minus, {xint, yint}));
-  EXPECT_TRUE(check_sortedness(Negate, {xint}));
+  EXPECT_TRUE(check_sortedness(Plus, { x, y }));
+  EXPECT_TRUE(check_sortedness(Plus, { xint, yint }));
+  EXPECT_TRUE(check_sortedness(Minus, { x, y }));
+  EXPECT_TRUE(check_sortedness(Minus, { xint, yint }));
+  EXPECT_TRUE(check_sortedness(Negate, { xint }));
 
-  EXPECT_TRUE(check_sortedness(To_Int, {x}));
-  EXPECT_TRUE(check_sortedness(To_Real, {xint}));
+  EXPECT_TRUE(check_sortedness(To_Int, { x }));
+  EXPECT_TRUE(check_sortedness(To_Real, { xint }));
 
   // wrong operators
-  EXPECT_FALSE(check_sortedness(To_Real, {x}));
-  EXPECT_FALSE(check_sortedness(To_Int, {xint}));
-  EXPECT_FALSE(check_sortedness(BVUgt, {x, y}));
-  EXPECT_FALSE(check_sortedness(BVSgt, {xint, yint}));
-  EXPECT_FALSE(check_sortedness(BVUlt, {x, y}));
-  EXPECT_FALSE(check_sortedness(BVSge, {xint, yint}));
-  EXPECT_FALSE(check_sortedness(BVAdd, {xint, yint}));
+  EXPECT_FALSE(check_sortedness(To_Real, { x }));
+  EXPECT_FALSE(check_sortedness(To_Int, { xint }));
+  EXPECT_FALSE(check_sortedness(BVUgt, { x, y }));
+  EXPECT_FALSE(check_sortedness(BVSgt, { xint, yint }));
+  EXPECT_FALSE(check_sortedness(BVUlt, { x, y }));
+  EXPECT_FALSE(check_sortedness(BVSge, { xint, yint }));
+  EXPECT_FALSE(check_sortedness(BVAdd, { xint, yint }));
 
   // wrong number of arguments
-  EXPECT_FALSE(check_sortedness(Negate, {xint, yint}));
+  EXPECT_FALSE(check_sortedness(Negate, { xint, yint }));
 }
 
 TEST_P(UnitArithmeticSortInferenceTests, ArithmeticSortComputation)
@@ -283,6 +285,7 @@ INSTANTIATE_TEST_SUITE_P(ParameterizedUnitSortInference,
 
 INSTANTIATE_TEST_SUITE_P(ParameterizedUnitArithmeticSortInference,
                          UnitArithmeticSortInferenceTests,
-                         testing::ValuesIn(filter_solver_configurations({ THEORY_INT, THEORY_REAL })));
+                         testing::ValuesIn(filter_solver_configurations(
+                             { THEORY_INT, THEORY_REAL })));
 
 }  // namespace smt_tests

--- a/tests/yices2/yices2-polynomial.cpp
+++ b/tests/yices2/yices2-polynomial.cpp
@@ -17,15 +17,14 @@
 #include <iostream>
 #include <memory>
 #include <vector>
-#include "assert.h"
 
+#include "assert.h"
 #include "gmp.h"
+#include "smt.h"
 #include "yices.h"
+#include "yices2_factory.h"
 #include "yices2_sort.h"
 #include "yices2_term.h"
-
-#include "smt.h"
-#include "yices2_factory.h"
 // after a full installation
 // #include "smt-switch/msat_factory.h"
 // #include "smt-switch/smt.h"

--- a/tests/z3/z3_full.cpp
+++ b/tests/z3/z3_full.cpp
@@ -35,7 +35,6 @@ int main()
   Result r = s->check_sat();
   cout << r << endl;
 
-
   Term xlt = s->make_term(Op(Lt), x, val1);
   s->assert_formula(xlt);
   r = s->check_sat();

--- a/yices2/include/yices2_extensions.h
+++ b/yices2/include/yices2_extensions.h
@@ -17,6 +17,7 @@
 #pragma once
 
 #include <gmp.h>
+
 #include "yices.h"
 
 namespace smt {

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -17,21 +17,20 @@
 #pragma once
 
 #include <gmp.h>
+#include <yices.h>
+
 #include <memory>
 #include <string>
 #include <unordered_set>
 #include <vector>
 
-#include <yices.h>
-
-#include "yices2_extensions.h"
-#include "yices2_sort.h"
-#include "yices2_term.h"
-
 #include "exceptions.h"
 #include "result.h"
 #include "smt.h"
 #include "sort.h"
+#include "yices2_extensions.h"
+#include "yices2_sort.h"
+#include "yices2_term.h"
 
 namespace smt {
 
@@ -98,12 +97,18 @@ class Yices2Solver : public AbsSmtSolver
   DatatypeDecl make_datatype_decl(const std::string & s) override;
   DatatypeConstructorDecl make_datatype_constructor_decl(
       const std::string s) override;
-  void add_constructor(DatatypeDecl & dt, const DatatypeConstructorDecl & con) const override;
-  void add_selector(DatatypeConstructorDecl & dt, const std::string & name, const Sort & s) const override;
-  void add_selector_self(DatatypeConstructorDecl & dt, const std::string & name) const override;
+  void add_constructor(DatatypeDecl & dt,
+                       const DatatypeConstructorDecl & con) const override;
+  void add_selector(DatatypeConstructorDecl & dt,
+                    const std::string & name,
+                    const Sort & s) const override;
+  void add_selector_self(DatatypeConstructorDecl & dt,
+                         const std::string & name) const override;
   Term get_constructor(const Sort & s, std::string name) const override;
   Term get_tester(const Sort & s, std::string name) const override;
-  Term get_selector(const Sort & s, std::string con, std::string name) const override;
+  Term get_selector(const Sort & s,
+                    std::string con,
+                    std::string name) const override;
 
   Term make_term(bool b) const override;
   Term make_term(int64_t i, const Sort & sort) const override;

--- a/yices2/include/yices2_sort.h
+++ b/yices2/include/yices2_sort.h
@@ -19,7 +19,6 @@
 #include "exceptions.h"
 #include "sort.h"
 #include "utils.h"
-
 #include "yices.h"
 
 namespace smt {
@@ -31,10 +30,10 @@ class Yices2Sort : public AbsSort
 {
  public:
   // Non-functions
-  Yices2Sort(type_t y_type) : type(y_type), is_function(false){};
+  Yices2Sort(type_t y_type) : type(y_type), is_function(false) {};
 
   // Functions
-  Yices2Sort(type_t y_type, bool is_fun) : type(y_type), is_function(is_fun){};
+  Yices2Sort(type_t y_type, bool is_fun) : type(y_type), is_function(is_fun) {};
 
   ~Yices2Sort() = default;
   std::size_t hash() const override;

--- a/yices2/include/yices2_term.h
+++ b/yices2/include/yices2_term.h
@@ -22,7 +22,6 @@
 #include "term.h"
 #include "utils.h"
 #include "yices.h"
-
 #include "yices2_sort.h"
 
 namespace smt {
@@ -33,9 +32,9 @@ class Yices2Solver;
 class Yices2TermIter : public TermIterBase
 {
  public:
-  Yices2TermIter(term_t t, uint32_t p) : term(t), pos(p){};
+  Yices2TermIter(term_t t, uint32_t p) : term(t), pos(p) {};
   Yices2TermIter(const Yices2TermIter & it);
-  ~Yices2TermIter(){};
+  ~Yices2TermIter() {};
   Yices2TermIter & operator=(const Yices2TermIter & it);
   void operator++() override;
   const Term operator*() override;
@@ -55,9 +54,9 @@ class Yices2Term : public AbsTerm
 {
  public:
   // assumes that term is not a function if flag is not passed
-  Yices2Term(term_t t) : term(t), is_function(false){};
-  Yices2Term(term_t t, bool is_fun) : term(t), is_function(is_fun){};
-  ~Yices2Term(){};
+  Yices2Term(term_t t) : term(t), is_function(false) {};
+  Yices2Term(term_t t, bool is_fun) : term(t), is_function(is_fun) {};
+  ~Yices2Term() {};
   std::size_t hash() const override;
   std::size_t get_id() const override;
   bool compare(const Term & absterm) const override;

--- a/yices2/src/yices2_extensions.cpp
+++ b/yices2/src/yices2_extensions.cpp
@@ -18,6 +18,7 @@
 #define SMT_YICES2_EXTENSIONS_H
 
 #include <inttypes.h>
+
 #include "gmp.h"
 #include "yices.h"
 #include "yices2_solver.h"

--- a/yices2/src/yices2_factory.cpp
+++ b/yices2/src/yices2_factory.cpp
@@ -16,9 +16,8 @@
 
 #include "yices2_factory.h"
 
-#include "yices2_solver.h"
-
 #include "logging_solver.h"
+#include "yices2_solver.h"
 
 namespace smt {
 

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -181,42 +181,54 @@ Term Yices2Solver::make_term(bool b) const
     throw InternalSolverException(msg.c_str());
   }
 
-  return std::make_shared<Yices2Term> (y_term);
+  return std::make_shared<Yices2Term>(y_term);
 }
 
-
-Sort Yices2Solver::make_sort(const DatatypeDecl & d) const {
+Sort Yices2Solver::make_sort(const DatatypeDecl & d) const
+{
   throw NotImplementedException("Yices2Solver::make_sort");
 };
-DatatypeDecl Yices2Solver::make_datatype_decl(const std::string & s)  {
-    throw NotImplementedException("Yices2Solver::make_datatype_decl");
+DatatypeDecl Yices2Solver::make_datatype_decl(const std::string & s)
+{
+  throw NotImplementedException("Yices2Solver::make_datatype_decl");
 }
 DatatypeConstructorDecl Yices2Solver::make_datatype_constructor_decl(
     const std::string s)
 {
   throw NotImplementedException("Yices2Solver::make_datatype_constructor_decl");
 };
-void Yices2Solver::add_constructor(DatatypeDecl & dt, const DatatypeConstructorDecl & con) const {
+void Yices2Solver::add_constructor(DatatypeDecl & dt,
+                                   const DatatypeConstructorDecl & con) const
+{
   throw NotImplementedException("Yices2Solver::add_constructor");
 };
-void Yices2Solver::add_selector(DatatypeConstructorDecl & dt, const std::string & name, const Sort & s) const {
+void Yices2Solver::add_selector(DatatypeConstructorDecl & dt,
+                                const std::string & name,
+                                const Sort & s) const
+{
   throw NotImplementedException("Yices2Solver::add_selector");
 };
-void Yices2Solver::add_selector_self(DatatypeConstructorDecl & dt, const std::string & name) const {
+void Yices2Solver::add_selector_self(DatatypeConstructorDecl & dt,
+                                     const std::string & name) const
+{
   throw NotImplementedException("Yices2Solver::add_selector_self");
 };
 
-Term Yices2Solver::get_constructor(const Sort & s, std::string name) const  {
+Term Yices2Solver::get_constructor(const Sort & s, std::string name) const
+{
   throw NotImplementedException("Yices2Solver::get_constructor");
 };
-Term Yices2Solver::get_tester(const Sort & s, std::string name) const  {
+Term Yices2Solver::get_tester(const Sort & s, std::string name) const
+{
   throw NotImplementedException("Yices2Solver::get_testeer");
 };
 
-Term Yices2Solver::get_selector(const Sort & s, std::string con, std::string name) const  {
+Term Yices2Solver::get_selector(const Sort & s,
+                                std::string con,
+                                std::string name) const
+{
   throw NotImplementedException("Yices2Solver::get_selector");
 };
-
 
 Term Yices2Solver::make_term(int64_t i, const Sort & sort) const
 {
@@ -245,7 +257,7 @@ Term Yices2Solver::make_term(int64_t i, const Sort & sort) const
     throw InternalSolverException(msg.c_str());
   }
 
-  return std::make_shared<Yices2Term> (y_term);
+  return std::make_shared<Yices2Term>(y_term);
 }
 
 Term Yices2Solver::make_term(const std::string val,
@@ -288,7 +300,7 @@ Term Yices2Solver::make_term(const std::string val,
     throw InternalSolverException(msg.c_str());
   }
 
-  return std::make_shared<Yices2Term> (y_term);
+  return std::make_shared<Yices2Term>(y_term);
 }
 
 Term Yices2Solver::make_term(const Term & val, const Sort & sort) const
@@ -430,8 +442,8 @@ Term Yices2Solver::get_value(const Term & t) const
 
   if (!yices_term_is_function(yterm->term))
   {
-    return std::make_shared<Yices2Term>
-        (yices_get_value_as_term(model, yterm->term));
+    return std::make_shared<Yices2Term>(
+        yices_get_value_as_term(model, yterm->term));
   }
   else
   {
@@ -494,7 +506,7 @@ Sort Yices2Solver::make_sort(const std::string name, uint64_t arity) const
     throw InternalSolverException(msg.c_str());
   }
 
-  return std::make_shared<Yices2Sort> (y_sort);
+  return std::make_shared<Yices2Sort>(y_sort);
 }
 
 Sort Yices2Solver::make_sort(SortKind sk) const
@@ -527,7 +539,7 @@ Sort Yices2Solver::make_sort(SortKind sk) const
     throw InternalSolverException(msg.c_str());
   }
 
-  return std::make_shared<Yices2Sort> (y_sort);
+  return std::make_shared<Yices2Sort>(y_sort);
 }
 
 Sort Yices2Solver::make_sort(SortKind sk, uint64_t size) const
@@ -571,13 +583,13 @@ Sort Yices2Solver::make_sort(SortKind sk,
 
   if (sk == ARRAY)
   {
-    ret_sort = std::make_shared<Yices2Sort>
-        (yices_function_type1(s1->type, s2->type));
+    ret_sort =
+        std::make_shared<Yices2Sort>(yices_function_type1(s1->type, s2->type));
   }
   else if (sk == FUNCTION)
   {
-    ret_sort = std::make_shared<Yices2Sort>
-        (yices_function_type1(s1->type, s2->type), true);
+    ret_sort = std::make_shared<Yices2Sort>(
+        yices_function_type1(s1->type, s2->type), true);
   }
   else
   {
@@ -663,7 +675,7 @@ Sort Yices2Solver::make_sort(SortKind sk, const SortVec & sorts) const
     throw InternalSolverException(msg.c_str());
   }
 
-  return std::make_shared<Yices2Sort> (y_sort, true);
+  return std::make_shared<Yices2Sort>(y_sort, true);
 }
 
 Sort Yices2Solver::make_sort(const Sort & sort_con, const SortVec & sorts) const
@@ -801,7 +813,7 @@ Term Yices2Solver::make_term(Op op, const Term & t) const
     throw InternalSolverException(msg.c_str());
   }
 
-  return std::make_shared<Yices2Term> (res);
+  return std::make_shared<Yices2Term>(res);
 }
 
 Term Yices2Solver::make_term(Op op, const Term & t0, const Term & t1) const
@@ -848,11 +860,11 @@ Term Yices2Solver::make_term(Op op, const Term & t0, const Term & t1) const
 
   if (yices_term_is_function(yterm0->term) && op.prim_op == Apply)
   {
-    return std::make_shared<Yices2Term> (res, true);
+    return std::make_shared<Yices2Term>(res, true);
   }
   else
   {
-    return std::make_shared<Yices2Term> (res);
+    return std::make_shared<Yices2Term>(res);
   }
 }
 
@@ -906,11 +918,11 @@ Term Yices2Solver::make_term(Op op,
 
   if (yices_term_is_function(yterm0->term) && op.prim_op == Apply)
   {
-    return std::make_shared<Yices2Term> (res, true);
+    return std::make_shared<Yices2Term>(res, true);
   }
   else
   {
-    return std::make_shared<Yices2Term> (res);
+    return std::make_shared<Yices2Term>(res);
   }
 }
 
@@ -1006,7 +1018,7 @@ Term Yices2Solver::make_term(Op op, const TermVec & terms) const
     throw InternalSolverException(msg.c_str());
   }
 
-  return std::make_shared<Yices2Term> (res);
+  return std::make_shared<Yices2Term>(res);
 }
 
 void Yices2Solver::reset()
@@ -1049,7 +1061,7 @@ Term Yices2Solver::substitute(const Term term,
     throw InternalSolverException(msg.c_str());
   }
 
-  return std::make_shared<Yices2Term> (res);
+  return std::make_shared<Yices2Term>(res);
 }
 
 void Yices2Solver::dump_smt2(std::string filename) const

--- a/yices2/src/yices2_sort.cpp
+++ b/yices2/src/yices2_sort.cpp
@@ -15,7 +15,9 @@
 **/
 
 #include "yices2_sort.h"
+
 #include <sstream>
+
 #include "exceptions.h"
 
 using namespace std;

--- a/yices2/src/yices2_term.cpp
+++ b/yices2/src/yices2_term.cpp
@@ -15,11 +15,12 @@
 **/
 
 #include "yices2_term.h"
+
+#include <unordered_map>
+
 #include "exceptions.h"
 #include "ops.h"
 #include "yices2_sort.h"
-
-#include <unordered_map>
 
 using namespace std;
 
@@ -376,12 +377,13 @@ bool Yices2Term::is_symbol() const
 
   term_constructor_t tc = yices_term_constructor(term);
   return (
-          (tc == YICES_UNINTERPRETED_TERM && yices_term_num_children(term) == 0));
+      (tc == YICES_UNINTERPRETED_TERM && yices_term_num_children(term) == 0));
 }
 
 bool Yices2Term::is_param() const
 {
-  throw NotImplementedException("Yices2 backend does not support parameters yet.");
+  throw NotImplementedException(
+      "Yices2 backend does not support parameters yet.");
 }
 
 bool Yices2Term::is_symbolic_const() const
@@ -500,7 +502,7 @@ string Yices2Term::const_to_string() const
     string repr = yices_term_to_string(term, 120, 1, 0);
     if (repr.substr(0, 2) == "0b")
     {
-      repr = "#b" + repr.substr(2, repr.length()-2);
+      repr = "#b" + repr.substr(2, repr.length() - 2);
     }
     return repr;
   }

--- a/z3/include/z3_datatype.h
+++ b/z3/include/z3_datatype.h
@@ -1,26 +1,26 @@
 #pragma once
-#include "z3++.h"
 #include "datatype.h"
 #include "exceptions.h"
+#include "z3++.h"
 
 namespace smt {
 
 class Z3DatatypeDecl : public AbsDatatypeDecl
 {
  public:
-  Z3DatatypeDecl(std::string name) : name(name){};
+  Z3DatatypeDecl(std::string name) : name(name) {};
 
  protected:
   friend class Z3Solver;
   std::string name;
-  std::vector<DatatypeConstructorDecl> consvec {};
+  std::vector<DatatypeConstructorDecl> consvec{};
 };
 
 class Z3DatatypeConstructorDecl : public AbsDatatypeConstructorDecl
 {
  public:
   Z3DatatypeConstructorDecl(z3::context & c, std::string name)
-      : c(c), constructorname(name){};
+      : c(c), constructorname(name) {};
   bool compare(const DatatypeConstructorDecl &) const override;
 
  protected:
@@ -28,8 +28,8 @@ class Z3DatatypeConstructorDecl : public AbsDatatypeConstructorDecl
 
   z3::context & c;
   std::string constructorname, datatypename;
-  std::vector<z3::symbol> fieldnames {};
-  std::vector<z3::sort> sorts {};
+  std::vector<z3::symbol> fieldnames{};
+  std::vector<z3::sort> sorts{};
 };
 
 class Z3Datatype : public AbsDatatype

--- a/z3/include/z3_solver.h
+++ b/z3/include/z3_solver.h
@@ -44,10 +44,10 @@ class Z3Solver : public AbsSmtSolver
         ctx(),
         slv(ctx),
         context_level(0),
-        last_query_assuming(false){};
+        last_query_assuming(false) {};
   Z3Solver(const Z3Solver &) = delete;
   Z3Solver & operator=(const Z3Solver &) = delete;
-  ~Z3Solver(){};
+  ~Z3Solver() {};
   void set_opt(const std::string option, const std::string value) override;
   void set_logic(const std::string logic) override;
   void assert_formula(const Term & t) override;
@@ -156,6 +156,8 @@ class Z3Solver : public AbsSmtSolver
       throw NotImplementedException("Unimplemented result type from Z3");
     }
   }
-  void add_constructor(z3::sort, z3::constructors*, const DatatypeConstructorDecl&) const;
+  void add_constructor(z3::sort,
+                       z3::constructors *,
+                       const DatatypeConstructorDecl &) const;
 };
 }  // namespace smt

--- a/z3/include/z3_sort.h
+++ b/z3/include/z3_sort.h
@@ -39,7 +39,7 @@ class Z3Sort : public AbsSort
 
   // Functions
   Z3Sort(func_decl zfunc, context & c)
-      : type(c), is_function(true), z_func(zfunc){};
+      : type(c), is_function(true), z_func(zfunc) {};
 
   ~Z3Sort() = default;
   std::size_t hash() const override;

--- a/z3/include/z3_term.h
+++ b/z3/include/z3_term.h
@@ -32,12 +32,12 @@ class Z3TermIter : public TermIterBase
 {
  public:
   Z3TermIter(expr t, uint32_t p, bool nt = false)
-      : term(t), pos(p), null_term(nt){};
+      : term(t), pos(p), null_term(nt) {};
   Z3TermIter(const Z3TermIter & it)
       : term(it.term), pos(it.pos), null_term(it.null_term)
   {
   }
-  ~Z3TermIter(){};
+  ~Z3TermIter() {};
   Z3TermIter & operator=(const Z3TermIter & it);
   void operator++() override;
   const Term operator*() override;
@@ -77,7 +77,7 @@ class Z3Term : public AbsTerm
   {
     ctx = &c;
   };
-  ~Z3Term(){};
+  ~Z3Term() {};
   std::size_t hash() const override;
   std::size_t get_id() const override;
   bool compare(const Term & absterm) const override;

--- a/z3/src/z3_solver.cpp
+++ b/z3/src/z3_solver.cpp
@@ -1251,7 +1251,8 @@ Term Z3Solver::make_term(Op op, const TermVec & terms) const
   }
 }
 
-void Z3Solver::reset() {
+void Z3Solver::reset()
+{
   slv.reset();
   symbol_table.clear();
 }

--- a/z3/src/z3_term.cpp
+++ b/z3/src/z3_term.cpp
@@ -193,8 +193,7 @@ Op Z3Term::get_op() const
         return Op(Select);
         // ternary
       case Z3_OP_ITE: return Op(Ite);
-      case Z3_OP_STORE:
-        return Op(Store);
+      case Z3_OP_STORE: return Op(Store);
       case Z3_OP_CONST_ARRAY:
         return Op();
         // variadic
@@ -228,10 +227,8 @@ Op Z3Term::get_op() const
         size_t out_width = range.bv_size();
         return Op(Int_To_BV, out_width);
       }
-      case Z3_OP_BV2INT:
-        return Op(UBV_To_Int);
-      case Z3_OP_SBV2INT:
-        return Op(SBV_To_Int);
+      case Z3_OP_BV2INT: return Op(UBV_To_Int);
+      case Z3_OP_SBV2INT: return Op(SBV_To_Int);
       case Z3_OP_UNINTERPRETED: return Op(Apply);
 
       default: {


### PR DESCRIPTION
.clang-format has been committed since 2022 but nothing enforced it, and the tree had drifted from it. Reformat the tree and enable the clang-format hook, the last of the formatters that was configured but not enforced.

The reformat touches 83 of the 226 C/C++ files. src/ and include/ were already conformant; the drift was confined to the solver backends, tests/ and one example. Outside of includes the diff is layout only -- brace placement, wrapping, comment reflow, blank-line collapsing and namespace-closing comments -- with no change to the code itself, verified by comparing every changed file with whitespace and comments stripped.

The exception is include ordering: the Google base sorts includes and regroups include blocks, which reorders the includes in 20 files, mostly moving system headers or the related header into Google's canonical grouping.

contrib/memstream-0.1/ is untouched, since the top-level exclude in the pre-commit config already keeps that vendored drop byte-identical to upstream.