### PR TITLE
fix: Link GMP by name so a static link can pick the archive

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -183,10 +183,6 @@ if(BUILD_PYTHON_BINDINGS)
   find_package(Python 3.9 REQUIRED COMPONENTS Interpreter Development.Module)
 endif()
 
-if(BUILD_BITWUZLA OR BUILD_CVC5 OR BUILD_MSAT OR BUILD_YICES2 OR BUILD_Z3)
-  find_package(GMP REQUIRED)
-endif()
-
 # should we build boolector?
 option(BUILD_BTOR "Should we build the libraries for boolector" OFF)
 if(BUILD_BTOR)

--- a/README.md
+++ b/README.md
@@ -65,7 +65,8 @@ Smt-Switch depends on the following libraries. Dependencies needed only for cert
   * MathSAT (must be obtained independently; user responsible for meeting license conditions)
   * Yices2 (must be obtained independently; user responsible for meeting license conditions)
 * pthread [optional: Bitwuzla]
-* gmp [optional: cvc5, MathSAT, Yices2]
+* gmp [optional: cvc5, MathSAT, Yices2, Z3]
+* gmpxx, the gmp C++ bindings [optional: MathSAT, Z3]
 * autoconf [optional: Yices2 setup script]
 * Flex >= 2.6.4 [optional: SMT-LIB parser]
 * Bison >= 3.7 [optional: SMT-LIB parser]
@@ -102,6 +103,9 @@ If you'd like to try your own version of a solver, you can use the `configure.sh
 `./configure.sh --prefix=<your desired install location> --cvc5-home ./custom-cvc5`
 
 where `./custom-cvc5/build/src/libcvc5.a` and `./custom-cvc5/build/src/parser/libcvc5parser.a` already exist. `build` is the default build directory for `cvc5`, and thus that's where `cmake` is configured to look.
+
+## Static Linking
+GMP is linked by name (`-lgmp`) rather than by path, so a fully static link (`-static`) picks up `libgmp.a` and an ordinary one keeps using the shared library, with nothing to configure either way. GMP is not bundled into the installed `libsmt-switch-<solver>.a`, so a consumer still has to name it on its own link line. If that link is fully static and mixes a backend needing the C++ bindings (MathSAT, Z3) with one needing only the C library (cvc5, Yices2), put `-lgmpxx` before `-lgmp`: `libgmpxx` references symbols from `libgmp`, and an archive only resolves what is still undefined by the time the linker reaches it.
 
 # Building Tests
 You can run all tests for the currently built solvers with `make test` from the build directory. To run a single test, run the binary `./tests/<test name>`. After you have a full installation, you can build the tests yourself by updating the includes to include the `smt-switch` directory. For example: `#include "cvc5_factory.h"` -> `#include "smt-switch/cvc5_factory.h"`.

--- a/cmake/FindGMP.cmake
+++ b/cmake/FindGMP.cmake
@@ -1,19 +1,165 @@
-# Find GMP
-# GMP_FOUND - system has GMP lib
-# GMP_INCLUDE_DIR - the GMP include directory
-# GMP_LIBRARIES - Libraries needed to use GMP
+#[=======================================================================[.rst:
+FindGMP
+-------
 
