### PR TITLE
refactor: Cover the Python templates with the ruff hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -45,9 +45,21 @@ repos:
       # The rule selection lives in .ruff.toml, which still carries a block of
       # temporary ignores for the rules this tree violates. Those are being
       # removed one at a time, so this hook stays green in the meantime.
+      #
+      # Both hooks also cover the .py.in templates that CMake configures into
+      # the build tree. Reaching them needs `files` *and* a `types_or`
+      # override: identify tags .py.in as plain text, never as python, so the
+      # manifest's `types_or` can never match it and the two are ANDed. That
+      # makes `files` the real filter, which is why it has to spell out the
+      # extensions the manifest would otherwise have handled -- .md included,
+      # since ruff formats the Python in Markdown code blocks.
       - id: ruff-check
         args: [--fix]
+        types_or: [text]
+        files: '\.i?py(i|nb|\.in)?$'
       - id: ruff-format
+        types_or: [text]
+        files: '\.i?py(i|nb|\.in)?$|\.md$'
 
   - repo: https://github.com/BlankSpruce/gersemi-pre-commit
     rev: 0.28.1

--- a/.ruff.toml
+++ b/.ruff.toml
@@ -27,6 +27,12 @@ ignore = [
 # The Cython `cdef extern` declarations this generator emits are single long
 # lines that neither the formatter nor a human can usefully wrap.
 "python/gen-smt-solver-declarations.py" = ["E501"]
+# This template generates the package __init__, whose job is to re-export the
+# public API, so every name it imports is unused by design. Declaring __all__
+# would silence this instead, but it would also drop the solver factories that
+# the trailing `import *` provides from `from smt_switch import *`, and those
+# cannot be listed because which ones exist depends on the build.
+"python/smt_switch/__init__.py.in" = ["F401"]
 # This module raises pysmt's own exception types with a message describing the
 # term or sort at fault, across 17 sites. Bespoke subclasses would not suit
 # borrowed exception types, and hoisting each message to a variable would add a

--- a/python/setup.py.in
+++ b/python/setup.py.in
@@ -1,22 +1,32 @@
-from Cython.Build import cythonize
+# SPDX-FileCopyrightText: 2020 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
+
 import os
+import platform
 import sys
 import sysconfig
-import platform
+from pathlib import Path
+
+from Cython.Build import cythonize
 from setuptools import setup
 from setuptools.extension import Extension
 
-# These variables will be substituted in by CMake during configuration.
+# These variables will be substituted in by CMake during configuration. Where
+# it substitutes a semicolon-separated list, the split is what turns that into
+# a list. Ruff sees only the placeholder, a string with no semicolon in it, and
+# so reads every one of those splits as redundant; its fix would collapse the
+# whole list into a single element, hence the suppression on each.
 PROJECT_SOURCE_DIR = "@PROJECT_SOURCE_DIR@"
 PROJECT_BINARY_DIR = "@PROJECT_BINARY_DIR@"
 SMT_SWITCH_LIB_TYPE = "@SMT_SWITCH_LIB_TYPE@"
-SOLVER_BACKEND_LIBS = "@SOLVER_BACKEND_LIBS@".split(";")
-BITWUZLA_LDFLAGS = "@BITWUZLA_LDFLAGS@".split(";")
+SOLVER_BACKEND_LIBS = "@SOLVER_BACKEND_LIBS@".split(";")  # noqa: SIM905
+BITWUZLA_LDFLAGS = "@BITWUZLA_LDFLAGS@".split(";")  # noqa: SIM905
 Z3_LIBRARY_LOCATION = "@Z3_LIBRARY_LOCATION@"
 # Resolved by cmake/FindGMP.cmake, and empty unless a backend needs GMP. The
 # libraries are already in the order they have to be linked in.
-GMP_LINK_LIBRARIES = [lib for lib in "@GMP_LINK_LIBRARIES@".split(";") if lib]
-GMP_LIBRARY_DIRS = [path for path in "@GMP_LIBRARY_DIRS@".split(";") if path]
+GMP_LINK_LIBRARIES = [lib for lib in "@GMP_LINK_LIBRARIES@".split(";") if lib]  # noqa: SIM905
+GMP_LIBRARY_DIRS = [path for path in "@GMP_LIBRARY_DIRS@".split(";") if path]  # noqa: SIM905
 
 # Get the platform-specific library extension
 if sys.platform == "darwin":
@@ -33,7 +43,7 @@ else:  # linux
 ext_filename = "smt_switch" + sysconfig.get_config_var("EXT_SUFFIX")
 
 # Handle Cython compilation if the extension hasn't been built yet
-if not os.path.isfile(os.path.join("smt_switch", ext_filename)):
+if not (Path("smt_switch") / ext_filename).is_file():
     # Add flags and directories for compilation.
     libraries = []
     library_dirs = [PROJECT_BINARY_DIR]
@@ -95,10 +105,10 @@ if not os.path.isfile(os.path.join("smt_switch", ext_filename)):
         solver_library_dirs.append(f"{PROJECT_BINARY_DIR}/{solver}")
         solver_include_dirs.append(f"{PROJECT_SOURCE_DIR}/{solver}/include")
     solver_libraries.extend(libraries)
-    for path in library_dirs:
-        extra_link_args.append(f"-Wl,-rpath,{path}")
+    extra_link_args.extend(f"-Wl,-rpath,{path}" for path in library_dirs)
     if SMT_SWITCH_LIB_TYPE == "STATIC":
-        # When smt-switch is compiled as a static library, we need to link dependencies manually.
+        # When smt-switch is compiled as a static library, we need to link
+        # dependencies manually.
         # Some solver implementations need GMP, in which case CMake has found it for us.
         solver_libraries += GMP_LINK_LIBRARIES
         # Some solvers have their own linking flags.

--- a/python/smt_switch/__init__.py.in
+++ b/python/smt_switch/__init__.py.in
@@ -1,3 +1,7 @@
+# SPDX-FileCopyrightText: 2021 the smt-switch authors
+# SPDX-FileContributor: Makai Mann
+# SPDX-License-Identifier: BSD-3-Clause
+
 from .api import (
     IdentityVisitor,
     Op,
@@ -13,6 +17,9 @@ from .api import (
     op_partition,
 )
 from .enums import PrimOp, SolverAttribute, SolverEnum, SortKind
-from .smt_solvers import *
+
+# Which solver factories this module defines depends on which backends CMake
+# built, so they cannot be imported by name.
+from .smt_solvers import *  # noqa: F403
 
 __version__ = "@PROJECT_VERSION@"


### PR DESCRIPTION
`python/setup.py.in` and `python/smt_switch/__init__.py.in` are Python that no hook saw: ruff-pre-commit filters on identify's `python` tag, which a `.py.in` never carries. Widen both hooks to reach them, and clear the 28 findings that surfaced.

Reaching a `.py.in` needs `files` *and* a `types_or` override, because the two are ANDed and the manifest's tag list can never match. That leaves `files` as the real filter, so it has to spell out the extensions the manifest would otherwise have handled. `.md` is among them for ruff-format, which formats the Python in Markdown code blocks; ruff-check keeps `.md` out, matching its manifest, since `ruff check` reports no Python files for a Markdown path.

Both templates were already `ruff format` clean, so nothing here is reformatted. Two of the findings needed more than their autofix:

* SIM905 wanted a list literal for each of the four `"@PLACEHOLDER@".split(";")` assignments. CMake substitutes a semicolon-separated list into those, so the split is load-bearing, and the suggestion would collapse a whole list into a single element. All four carry a suppression, and the comment above them gives the reason.
* F401 fires 16 times on the re-exports in the generated package `__init__`. Declaring `__all__` would silence it, but would also drop the solver factories the trailing `import *` supplies from `from smt_switch import *`, and those cannot be listed because which of them exist depends on the build. It is a per-file-ignore instead. F403, on the `import *` itself, takes an inline suppression.

The rest were mechanical: import order, one `os.path` call moved to `pathlib`, a loop folded into `list.extend`, an over-long comment wrapped, and the SPDX headers both files were missing.