### PR TITLE
style: Reformat the YAML files with yamlfmt

### DIFF
--- a/.clang-format
+++ b/.clang-format
@@ -1,6 +1,5 @@
----
-Language:        Cpp
-BasedOnStyle:  Google
+Language: Cpp
+BasedOnStyle: Google
 AlignTrailingComments: true
 AllowShortCaseLabelsOnASingleLine: true
 BinPackArguments: false
@@ -20,4 +19,3 @@ BreakConstructorInitializers: BeforeColon
 Cpp11BracedListStyle: false
 DerivePointerAlignment: false
 PointerAlignment: Middle
-...

--- a/.github/workflows/auto-draft-release.yml
+++ b/.github/workflows/auto-draft-release.yml
@@ -1,23 +1,19 @@
 name: Automatically Draft a Release on Version Bump
-
 on:
   push:
     branches:
       - main
-
 jobs:
   create-tag:
     runs-on: ubuntu-latest
     permissions:
-      contents: write  # Needed to create tags
-
+      contents: write # Needed to create tags
     steps:
       # Check out the repository
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0  # Fetch all history to ensure we can check if tag exists
-
+          fetch-depth: 0 # Fetch all history to ensure we can check if tag exists
       - name: Read VERSION file
         id: version
         run: |
@@ -25,7 +21,6 @@ jobs:
           VERSION_VALUE=$(grep -v '^#' VERSION | head -n 1 | tr -d '[:space:]')
           echo "Detected version: $VERSION_VALUE"
           echo "version=$VERSION_VALUE" >> $GITHUB_OUTPUT
-
       - name: Check if tag exists
         id: check_tag
         run: |
@@ -34,7 +29,6 @@ jobs:
           else
             echo "tag_exists=false" >> $GITHUB_OUTPUT
           fi
-
       # Create and push the tag if it doesn't already exist
       - name: Create and push tag
         if: steps.check_tag.outputs.tag_exists == 'false'
@@ -43,7 +37,6 @@ jobs:
           git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
           git tag -a v${{ steps.version.outputs.version }} -m "Version ${{ steps.version.outputs.version }}"
           git push origin "v${{ steps.version.outputs.version }}"
-
       - name: Create draft GitHub Release
         if: steps.check_tag.outputs.tag_exists == 'false'
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -1,5 +1,4 @@
 name: Build and Upload Wheels
-
 on:
   release:
     types: [published]
@@ -11,10 +10,9 @@ on:
         type: choice
         description: "Choose the deployment target"
         options:
-        - None
-        - PyPI
-        - Test PyPI
-
+          - None
+          - PyPI
+          - Test PyPI
 jobs:
   build_wheels:
     name: ${{ matrix.name }}
@@ -36,90 +34,85 @@ jobs:
           - name: macos-arm64
             os: macos-15
             macos-target: 15
-
     steps:
