### PR TITLE
build: Enable the yamlfmt hook

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -18,3 +18,6 @@ f8935125f9812bd70592991629692f2b71f952e6
 
 # style: Apply clang-format and enable the hook (#528)
 7cbd83717b504ed5be87c018510cbd4e522e15c0
+
+# style: Reformat the YAML files with yamlfmt (#538)
+ea1664d973f43040669734cb5922879302efb9c5

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -63,6 +63,11 @@ repos:
     hooks:
       # Uses .gersemirc. Leave `args` unset to keep the hook's default `-i`.
       - id: gersemi
+  - repo: https://github.com/google/yamlfmt
+    rev: v0.21.0
+    hooks:
+      # Uses .yamlfmt. Also covers .clang-format, which is YAML despite its name.
+      - id: yamlfmt
   - repo: https://github.com/ComPWA/taplo-pre-commit
     rev: v0.9.3
     hooks:

--- a/.yamlfmt
+++ b/.yamlfmt
@@ -1,0 +1,7 @@
+# Used by the yamlfmt hook in .pre-commit-config.yaml.
+#
+# Without scan_folded_as_literal, yamlfmt joins a `>` scalar written over
+# several lines onto one line, however long that leaves it. Where such a
+# scalar has to stay folded, the reason is recorded next to it.
+formatter:
+  scan_folded_as_literal: true

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -29,6 +29,15 @@ clang-format hook. Note that clang-format's output changes between releases, so 
 version pinned in [.pre-commit-config.yaml](./.pre-commit-config.yaml) is what decides
 the layout; bumping it may reformat files it previously left alone.
 
+YAML formatting is enforced by the yamlfmt hook and configured by
+[.yamlfmt](./.yamlfmt). It covers [.clang-format](./.clang-format) too, since that
+file is YAML.
+
+Commits that only reformat are listed in
+[.git-blame-ignore-revs](./.git-blame-ignore-revs) so that `git blame` can skip
+them. GitHub uses that file automatically; locally it needs
+`git config blame.ignoreRevsFile .git-blame-ignore-revs`.
+
 ## Design Decisions
 
 * Everything is a pointer


### PR DESCRIPTION
The reformat landed separately in #538, so this change has no YAML diff of its own: the hook is a no-op on the tree as it stands.

`.yamlfmt` sets scan_folded_as_literal, without which yamlfmt joins every `>` scalar written over several lines onto a single line. The tree has one such scalar, `CIBW_ENVIRONMENT_MACOS` in cibuildwheel.yml, and joining it would take the longest YAML line here from 141 to 239 columns. That scalar has to stay `>`, because with `|` cibuildwheel reads only the first of its five assignments.

Also record #538 in .git-blame-ignore-revs, since its diff is layout only, and describe both files in DEVELOPERS.md.