-find_path(GMP_INCLUDE_DIR NAMES gmp.h gmpxx.h)
-find_library(GMP_LIBRARIES NAMES gmp)
-find_library(GMPXX_LIBRARIES NAMES gmpxx)
+Finds the GNU Multiple Precision Arithmetic Library (GMP) and, optionally, its
+C++ bindings.
+
+Components
+^^^^^^^^^^
+
+``gmp``
+  The C library, ``libgmp`` and ``gmp.h``.  Requested by default.
+``gmpxx``
+  The C++ bindings, ``libgmpxx`` and ``gmpxx.h``.  Requesting these implies
+  ``gmp``, because ``libgmpxx`` is built on top of ``libgmp``::
+
+    find_package(GMP REQUIRED COMPONENTS gmpxx)
+
+Imported Targets
+^^^^^^^^^^^^^^^^
+
+This module provides the following imported targets, if found:
+
+``GMP::gmp``
+  The GMP C library.
+``GMP::gmpxx``
+  The GMP C++ bindings.  Depends on ``GMP::gmp``, so linking against this
+  target alone is enough, and the two libraries reach the link line in an
+  order that resolves.
+
+Both targets name their library rather than pointing at the file that was
+found, so that the linker picks the shared library or the static archive
+depending on how the consumer is being linked.  An imported target with an
+``IMPORTED_LOCATION`` would name ``libgmp.so`` by absolute path, which stays on
+the link line even under ``-static``, leaving a dynamic dependency on GMP in
+what was supposed to be a static binary.
+
+Result Variables
+^^^^^^^^^^^^^^^^
+
+This module defines the following variables:
+
+``GMP_FOUND``
+  Boolean indicating whether GMP and every requested component were found.
+``GMP_gmp_FOUND``, ``GMP_gmpxx_FOUND``
+  Booleans indicating whether the individual components were found.
+``GMP_INCLUDE_DIRS``
+  The include directories of the requested components.
+``GMP_LIBRARY_DIRS``
+  The directories holding the libraries of the requested components.
+``GMP_LINK_LIBRARIES``
+  The names of the libraries of the requested components, in the order they
+  have to be linked in.  Together with ``GMP_LIBRARY_DIRS`` this is what the
+  imported targets above expand to; prefer the targets, and reach for these
+  variables only where a target cannot be used, such as when handing the flags
+  to a build system other than CMake.
+
+Cache Variables
+^^^^^^^^^^^^^^^
+
+The following cache variables may also be set:
+
+``GMP_INCLUDE_DIR``
+  The directory containing ``gmp.h``.
+``GMP_gmpxx_INCLUDE_DIR``
+  The directory containing ``gmpxx.h``.  Not necessarily the directory above:
+  Debian and its derivatives install ``gmp.h`` into the architecture-specific
+  include directory, but not ``gmpxx.h``.
+``GMP_gmp_LIBRARY``
+  The path to the GMP C library.
+``GMP_gmpxx_LIBRARY``
+  The path to the GMP C++ bindings library.
+
+#]=======================================================================]
+
+# The C++ bindings cannot be used on their own: libgmpxx is built on top of
+# libgmp, and gmpxx.h includes gmp.h. Requesting them therefore implies the C
+# library, at the same level of requiredness.
+if(NOT GMP_FIND_COMPONENTS)
+  set(GMP_FIND_COMPONENTS gmp)
+endif()
+if("gmpxx" IN_LIST GMP_FIND_COMPONENTS AND NOT "gmp" IN_LIST GMP_FIND_COMPONENTS)
+  list(APPEND GMP_FIND_COMPONENTS gmp)
+  set(GMP_FIND_REQUIRED_gmp "${GMP_FIND_REQUIRED_gmpxx}")
+endif()
+
+find_path(GMP_INCLUDE_DIR NAMES gmp.h)
+find_path(GMP_gmpxx_INCLUDE_DIR NAMES gmpxx.h)
+find_library(GMP_gmp_LIBRARY NAMES gmp)
+find_library(GMP_gmpxx_LIBRARY NAMES gmpxx)
+mark_as_advanced(GMP_INCLUDE_DIR GMP_gmpxx_INCLUDE_DIR GMP_gmp_LIBRARY GMP_gmpxx_LIBRARY)
+
+set(GMP_gmp_FOUND FALSE)
+if(GMP_INCLUDE_DIR AND GMP_gmp_LIBRARY)
+  set(GMP_gmp_FOUND TRUE)
+endif()
+
+set(GMP_gmpxx_FOUND FALSE)
+if(GMP_gmp_FOUND AND GMP_gmpxx_INCLUDE_DIR AND GMP_gmpxx_LIBRARY)
+  set(GMP_gmpxx_FOUND TRUE)
+endif()
 
 include(FindPackageHandleStandardArgs)
-find_package_handle_standard_args(GMP DEFAULT_MSG GMP_INCLUDE_DIR GMP_LIBRARIES)
+# The C library is required whichever components were asked for, because the
+# expansion above adds it to every request that does not name it already.
+find_package_handle_standard_args(
+  GMP
+  REQUIRED_VARS GMP_gmp_LIBRARY GMP_INCLUDE_DIR
+  HANDLE_COMPONENTS
+)
 
