### PR TITLE
fix: Do not rely on YAML folding in cibuildwheel.yml

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -82,11 +82,14 @@ jobs:
           brew install gperf
           brew install SRI-CSL/sri-csl/libpoly
           bash {project}/ci-scripts/cibw-build-deps.sh
-        CIBW_BEFORE_BUILD: >
+        CIBW_BEFORE_BUILD: |
           python3 -m pip install \
             Cython>=3.0.0 \
             setuptools
           bash {project}/ci-scripts/cibw-build-before.sh
+        # `>` folds the lines below into one space-separated line, which is the
+        # only form cibuildwheel accepts here. With `|` each would keep its
+        # newline and cibuildwheel would read just the first assignment.
         CIBW_ENVIRONMENT_MACOS: >
           CPATH="$(brew --prefix)/include"
           LIBRARY_PATH="$(brew --prefix)/lib"
@@ -100,10 +103,7 @@ jobs:
           python3 -m pytest {project}/tests
 
     - name: Upload wheels to PyPI
-      if: >
-        github.event_name == 'release' ||
-        (github.event_name == 'workflow_dispatch' &&
-          github.event.inputs.deploy_target == 'PyPI')
+      if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'PyPI')
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
@@ -114,9 +114,7 @@ jobs:
         python3 -m twine upload --skip-existing wheelhouse/*.whl
 
     - name: Upload wheels to TestPyPI
-      if: >
-        github.event_name == 'workflow_dispatch' &&
-        github.event.inputs.deploy_target == 'Test PyPI'
+      if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'Test PyPI'
       env:
         TWINE_USERNAME: __token__
         TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -2,7 +2,7 @@
 # `pre-commit run --all-files` to check the whole tree.
 #
 # Hook revisions are kept current by Dependabot (see .github/dependabot.yml).
-
+#
 # contrib/memstream-0.1 is a vendored third-party drop, kept byte-identical to
 # upstream so it can be diffed against new releases. The rest of contrib/ is
 # first-party and is checked normally.


### PR DESCRIPTION
A `>` scalar folds lines at the base indent but keeps the break before a line indented further, so a continuation indented one step deeper silently behaves like a literal block. CIBW_BEFORE_BUILD and the PyPI `if:` both relied on that.

CIBW_BEFORE_BUILD is a shell script wanting real newlines, so it becomes `|`, with no change to its value. Both `if:` conditions become plain single lines: an expression is one logical line, and GitHub ignores the whitespace around a bare one. CIBW_ENVIRONMENT_MACOS keeps `>` and gains a comment saying why, since it has to fold or cibuildwheel reads only its first assignment.

In .pre-commit-config.yaml, the blank line between the two paragraphs of the header comment becomes a `#`, which a formatter cannot close up.