-    - uses: actions/checkout@v7
-      with:
-        fetch-depth: 0
-
-    # cibuildwheel requires the pyproject.toml to be present from the beginning
-    - name: Place pyproject.toml
-      run: |
-        mkdir -p ./build/python
-        cp ./python/pyproject.toml ./build/python/
-
-    - name: Build wheels
-      uses: pypa/cibuildwheel@v4.2.1
-      with:
-        # Where the setup.py and pyproject.toml build infrastructure is
-        package-dir: ./build/python
-      env:
-        CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
-        CIBW_SKIP: "*-win32 *-win_amd64 *-win_arm64 *-musllinux_*"
-        CIBW_ARCHS_LINUX: ${{ matrix.arch }}
-        CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
-        CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
-        CIBW_BEFORE_ALL_LINUX: |
-          dnf install -y \
-            cmake \
-            gettext \
-            glibc-static \
-            gperf \
-            libstdc++-static \
-            ninja-build \
-            wget
-          # Build GMP and MPFR manually, which are too old in the repos
-          mkdir -p {project}/deps && pushd {project}/deps
-          wget https://ftpmirror.gnu.org/gmp/gmp-6.3.0.tar.xz
-          tar -xf gmp-6.3.0.tar.xz && mv gmp-6.3.0 gmp && rm -f gmp-6.3.0.tar.xz
-          pushd gmp && ./configure --enable-cxx && make install && popd
-          wget https://ftpmirror.gnu.org/mpfr/mpfr-4.2.2.tar.xz
-          tar -xf mpfr-4.2.2.tar.xz && mv mpfr-4.2.2 mpfr && rm -f mpfr-4.2.2.tar.xz
-          cd mpfr && ./configure && make install && popd
-          bash {project}/ci-scripts/cibw-build-deps.sh
-        CIBW_BEFORE_ALL_MACOS: |
-          brew update
-          brew install gperf
-          brew install SRI-CSL/sri-csl/libpoly
-          bash {project}/ci-scripts/cibw-build-deps.sh
-        CIBW_BEFORE_BUILD: |
-          python3 -m pip install \
-            Cython>=3.0.0 \
-            setuptools
-          bash {project}/ci-scripts/cibw-build-before.sh
-        # `>` folds the lines below into one space-separated line, which is the
-        # only form cibuildwheel accepts here. With `|` each would keep its
-        # newline and cibuildwheel would read just the first assignment.
-        CIBW_ENVIRONMENT_MACOS: >
-          CPATH="$(brew --prefix)/include"
-          LIBRARY_PATH="$(brew --prefix)/lib"
-          PKG_CONFIG_PATH="$(brew --prefix)/lib/pkgconfig"
-          DYLD_LIBRARY_PATH="$(pwd)/install/lib:$DYLD_LIBRARY_PATH"
-          MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos-target }}
-        CIBW_TEST_COMMAND: |
-          # cibuildwheel creates a dedicated virtualenv for the test
-          # make sure to use that python (just calling pytest may use system pytest)
-          python3 -m pip install pytest
-          python3 -m pytest {project}/tests
-
-    - name: Upload wheels to PyPI
-      if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'PyPI')
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
-      run: |
-        python3 -m venv ./upload-env
-        source ./upload-env/bin/activate
-        python3 -m pip install twine
-        python3 -m twine upload --skip-existing wheelhouse/*.whl
-
-    - name: Upload wheels to TestPyPI
-      if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'Test PyPI'
-      env:
-        TWINE_USERNAME: __token__
-        TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
-      run: |
-        python3 -m venv ./upload-env
-        source ./upload-env/bin/activate
-        python3 -m pip install twine
-        python3 -m twine upload --skip-existing --repository testpypi wheelhouse/*.whl
+      - uses: actions/checkout@v7
+        with:
+          fetch-depth: 0
+      # cibuildwheel requires the pyproject.toml to be present from the beginning
+      - name: Place pyproject.toml
+        run: |
+          mkdir -p ./build/python
+          cp ./python/pyproject.toml ./build/python/
+      - name: Build wheels
+        uses: pypa/cibuildwheel@v4.2.1
+        with:
+          # Where the setup.py and pyproject.toml build infrastructure is
+          package-dir: ./build/python
+        env:
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+          CIBW_SKIP: "*-win32 *-win_amd64 *-win_arm64 *-musllinux_*"
+          CIBW_ARCHS_LINUX: ${{ matrix.arch }}
+          CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64
+          CIBW_MANYLINUX_AARCH64_IMAGE: quay.io/pypa/manylinux_2_28_aarch64
+          CIBW_BEFORE_ALL_LINUX: |
+            dnf install -y \
+              cmake \
+              gettext \
+              glibc-static \
+              gperf \
+              libstdc++-static \
+              ninja-build \
+              wget
+            # Build GMP and MPFR manually, which are too old in the repos
+            mkdir -p {project}/deps && pushd {project}/deps
+            wget https://ftpmirror.gnu.org/gmp/gmp-6.3.0.tar.xz
+            tar -xf gmp-6.3.0.tar.xz && mv gmp-6.3.0 gmp && rm -f gmp-6.3.0.tar.xz
+            pushd gmp && ./configure --enable-cxx && make install && popd
+            wget https://ftpmirror.gnu.org/mpfr/mpfr-4.2.2.tar.xz
+            tar -xf mpfr-4.2.2.tar.xz && mv mpfr-4.2.2 mpfr && rm -f mpfr-4.2.2.tar.xz
+            cd mpfr && ./configure && make install && popd
+            bash {project}/ci-scripts/cibw-build-deps.sh
+          CIBW_BEFORE_ALL_MACOS: |
+            brew update
+            brew install gperf
+            brew install SRI-CSL/sri-csl/libpoly
+            bash {project}/ci-scripts/cibw-build-deps.sh
+          CIBW_BEFORE_BUILD: |
+            python3 -m pip install \
+              Cython>=3.0.0 \
+              setuptools
+            bash {project}/ci-scripts/cibw-build-before.sh
+          # `>` folds the lines below into one space-separated line, which is the
+          # only form cibuildwheel accepts here. With `|` each would keep its
+          # newline and cibuildwheel would read just the first assignment.
+          CIBW_ENVIRONMENT_MACOS: >
+            CPATH="$(brew --prefix)/include"
+            LIBRARY_PATH="$(brew --prefix)/lib"
+            PKG_CONFIG_PATH="$(brew --prefix)/lib/pkgconfig"
+            DYLD_LIBRARY_PATH="$(pwd)/install/lib:$DYLD_LIBRARY_PATH"
+            MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos-target }}
+          CIBW_TEST_COMMAND: |
+            # cibuildwheel creates a dedicated virtualenv for the test
+            # make sure to use that python (just calling pytest may use system pytest)
+            python3 -m pip install pytest
+            python3 -m pytest {project}/tests
+      - name: Upload wheels to PyPI
+        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'PyPI')
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
+        run: |
+          python3 -m venv ./upload-env
+          source ./upload-env/bin/activate
+          python3 -m pip install twine
+          python3 -m twine upload --skip-existing wheelhouse/*.whl
+      - name: Upload wheels to TestPyPI
+        if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'Test PyPI'
+        env:
+          TWINE_USERNAME: __token__
+          TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
+        run: |
+          python3 -m venv ./upload-env
+          source ./upload-env/bin/activate
+          python3 -m pip install twine
+          python3 -m twine upload --skip-existing --repository testpypi wheelhouse/*.whl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -7,7 +7,6 @@
 # upstream so it can be diffed against new releases. The rest of contrib/ is
 # first-party and is checked normally.
 exclude: ^contrib/memstream-0\.1/
-
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -35,7 +34,6 @@ repos:
       - id: check-toml
       - id: check-ast
       - id: debug-statements
-
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.6
     hooks:
@@ -60,13 +58,11 @@ repos:
       - id: ruff-format
         types_or: [text]
         files: '\.i?py(i|nb|\.in)?$|\.md$'
-
   - repo: https://github.com/BlankSpruce/gersemi-pre-commit
     rev: 0.28.1
     hooks:
       # Uses .gersemirc. Leave `args` unset to keep the hook's default `-i`.
       - id: gersemi
-
   - repo: https://github.com/ComPWA/taplo-pre-commit
     rev: v0.9.3
     hooks:
@@ -74,7 +70,6 @@ repos:
       # --default-schema-catalogs fetches a remote schema catalog, which is
       # unreliable in CI and broken offline. check-toml covers syntax.
       - id: taplo-format
-
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.13.1-1
     hooks:
@@ -88,7 +83,6 @@ repos:
       # take its indentation from that file and ignore these flags.
       - id: shfmt
         args: [-w, -i, "2", -ci, -s]
-
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1-1
     hooks:
@@ -96,7 +90,6 @@ repos:
       # the `# shellcheck source=` directives in contrib/setup-*.sh resolve
       # no matter which files a given commit stages.
       - id: shellcheck
-
   - repo: https://github.com/openstack/bashate
     rev: 2.1.1
     hooks:
@@ -111,7 +104,6 @@ repos:
       # before the error/warning split.
       - id: bashate
         args: [-i, E003, -e, E]
-
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v23.1.0
     hooks:


### PR DESCRIPTION
YAML is one of the three file types in the repo still without a formatter behind it. Reformat it first, so that enabling the hook is a separate change with no diff of its own. The hook and its config follow.

Nearly all of this is cibuildwheel.yml, the one file that wrote its sequences unindented while every other file here indents them. The rest is yamlfmt closing up blank lines it does not keep by default: the ones between the `- repo:` blocks in .pre-commit-config.yaml and between the steps in auto-draft-release.yml, which also loses a two-space gap before two inline comments.

.clang-format is in scope because identify reports it as YAML, so the hook will pick it up. It loses its `---` and `...` markers and the padding that aligned its first two values. clang-format reads it the same either way: `clang-format --dump-config` is byte-identical before and after, and the clang-format hook leaves the C++ tree alone.

The diff is layout only. All seven YAML files parse to the same data before and after, checked by loading both with a parser and comparing, and a second run of the formatter is a no-op.