-mark_as_advanced(GMP_INCLUDE_DIR GMP_LIBRARIES)
-if(GMP_LIBRARIES)
-  message(STATUS "Found GMP libs: ${GMP_LIBRARIES}")
-endif()
-if(GMPXX_LIBRARIES)
-  message(STATUS "Found GMPXX libs: ${GMPXX_LIBRARIES}")
+if(GMP_FOUND)
+  get_filename_component(gmp_library_dir "${GMP_gmp_LIBRARY}" DIRECTORY)
+
+  # Report what was requested rather than what happens to be installed, so
+  # that a consumer of the C library alone does not end up linking libgmpxx.
+  set(GMP_INCLUDE_DIRS "${GMP_INCLUDE_DIR}")
+  set(GMP_LIBRARY_DIRS "${gmp_library_dir}")
+  set(GMP_LINK_LIBRARIES gmp)
+
+  # Name the library instead of the file that was found. This is the whole
+  # point of the module: -lgmp lets a static link substitute libgmp.a, and
+  # CMake still derives the rpath from the link directory, so a GMP outside
+  # the system prefix is found at run time all the same.
+  if(NOT TARGET GMP::gmp)
+    add_library(GMP::gmp INTERFACE IMPORTED GLOBAL)
+    set_target_properties(
+      GMP::gmp
+      PROPERTIES
+        INTERFACE_INCLUDE_DIRECTORIES "${GMP_INCLUDE_DIR}"
+        INTERFACE_LINK_DIRECTORIES "${gmp_library_dir}"
+        INTERFACE_LINK_LIBRARIES gmp
+    )
+  endif()
+
+  if(GMP_gmpxx_FOUND)
+    get_filename_component(gmpxx_library_dir "${GMP_gmpxx_LIBRARY}" DIRECTORY)
+
+    if("gmpxx" IN_LIST GMP_FIND_COMPONENTS)
+      list(APPEND GMP_INCLUDE_DIRS "${GMP_gmpxx_INCLUDE_DIR}")
+      list(APPEND GMP_LIBRARY_DIRS "${gmpxx_library_dir}")
+      list(REMOVE_DUPLICATES GMP_INCLUDE_DIRS)
+      list(REMOVE_DUPLICATES GMP_LIBRARY_DIRS)
+      # libgmpxx has to be linked before libgmp: it references symbols from
+      # the C library, and an archive only resolves what is undefined by the
+      # time the linker reaches it.
+      set(GMP_LINK_LIBRARIES gmpxx gmp)
+    endif()
+
+    # Created whenever the C++ bindings are installed, even if they were not
+    # requested here, so that another directory may link them without asking
+    # again. Linking a target that does not exist is a configure-time error,
+    # never a silent misbuild.
+    if(NOT TARGET GMP::gmpxx)
+      add_library(GMP::gmpxx INTERFACE IMPORTED GLOBAL)
+      set_target_properties(
+        GMP::gmpxx
+        PROPERTIES
+          INTERFACE_INCLUDE_DIRECTORIES "${GMP_gmpxx_INCLUDE_DIR}"
+          INTERFACE_LINK_DIRECTORIES "${gmpxx_library_dir}"
+          INTERFACE_LINK_LIBRARIES "gmpxx;GMP::gmp"
+      )
+    endif()
+  endif()
 endif()

