### PR TITLE
fix: Modernize and correct the C header includes

### DIFF
--- a/bitwuzla/src/bitwuzla_solver.cpp
+++ b/bitwuzla/src/bitwuzla_solver.cpp
@@ -16,6 +16,7 @@
 
 #include "bitwuzla_solver.h"
 
+#include <cassert>
 #include <cstddef>
 #include <cstdint>
 #include <exception>

--- a/btor/include/boolector_extensions.h
+++ b/btor/include/boolector_extensions.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "boolector.h"
 
 namespace smt {

--- a/btor/include/boolector_solver.h
+++ b/btor/include/boolector_solver.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cassert>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_set>

--- a/btor/include/boolector_sort.h
+++ b/btor/include/boolector_sort.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "boolector.h"
 #include "exceptions.h"
 #include "sort.h"

--- a/btor/include/boolector_term.h
+++ b/btor/include/boolector_term.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "boolector.h"

--- a/btor/src/boolector_extensions.cpp
+++ b/btor/src/boolector_extensions.cpp
@@ -16,8 +16,6 @@
 
 #include "boolector_extensions.h"
 
-#include "math.h"
-
 namespace smt {
 BoolectorNode * custom_boolector_rotate_left(Btor * btor,
                                              BoolectorNode * node,

--- a/btor/src/boolector_extensions.cpp
+++ b/btor/src/boolector_extensions.cpp
@@ -16,6 +16,8 @@
 
 #include "boolector_extensions.h"
 
+#include <cstdint>
+
 namespace smt {
 BoolectorNode * custom_boolector_rotate_left(Btor * btor,
                                              BoolectorNode * node,

--- a/btor/src/boolector_solver.cpp
+++ b/btor/src/boolector_solver.cpp
@@ -16,6 +16,10 @@
 
 #include "boolector_solver.h"
 
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
+
 #include "solver_utils.h"
 
 extern "C" {

--- a/btor/src/boolector_sort.cpp
+++ b/btor/src/boolector_sort.cpp
@@ -16,6 +16,7 @@
 
 #include "boolector_sort.h"
 
+#include <cstdint>
 #include <sstream>
 
 namespace smt {

--- a/btor/src/boolector_term.cpp
+++ b/btor/src/boolector_term.cpp
@@ -22,9 +22,9 @@ extern "C" {
 #include "memstream.h"
 }
 
+#include <cassert>
 #include <unordered_map>
 
-#include "assert.h"
 #include "stdio.h"
 
 // defining hash for old compilers

--- a/btor/src/boolector_term.cpp
+++ b/btor/src/boolector_term.cpp
@@ -23,9 +23,8 @@ extern "C" {
 }
 
 #include <cassert>
+#include <cstdio>
 #include <unordered_map>
-
-#include "stdio.h"
 
 // defining hash for old compilers
 namespace std {

--- a/btor/src/boolector_term.cpp
+++ b/btor/src/boolector_term.cpp
@@ -23,7 +23,9 @@ extern "C" {
 }
 
 #include <cassert>
+#include <cstdint>
 #include <cstdio>
+#include <cstdlib>
 #include <unordered_map>
 
 // defining hash for old compilers

--- a/cvc5/include/cvc5_sort.h
+++ b/cvc5/include/cvc5_sort.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <unordered_map>
 
 #include "cvc5/cvc5.h"

--- a/cvc5/include/cvc5_term.h
+++ b/cvc5/include/cvc5_term.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "cvc5/cvc5.h"
 #include "term.h"
 #include "utils.h"

--- a/cvc5/src/cvc5_sort.cpp
+++ b/cvc5/src/cvc5_sort.cpp
@@ -16,6 +16,8 @@
 
 #include "cvc5_sort.h"
 
+#include <cstdint>
+
 #include "cvc5_datatype.h"
 #include "exceptions.h"
 

--- a/cvc5/src/cvc5_term.cpp
+++ b/cvc5/src/cvc5_term.cpp
@@ -17,6 +17,7 @@
 #include "cvc5_term.h"
 
 #include <cassert>
+#include <cstdint>
 #include <string>
 
 #include "cvc5/cvc5.h"

--- a/cvc5/src/cvc5_term.cpp
+++ b/cvc5/src/cvc5_term.cpp
@@ -16,9 +16,9 @@
 
 #include "cvc5_term.h"
 
+#include <cassert>
 #include <string>
 
-#include "assert.h"
 #include "cvc5/cvc5.h"
 #include "cvc5_sort.h"
 #include "exceptions.h"

--- a/msat/include/msat_solver.h
+++ b/msat/include/msat_solver.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cassert>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/msat/include/msat_sort.h
+++ b/msat/include/msat_sort.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "mathsat.h"
 #include "sort.h"
 

--- a/msat/include/msat_term.h
+++ b/msat/include/msat_term.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "mathsat.h"
 #include "term.h"
 #include "utils.h"

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -16,6 +16,9 @@
 
 #include "msat_solver.h"
 
+#include <cassert>
+#include <cstdint>
+#include <cstdio>
 #include <sstream>
 #include <unordered_map>
 #include <vector>

--- a/msat/src/msat_sort.cpp
+++ b/msat/src/msat_sort.cpp
@@ -16,6 +16,8 @@
 
 #include "msat_sort.h"
 
+#include <cstdint>
+
 #include "exceptions.h"
 
 using namespace std;

--- a/msat/src/msat_term.cpp
+++ b/msat/src/msat_term.cpp
@@ -16,9 +16,9 @@
 
 #include "msat_term.h"
 
+#include <cassert>
 #include <unordered_map>
 
-#include "assert.h"
 #include "exceptions.h"
 #include "msat_sort.h"
 #include "ops.h"

--- a/msat/src/msat_term.cpp
+++ b/msat/src/msat_term.cpp
@@ -17,6 +17,7 @@
 #include "msat_term.h"
 
 #include <cassert>
+#include <cstdint>
 #include <unordered_map>
 
 #include "exceptions.h"

--- a/src/generic_sort.cpp
+++ b/src/generic_sort.cpp
@@ -17,6 +17,7 @@
 
 #include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_map>

--- a/src/logging_solver.cpp
+++ b/src/logging_solver.cpp
@@ -17,6 +17,7 @@
 #include "logging_solver.h"
 
 #include <cassert>
+#include <cstdint>
 #include <memory>
 #include <unordered_set>
 

--- a/src/logging_sort.cpp
+++ b/src/logging_sort.cpp
@@ -17,6 +17,7 @@
 #include "logging_sort.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 #include <string>
 

--- a/src/logging_term.cpp
+++ b/src/logging_term.cpp
@@ -17,6 +17,7 @@
 #include "logging_term.h"
 
 #include <cstddef>
+#include <cstdint>
 #include <memory>
 
 #include "sort.h"

--- a/src/smtlib_reader.cpp
+++ b/src/smtlib_reader.cpp
@@ -16,7 +16,9 @@
 
 #include "smtlib_reader.h"
 
+#include <cassert>
 #include <cstddef>
+#include <cstdint>
 #include <iostream>
 #include <string>
 #include <unordered_map>

--- a/src/smtlibparser.yy
+++ b/src/smtlibparser.yy
@@ -15,6 +15,7 @@
 **
 **/
 
+#include <cassert>
 #include <cstdio>
 #include <iostream>
 using namespace std;

--- a/src/smtlibscanner.l
+++ b/src/smtlibscanner.l
@@ -14,8 +14,8 @@
 **
 **
 **/
+#include <cstdio>
 #include <iostream>
-#include "stdio.h"
 #include "smtlib_reader.h"
 #include "smtlibparser.h"
 using namespace std;

--- a/src/smtlibscanner.l
+++ b/src/smtlibscanner.l
@@ -15,6 +15,8 @@
 **
 **/
 #include <cstdio>
+#include <cstdlib>
+#include <cstring>
 #include <iostream>
 #include "smtlib_reader.h"
 #include "smtlibparser.h"

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -17,6 +17,7 @@
 #include "utils.h"
 
 #include <algorithm>
+#include <cassert>
 #include <cstddef>
 #include <map>
 #include <random>

--- a/tests/btor/btor-array-empty-assignment.cpp
+++ b/tests/btor/btor-array-empty-assignment.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-array-models.cpp
+++ b/tests/btor/btor-array-models.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-arrays.cpp
+++ b/tests/btor/btor-arrays.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-const-arrays.cpp
+++ b/tests/btor/btor-const-arrays.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-data-structures.cpp
+++ b/tests/btor/btor-data-structures.cpp
@@ -14,10 +14,10 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <string>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-exceptions.cpp
+++ b/tests/btor/btor-exceptions.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-incremental.cpp
+++ b/tests/btor/btor-incremental.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after full installation

--- a/tests/btor/btor-indexed-op-tests.cpp
+++ b/tests/btor/btor-indexed-op-tests.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-neg-numbers.cpp
+++ b/tests/btor/btor-neg-numbers.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-negation.cpp
+++ b/tests/btor/btor-negation.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-opts.cpp
+++ b/tests/btor/btor-opts.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "gtest/gtest.h"
 #include "smt.h"

--- a/tests/btor/btor-simple.cpp
+++ b/tests/btor/btor-simple.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-substitute.cpp
+++ b/tests/btor/btor-substitute.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-tests.cpp
+++ b/tests/btor/btor-tests.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/btor/btor-transfer.cpp
+++ b/tests/btor/btor-transfer.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "boolector_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/bzla/bzla-interpolants.cpp
+++ b/tests/bzla/bzla-interpolants.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "bitwuzla_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/bzla/bzla-seq-interpolants.cpp
+++ b/tests/bzla/bzla-seq-interpolants.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "bitwuzla_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/cvc5/cvc5-arrays.cpp
+++ b/tests/cvc5/cvc5-arrays.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "cvc5_factory.h"
 #include "smt.h"
 // after full installation

--- a/tests/cvc5/cvc5-data-structures.cpp
+++ b/tests/cvc5/cvc5-data-structures.cpp
@@ -14,10 +14,10 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <string>
 
-#include "assert.h"
 #include "cvc5_factory.h"
 #include "smt.h"
 // after full installation

--- a/tests/cvc5/cvc5-incremental.cpp
+++ b/tests/cvc5/cvc5-incremental.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "cvc5_factory.h"
 #include "smt.h"
 // after full installation

--- a/tests/cvc5/cvc5-indexed-op-tests.cpp
+++ b/tests/cvc5/cvc5-indexed-op-tests.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "cvc5_factory.h"
 #include "smt.h"
 // after full installation

--- a/tests/cvc5/cvc5-int-arithmetic.cpp
+++ b/tests/cvc5/cvc5-int-arithmetic.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "cvc5_factory.h"
 #include "smt.h"
 // after full installation

--- a/tests/cvc5/cvc5-interpolants.cpp
+++ b/tests/cvc5/cvc5-interpolants.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "cvc5_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/cvc5/cvc5-neg-numbers.cpp
+++ b/tests/cvc5/cvc5-neg-numbers.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "cvc5_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/cvc5/cvc5-str.cpp
+++ b/tests/cvc5/cvc5-str.cpp
@@ -13,11 +13,11 @@
 ** Tests for strings in the cvc5 backend.
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "cvc5_factory.h"
 #include "smt.h"
 

--- a/tests/cvc5/cvc5-term-iter.cpp
+++ b/tests/cvc5/cvc5-term-iter.cpp
@@ -14,9 +14,9 @@
 **
 **/
 
+#include <cassert>
 #include <vector>
 
-#include "assert.h"
 #include "cvc5/cvc5.h"
 #include "cvc5_term.h"
 #include "gtest/gtest.h"

--- a/tests/cvc5/cvc5-tests.cpp
+++ b/tests/cvc5/cvc5-tests.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "cvc5_factory.h"
 #include "smt.h"
 // after full installation

--- a/tests/cvc5/cvc5-transfer.cpp
+++ b/tests/cvc5/cvc5-transfer.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "cvc5_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-array-models.cpp
+++ b/tests/msat/msat-array-models.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-arrays.cpp
+++ b/tests/msat/msat-arrays.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-arrays2.cpp
+++ b/tests/msat/msat-arrays2.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-const-arrays.cpp
+++ b/tests/msat/msat-const-arrays.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-data-structures.cpp
+++ b/tests/msat/msat-data-structures.cpp
@@ -14,10 +14,10 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <string>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-ext-ops.cpp
+++ b/tests/msat/msat-ext-ops.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-incremental.cpp
+++ b/tests/msat/msat-incremental.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "msat_solver.h"  // only needed for the static_pointer_cast for testing
 #include "smt.h"

--- a/tests/msat/msat-indexed-op-tests.cpp
+++ b/tests/msat/msat-indexed-op-tests.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-int-arithmetic.cpp
+++ b/tests/msat/msat-int-arithmetic.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after full installation

--- a/tests/msat/msat-interpolants.cpp
+++ b/tests/msat/msat-interpolants.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-ite-test.cpp
+++ b/tests/msat/msat-ite-test.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-neg-numbers.cpp
+++ b/tests/msat/msat-neg-numbers.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-seq-interpolants.cpp
+++ b/tests/msat/msat-seq-interpolants.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-substitute.cpp
+++ b/tests/msat/msat-substitute.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-tests.cpp
+++ b/tests/msat/msat-tests.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-transfer.cpp
+++ b/tests/msat/msat-transfer.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/msat/msat-traversal.cpp
+++ b/tests/msat/msat-traversal.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "msat_factory.h"
 #include "smt.h"
 // after a full installation

--- a/tests/test-bv.cpp
+++ b/tests/test-bv.cpp
@@ -14,6 +14,7 @@
 **
 **/
 
+#include <cstdint>
 #include <utility>
 #include <vector>
 

--- a/tests/test-dt.cpp
+++ b/tests/test-dt.cpp
@@ -14,6 +14,7 @@
 **
 **/
 
+#include <cassert>
 #include <utility>
 #include <vector>
 

--- a/tests/test-int.cpp
+++ b/tests/test-int.cpp
@@ -14,6 +14,7 @@
 **
 **/
 
+#include <cassert>
 #include <utility>
 #include <vector>
 

--- a/tests/test-str.cpp
+++ b/tests/test-str.cpp
@@ -13,6 +13,7 @@
 ** Tests for theory of strings.
 **/
 
+#include <cassert>
 #include <utility>
 #include <vector>
 

--- a/tests/test-time-limit.cpp
+++ b/tests/test-time-limit.cpp
@@ -14,9 +14,8 @@
 **
 **/
 
-#include <math.h>
-
 #include <chrono>
+#include <cmath>
 #include <utility>
 #include <vector>
 
@@ -55,7 +54,7 @@ TEST_P(TimeLimitTests, TestTimeLimit)
 
   s->assert_formula(s->make_symbol("b", s->make_sort(BOOL)));
 
-  size_t num_vars = (size_t)pow(2, width) + 1;
+  size_t num_vars = (size_t)std::pow(2, width) + 1;
   TermVec vars;
   vars.reserve(num_vars);
   for (size_t i = 0; i < num_vars; ++i)

--- a/tests/unit/unit-reset-assertions.cpp
+++ b/tests/unit/unit-reset-assertions.cpp
@@ -18,6 +18,8 @@
 **
 **/
 
+#include <cassert>
+
 #include "available_solvers.h"
 #include "gtest/gtest.h"
 #include "smt.h"

--- a/tests/unit/unit-walker.cpp
+++ b/tests/unit/unit-walker.cpp
@@ -14,6 +14,7 @@
 **
 **/
 
+#include <cassert>
 #include <utility>
 #include <vector>
 

--- a/tests/yices2/yices2-array-models.cpp
+++ b/tests/yices2/yices2-array-models.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "smt.h"
 #include "yices2_factory.h"
 // after a full installation

--- a/tests/yices2/yices2-arrays.cpp
+++ b/tests/yices2/yices2-arrays.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "smt.h"
 #include "yices2_factory.h"
 // after a full installation

--- a/tests/yices2/yices2-arrays2.cpp
+++ b/tests/yices2/yices2-arrays2.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "smt.h"
 #include "yices2_factory.h"
 // after a full installation

--- a/tests/yices2/yices2-ext-ops.cpp
+++ b/tests/yices2/yices2-ext-ops.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "smt.h"
 #include "yices2_factory.h"
 // after a full installation

--- a/tests/yices2/yices2-incremental.cpp
+++ b/tests/yices2/yices2-incremental.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "smt.h"
 #include "yices2_factory.h"
 // after full installation

--- a/tests/yices2/yices2-indexed-op-tests.cpp
+++ b/tests/yices2/yices2-indexed-op-tests.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "smt.h"
 #include "yices2_factory.h"
 // after a full installation

--- a/tests/yices2/yices2-ite-test.cpp
+++ b/tests/yices2/yices2-ite-test.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "smt.h"
 #include "yices2_factory.h"
 // after a full installation

--- a/tests/yices2/yices2-neg-numbers.cpp
+++ b/tests/yices2/yices2-neg-numbers.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "smt.h"
 #include "yices2_factory.h"
 // after a full installation

--- a/tests/yices2/yices2-polynomial.cpp
+++ b/tests/yices2/yices2-polynomial.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "gmp.h"
 #include "smt.h"
 #include "yices.h"

--- a/tests/yices2/yices2-tests.cpp
+++ b/tests/yices2/yices2-tests.cpp
@@ -14,11 +14,11 @@
 **
 **/
 
+#include <cassert>
 #include <iostream>
 #include <memory>
 #include <vector>
 
-#include "assert.h"
 #include "smt.h"
 #include "yices2_factory.h"
 // after a full installation

--- a/tests/z3/z3_full.cpp
+++ b/tests/z3/z3_full.cpp
@@ -1,6 +1,6 @@
+#include <cassert>
 #include <iostream>
 
-#include "assert.h"
 #include "smt.h"
 #include "z3_factory.h"
 #include "z3_sort.h"

--- a/tests/z3/z3_test.cpp
+++ b/tests/z3/z3_test.cpp
@@ -1,6 +1,6 @@
+#include <cassert>
 #include <iostream>
 
-#include "assert.h"
 #include "smt.h"
 #include "z3_factory.h"
 #include "z3_sort.h"

--- a/yices2/include/yices2_solver.h
+++ b/yices2/include/yices2_solver.h
@@ -19,6 +19,7 @@
 #include <gmp.h>
 #include <yices.h>
 
+#include <cstdint>
 #include <memory>
 #include <string>
 #include <unordered_set>

--- a/yices2/include/yices2_sort.h
+++ b/yices2/include/yices2_sort.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "exceptions.h"
 #include "sort.h"
 #include "utils.h"

--- a/yices2/include/yices2_term.h
+++ b/yices2/include/yices2_term.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "gmp.h"

--- a/yices2/src/yices2_extensions.cpp
+++ b/yices2/src/yices2_extensions.cpp
@@ -17,8 +17,6 @@
 #ifndef SMT_YICES2_EXTENSIONS_H
 #define SMT_YICES2_EXTENSIONS_H
 
-#include <inttypes.h>
-
 #include "gmp.h"
 #include "yices.h"
 #include "yices2_solver.h"

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -19,6 +19,7 @@
 #include <signal.h>
 #include <unistd.h>
 
+#include <cassert>
 #include <cstdint>
 
 #include "solver_utils.h"

--- a/yices2/src/yices2_solver.cpp
+++ b/yices2/src/yices2_solver.cpp
@@ -16,9 +16,10 @@
 
 #include "yices2_solver.h"
 
-#include <inttypes.h>
 #include <signal.h>
 #include <unistd.h>
+
+#include <cstdint>
 
 #include "solver_utils.h"
 #include "yices.h"

--- a/yices2/src/yices2_sort.cpp
+++ b/yices2/src/yices2_sort.cpp
@@ -16,6 +16,7 @@
 
 #include "yices2_sort.h"
 
+#include <cstdint>
 #include <sstream>
 
 #include "exceptions.h"

--- a/yices2/src/yices2_term.cpp
+++ b/yices2/src/yices2_term.cpp
@@ -16,6 +16,7 @@
 
 #include "yices2_term.h"
 
+#include <cstdint>
 #include <unordered_map>
 
 #include "exceptions.h"

--- a/z3/include/z3_solver.h
+++ b/z3/include/z3_solver.h
@@ -18,6 +18,7 @@
 
 #include <z3++.h>
 
+#include <cstdint>
 #include <string>
 #include <unordered_set>
 #include <vector>

--- a/z3/include/z3_sort.h
+++ b/z3/include/z3_sort.h
@@ -16,6 +16,8 @@
 
 #pragma once
 
+#include <cstdint>
+
 #include "exceptions.h"
 #include "sort.h"
 #include "utils.h"

--- a/z3/include/z3_term.h
+++ b/z3/include/z3_term.h
@@ -16,6 +16,7 @@
 
 #pragma once
 
+#include <cstdint>
 #include <vector>
 
 #include "term.h"

--- a/z3/src/z3_solver.cpp
+++ b/z3/src/z3_solver.cpp
@@ -2,6 +2,7 @@
 
 #include <z3++.h>
 
+#include <cassert>
 #include <cstdint>
 #include <exception>
 #include <iostream>

--- a/z3/src/z3_solver.cpp
+++ b/z3/src/z3_solver.cpp
@@ -1,8 +1,8 @@
 #include "z3_solver.h"
 
-#include <inttypes.h>
 #include <z3++.h>
 
+#include <cstdint>
 #include <exception>
 #include <iostream>
 #include <iterator>

--- a/z3/src/z3_sort.cpp
+++ b/z3/src/z3_sort.cpp
@@ -1,5 +1,6 @@
 #include "z3_sort.h"
 
+#include <cstdint>
 #include <sstream>
 
 #include "exceptions.h"

--- a/z3/src/z3_term.cpp
+++ b/z3/src/z3_term.cpp
@@ -1,5 +1,7 @@
 #include "z3_term.h"
 
+#include <cassert>
+#include <cstdint>
 #include <unordered_map>
 
 #include "exceptions.h"


### PR DESCRIPTION
Replaces the old-style C includes with their C++ names: 60 files used
`#include "assert.h"`, which searches the including file's own directory
first, plus a few `"stdio.h"`, `"math.h"` and `<inttypes.h>`.

Also adds 67 includes to 45 files that used a C library symbol without
including the header declaring it, compiling only because something else
dragged it in. `yices2_solver.cpp` is the clearest case: four `assert()`
calls and no `<cassert>` anywhere.

Two unused includes are dropped: `"math.h"` from
`boolector_extensions.cpp` and `<inttypes.h>` from
`yices2_extensions.cpp`. The one `pow` call is now `std::pow`.

Both `<signal.h>` includes stay, since `<csignal>` does not cover the
POSIX `kill`, `SIGKILL` and `SIGALRM` these files need. `<unistd.h>`
and `<sys/*.h>` have no C++ spelling, and vendored
`contrib/memstream-0.1/` is untouched.

This finishes the convention the core `include/` headers and the
bitwuzla and cvc5 backends already followed. Include placement is
clang-format's.