--- a/cvc5/CMakeLists.txt
+++ b/cvc5/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+find_package(GMP REQUIRED)
+
 find_library(LIBRT rt)
 
 add_library(
@@ -18,7 +20,6 @@ target_include_directories(smt-switch-cvc5 PUBLIC "${CVC5_HOME}/src")
 target_include_directories(smt-switch-cvc5 PUBLIC "${CVC5_HOME}/include")
 # TEMP only until the internal kinds are no longer part of public API
 target_include_directories(smt-switch-cvc5 PUBLIC "${CVC5_HOME}/build/include")
-target_include_directories(smt-switch-cvc5 PUBLIC ${GMP_INCLUDE_DIR})
 
 if(LIBRT)
   target_link_libraries(smt-switch-cvc5 ${LIBRT})
@@ -36,7 +37,7 @@ target_link_libraries(smt-switch-cvc5 "${POLYLIBXX}")
 target_link_libraries(smt-switch-cvc5 "${POLYLIB}")
 target_link_libraries(smt-switch-cvc5 "${CADICAL}")
 target_link_libraries(smt-switch-cvc5 smt-switch)
-target_link_libraries(smt-switch-cvc5 ${GMP_LIBRARIES})
+target_link_libraries(smt-switch-cvc5 GMP::gmp)
 
 if(SMT_SWITCH_LIB_TYPE STREQUAL STATIC)
   # we want the static library to include the cvc5 source and dependencies (except GMP)

--- a/msat/CMakeLists.txt
+++ b/msat/CMakeLists.txt
@@ -1,5 +1,7 @@
 set(CMAKE_POSITION_INDEPENDENT_CODE ON)
 
+find_package(GMP REQUIRED COMPONENTS gmpxx)
+
 add_library(
   smt-switch-msat
   "${SMT_SWITCH_LIB_TYPE}"
@@ -13,12 +15,10 @@ target_include_directories(smt-switch-msat PUBLIC "${PROJECT_SOURCE_DIR}/include
 target_include_directories(smt-switch-msat PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_include_directories(smt-switch-msat PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/msat/include")
 target_include_directories(smt-switch-msat PUBLIC "${MSAT_HOME}/include/")
-target_include_directories(smt-switch-msat PUBLIC "${GMP_INCLUDE_DIR}")
 
 target_link_libraries(smt-switch-msat "${MSAT_HOME}/lib/libmathsat.a")
 target_link_libraries(smt-switch-msat smt-switch)
-target_link_libraries(smt-switch-msat ${GMP_LIBRARIES})
-target_link_libraries(smt-switch-msat ${GMPXX_LIBRARIES})
+target_link_libraries(smt-switch-msat GMP::gmpxx)
 
 if(SMT_SWITCH_LIB_TYPE STREQUAL STATIC)
   # we want the static library to include the mathsat source

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -11,6 +11,17 @@ include(CheckPythonModule)
 # Verify required Python packages are installed
 check_python_module("packaging")
 
+# setup.py links the extension module itself rather than through a CMake
+# target, so it needs the GMP flags of whichever backends were enabled.
+if(BUILD_CVC5 OR BUILD_MSAT OR BUILD_YICES2 OR BUILD_Z3)
+  if(BUILD_MSAT OR BUILD_Z3)
+    # The MathSAT and Z3 backends use the C++ bindings as well.
+    find_package(GMP REQUIRED COMPONENTS gmpxx)
+  else()
+    find_package(GMP REQUIRED)
+  endif()
+endif()
+
 configure_file(
   "${CMAKE_CURRENT_SOURCE_DIR}/gen-smt-solver-declarations.py"
   "${CMAKE_CURRENT_BINARY_DIR}/gen-smt-solver-declarations.py"

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -13,6 +13,10 @@ SMT_SWITCH_LIB_TYPE = "@SMT_SWITCH_LIB_TYPE@"
 SOLVER_BACKEND_LIBS = "@SOLVER_BACKEND_LIBS@".split(";")
 BITWUZLA_LDFLAGS = "@BITWUZLA_LDFLAGS@".split(";")
 Z3_LIBRARY_LOCATION = "@Z3_LIBRARY_LOCATION@"
+# Resolved by cmake/FindGMP.cmake, and empty unless a backend needs GMP. The
+# libraries are already in the order they have to be linked in.
+GMP_LINK_LIBRARIES = [lib for lib in "@GMP_LINK_LIBRARIES@".split(";") if lib]
+GMP_LIBRARY_DIRS = [path for path in "@GMP_LIBRARY_DIRS@".split(";") if path]
 
 # Get the platform-specific library extension
 if sys.platform == "darwin":
@@ -95,11 +99,8 @@ if not os.path.isfile(os.path.join("smt_switch", ext_filename)):
         extra_link_args.append(f"-Wl,-rpath,{path}")
     if SMT_SWITCH_LIB_TYPE == "STATIC":
         # When smt-switch is compiled as a static library, we need to link dependencies manually.
-        for gmp_solver in ["cvc5", "msat", "yices2", "z3"]:
-            # Some solver implementations need GMP.
-            if gmp_solver in built_solvers:
-                solver_libraries += ["gmp", "gmpxx"]
-                break
+        # Some solver implementations need GMP, in which case CMake has found it for us.
+        solver_libraries += GMP_LINK_LIBRARIES
         # Some solvers have their own linking flags.
         if "bitwuzla" in built_solvers:
             extra_link_args += BITWUZLA_LDFLAGS
@@ -110,7 +111,11 @@ if not os.path.isfile(os.path.join("smt_switch", ext_filename)):
             name="smt_switch.smt_solvers",
             sources=["smt_switch/smt_solvers.pyx"],
             libraries=solver_libraries,
-            library_dirs=solver_library_dirs,
+            # GMP is only added to the link-time search path: it is a system
+            # library, and putting its directory on the run-time path as well
+            # would change where the extension module looks for its other
+            # dependencies.
+            library_dirs=solver_library_dirs + GMP_LIBRARY_DIRS,
             runtime_library_dirs=solver_library_dirs,
             include_dirs=solver_include_dirs,
             language="c++",

--- a/yices2/CMakeLists.txt
+++ b/yices2/CMakeLists.txt
@@ -1,3 +1,5 @@
+find_package(GMP REQUIRED)
+
 add_library(
   smt-switch-yices2
   "${SMT_SWITCH_LIB_TYPE}"
@@ -12,8 +14,7 @@ target_include_directories(smt-switch-yices2 PUBLIC "${PROJECT_SOURCE_DIR}/inclu
 target_include_directories(smt-switch-yices2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
 target_include_directories(smt-switch-yices2 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/yices2/include")
 target_include_directories(smt-switch-yices2 PUBLIC "${YICES2_HOME}/src/include")
-target_include_directories(smt-switch-yices2 PUBLIC "${GMP_INCLUDE_DIR}")
-target_link_libraries(smt-switch-yices2 "${GMP_LIBRARIES}")
+target_link_libraries(smt-switch-yices2 GMP::gmp)
 target_link_libraries(smt-switch-yices2 "${YICES2_HOME}/build/lib/libyices.a")
 target_link_libraries(smt-switch-yices2 smt-switch)
 target_link_libraries(smt-switch-yices2 pthread)

--- a/z3/CMakeLists.txt
+++ b/z3/CMakeLists.txt
@@ -4,6 +4,8 @@ if(DEFINED Z3_INSTALL_DIR)
 endif()
 find_package(Z3 REQUIRED)
 
+find_package(GMP REQUIRED COMPONENTS gmpxx)
+
 # Variables needed in setup.py
 # TODO: move all compilation commands into CMake
 get_target_property(Z3_CONFIGURATIONS z3::libz3 IMPORTED_CONFIGURATIONS)
@@ -23,11 +25,9 @@ add_library(
 
 target_include_directories(smt-switch-z3 PUBLIC "${PROJECT_SOURCE_DIR}/include")
 target_include_directories(smt-switch-z3 PUBLIC "${CMAKE_CURRENT_SOURCE_DIR}/include")
-target_include_directories(smt-switch-z3 PRIVATE ${GMP_INCLUDE_DIR})
 target_link_libraries(smt-switch-z3 PUBLIC smt-switch)
 target_link_libraries(smt-switch-z3 PUBLIC z3::libz3)
-target_link_libraries(smt-switch-z3 PRIVATE ${GMP_LIBRARIES})
-target_link_libraries(smt-switch-z3 PRIVATE ${GMPXX_LIBRARIES})
+target_link_libraries(smt-switch-z3 PRIVATE GMP::gmpxx)
 
 install(TARGETS smt-switch-z3 DESTINATION lib)
 # install headers -- for expert use only


### PR DESCRIPTION
FindGMP.cmake resolved GMP with a plain find_library(), which on a system
carrying both libgmp.so and libgmp.a returns the shared library by absolute
path. That path went straight to the linker, and an absolute path to a shared
object is not substitutable: -static cannot satisfy it, and an ordinary link
silently keeps a dynamic dependency on GMP. A fully static build of
smt-switch, or of a consumer such as pono, could therefore never shed libgmp.

Name the library instead of the file that was found, so that the decision
belongs to whoever does the final link: -lgmp picks libgmp.a under -static and
libgmp.so otherwise, with nothing to configure either way. CMake still derives
the rpath from the link directory, so a GMP outside the system prefix is found
at run time as before, and an ordinary build links exactly as it did.

The libraries are handed out as GMP::gmp and GMP::gmpxx, which also carry the
include directories, and gmpxx is now a find_package component. Three things
fall out of that:

- The C++ bindings are named before the C library, as an archive requires.
  msat had them the other way around, which only ever worked because shared
  libraries are order insensitive.
- A missing libgmpxx fails at configure time with "Could NOT find GMP
  (missing: gmpxx)", rather than putting the literal GMPXX_LIBRARIES-NOTFOUND
  on the msat and z3 link lines.
- Each backend states the dependency it actually has, so cvc5 and yices2 no
  longer require the C++ bindings, and gmp.h and gmpxx.h may live in
  different directories, as they do on Debian.

setup.py no longer hardcodes -lgmp -lgmpxx either, which had it depending on
LIBRARY_PATH pointing at GMP and adding the C++ bindings even to a cvc5-only
build; it now substitutes what CMake resolved. Only the link-time search path
is extended, since putting a system directory on the run-time path would
change where the extension module looks for its other dependencies.