### PR TITLE
style: Apply mdformat's structural fixes to the Markdown files

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,11 +2,12 @@
 
 External contributions to smt-switch may be proposed via a pull request. All
 external contributions are subject to the following terms:
-* Pull requests must be squashed into a single commit before being submitted and
+
+- Pull requests must be squashed into a single commit before being submitted and
   must be signed using `git commit -s`
-* By submitting a signed contribution, you agree to all the terms of the
+- By submitting a signed contribution, you agree to all the terms of the
   3-clause BSD license (see [LICENSE](./LICENSE))
-* But submitting a signed contribution, you agree that the [Developer
+- But submitting a signed contribution, you agree that the [Developer
   Certificate of Origin](https://developercertificate.org/) (reproduced below)
   applies to your contribution.
 

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -1,24 +1,27 @@
 # Developer Information
 
 ## Cutting a New Release
+
 To make a new release of `smt-switch`, simply update the version in [VERSION](./VERSION). Once this is committed to master it will trigger the [auto release workflow](./.github/workflows/auto-draft-release.yml) which will create a new version tag and open a draft release. Once you submit the release that will then trigger the [cibuildwheel workflow](./.github/workflows/cibuildwheel.yml) to generate Python wheels and upload them to PyPi.
 
 ## Style Decisions
 
-* Formatting is enforced by [pre-commit](https://pre-commit.com) (see [.pre-commit-config.yaml](./.pre-commit-config.yaml))
-* Class names are capitalized
-* Kind enums are all capitalized
-* Operator enums use smt-lib names, but with the first letter (and letters after an underscore if it exists) capitalized
-  * Exception: "bv" is always capitalized to "BV"
-* Functions/methods are lower-cased with underscores
-* Interface matches smt-lib closely
+- Formatting is enforced by [pre-commit](https://pre-commit.com) (see [.pre-commit-config.yaml](./.pre-commit-config.yaml))
+- Class names are capitalized
+- Kind enums are all capitalized
+- Operator enums use smt-lib names, but with the first letter (and letters after an underscore if it exists) capitalized
+  - Exception: "bv" is always capitalized to "BV"
+- Functions/methods are lower-cased with underscores
+- Interface matches smt-lib closely
 
 ### Formatting
 
 Install the hooks once, and they run on each commit:
 
-    pip install pre-commit
-    pre-commit install
+```
+pip install pre-commit
+pre-commit install
+```
 
 To check the whole tree, run `pre-commit run --all-files`. CI runs the same hooks with
 [prek](https://github.com/j178/prek), a drop-in replacement that reads the same
@@ -40,21 +43,21 @@ them. GitHub uses that file automatically; locally it needs
 
 ## Design Decisions
 
-* Everything is a pointer
-  * There are `using` statements which give convenient names so things may not *look* like pointers, but they are all shared_ptr to abstract base classes
-  * In the solver implementations, the abstract class pointers are statically casted to the correct type. In particular, this means that mixing terms from different solvers will result in undefined behavior
-* Modern C++
-  * This library attempts to make use of modern C++ design paradigms whenever possible. In particular, we use C++17 for the support of constexpr arrays, and variants.
-  * The philosophy here is that it is better to rely on the new standard than adopt another dependency such as `boost`
-* The abstract classes provide a common interface, but they were designed to give each solver as much flexibility as possible
+- Everything is a pointer
+  - There are `using` statements which give convenient names so things may not *look* like pointers, but they are all shared_ptr to abstract base classes
+  - In the solver implementations, the abstract class pointers are statically casted to the correct type. In particular, this means that mixing terms from different solvers will result in undefined behavior
+- Modern C++
+  - This library attempts to make use of modern C++ design paradigms whenever possible. In particular, we use C++17 for the support of constexpr arrays, and variants.
+  - The philosophy here is that it is better to rely on the new standard than adopt another dependency such as `boost`
+- The abstract classes provide a common interface, but they were designed to give each solver as much flexibility as possible
 
 There are three abstract classes:
-* `AbsSmtSolver`
-* `AbsSort`
-* `AbsTerm`
+
+- `AbsSmtSolver`
+- `AbsSort`
+- `AbsTerm`
 
 Each one has a `using` declaration which provides a convenient name for a `shared_ptr` to the abstract class, e.g. `using Solver=std::shared_ptr<AbsSolver>`.
-
 
 An `Op` is a simple struct that holds a `PrimOp` and up to two integer indices. The constructor for a single `PrimOp` is marked `explicit` so that there is no ambiguity in overloaded functions that take a `PrimOp` or an `Op`. Note: this could have workded by only taking an `Op`, but that would require constructing (either implicitly or explicitly) an `Op` object even if we just want to apply a `PrimOp`.
 
@@ -62,12 +65,13 @@ An `Op` is a simple struct that holds a `PrimOp` and up to two integer indices. 
 
 There is an implementation of assertions and logging commands using `constexpr` functions in `include/utils.h`, these should be the only assertions/logging functions used throughout the codebase.
 
-
 # Implementing New Solvers
+
 As a general principle, smt-switch is meant to be as lightweight as possible. In other words, it should query the underlying solver for information (e.g. the sort of a term) whenever possible. To implement a new solver, look at the abstract classes in:
-* `include/sort.h`
-* `include/term.h`
-* `include/solver.h`
+
+- `include/sort.h`
+- `include/term.h`
+- `include/solver.h`
 
 You will need to implement a solver-specific version of each of those classes. To be able to build terms, you should map each operator in `include/ops.h`. Note that some methods have default implementations in `*.cpp` files under the `src` directory. These default implementations can be replaced with solver-specific implementations for performance improvements. For example, `substitute` takes a map and a term and performs sub-term substitution. This has a default implementation but is overriden in the `boolector` implementation to rely on `boolector's` underlying substitution map infrastructure.
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,9 @@
 # Smt-Switch
+
 A generic C++ API for SMT solving. It provides abstract classes which can be implemented by different SMT solvers.
 
 # Quick Start
+
 ```
 $ git clone git@github.com:stanford-centaur/smt-switch.git
 $ cd smt-switch
@@ -11,6 +13,7 @@ $ cd build
 $ make
 $ make test
 ```
+
 More details are in the Solvers section of this README.
 
 For an example of how to link and use `smt-switch`, please see the [examples directory](./examples).
@@ -18,25 +21,28 @@ For an example of how to link and use `smt-switch`, please see the [examples dir
 # Architecture Overview
 
 There are three abstract classes:
-* `AbsSmtSolver`
-* `AbsSort`
-* `AbsTerm`
+
+- `AbsSmtSolver`
+- `AbsSort`
+- `AbsTerm`
 
 Each of them has a `using` statement that names a smart pointer of that type, e.g. `using Term = shared_ptr<AbsTerm>;`. The key thing to remember when using this library is that all solver-specific objects are pointers to the abstract base class. `SmtSolver`, `Sort`, and `Term` are all smart pointers. Note: there are many convenience functions which operate on these pointers, so they may not *look* like pointers. Additionally, the library also includes `using` statements for commonly used data structures, for example, `TermVec` is a vector of shared pointers to `AbsTerm`s.
 
 The function names are based on SMT-LIB. The general rule is that functions/methods in this library can be obtained syntactically from SMT-LIB commands by replacing dashes with underscores. There are a few exceptions, for example `assert` is `assert_formula` in this library to avoid clashing with the `assert` macro. Operator names are also based on SMT-LIB operators, and can be obtained syntactically from an SMT-LIB operator by capitalizing the first letter and any letter after an underscore. The only exception is `bv` which is always capitalized to `BV` and does not count towards the capitalization of the first letter. Some examples include:
 
-* `And`
-* `BVAnd`
-* `Zero_Extend`
-* `BVAshr`
+- `And`
+- `BVAnd`
+- `Zero_Extend`
+- `BVAshr`
 
 Please see this [extended abstract](https://arxiv.org/abs/2007.01374) for more documentation or the `tests` directory for some example usage.
 
 # Creating a Smt-Switch Solver
+
 To create a Smt-Switch solver through the API, first include the relevant factory header and then use the static `create` method. It takes a single boolean parameter which configures term logging. If passed `false`, the created `SmtSolver` relies on the underlying solver for term traversal and querying a term for the `Sort` or `Op`. If passed `true`, it instantiates a `LoggingSolver` wrapper which keeps track of the `Op`, `Sort` and children of terms as they are created. A `LoggingSolver` wraps all the terms and sorts created through the API. Thus, a `LoggingSolver` always returns a `LoggingTerm`. However, this is invisible to the user and all the objects can be used in the expected way. The logging feature is useful for solvers that alias sorts (for example don't distinguish between booleans and bitvectors of size one) or perform on-the-fly rewriting. The `LoggingSolver` wrapper ensures that the built term has the expected `Op`, `Sort` and children. In other words, the created term is exactly what was built through the API -- it cannot be rewritten or alias the sort. This drastically simplifies transferring between solvers and can be more intuitive than on-the-fly rewriting. Note: the rewriting still happens in the underlying solver, but this is hidden at the Smt-Switch level. Some solvers, such as `Yices2`, rely on the `LoggingSolver` for term traversal. E.g. creating a `Yices2` `SmtSolver` without term logging would not allow term traversal.
 
 Here is an example that creates a solver interface to cvc5:
+
 ```
 #include "smt-switch/cvc5_factory.h"
 
@@ -52,32 +58,34 @@ int main()
 # Dependencies
 
 Smt-Switch depends on the following libraries. Dependencies needed only for certain backends and/or optional features are marked \["optional" : _reason_\].
-* CMake >= 3.10
-* GNU Make or Ninja
-* C compiler
-* C++ compiler supporting C++11
-* git
-* curl \[optional : setup scripts in `contrib`\]
-* Solver libraries
-  * Bitwuzla (has setup script in `contrib`)
-  * Boolector (has setup script in `contrib`)
-  * cvc5 (has setup script in `contrib`)
-  * MathSAT (must be obtained independently; user responsible for meeting license conditions)
-  * Yices2 (must be obtained independently; user responsible for meeting license conditions)
-* pthread [optional: Bitwuzla]
-* gmp [optional: cvc5, MathSAT, Yices2, Z3]
-* gmpxx, the gmp C++ bindings [optional: MathSAT, Z3]
-* autoconf [optional: Yices2 setup script]
-* Flex >= 2.6.4 [optional: SMT-LIB parser]
-* Bison >= 3.7 [optional: SMT-LIB parser]
-* Python [optional: Python bindings]
-* packaging [optional: Python bindings]
+
+- CMake >= 3.10
+- GNU Make or Ninja
+- C compiler
+- C++ compiler supporting C++11
+- git
+- curl \[optional : setup scripts in `contrib`\]
+- Solver libraries
+  - Bitwuzla (has setup script in `contrib`)
+  - Boolector (has setup script in `contrib`)
+  - cvc5 (has setup script in `contrib`)
+  - MathSAT (must be obtained independently; user responsible for meeting license conditions)
+  - Yices2 (must be obtained independently; user responsible for meeting license conditions)
+- pthread [optional: Bitwuzla]
+- gmp [optional: cvc5, MathSAT, Yices2, Z3]
+- gmpxx, the gmp C++ bindings [optional: MathSAT, Z3]
+- autoconf [optional: Yices2 setup script]
+- Flex >= 2.6.4 [optional: SMT-LIB parser]
+- Bison >= 3.7 [optional: SMT-LIB parser]
+- Python [optional: Python bindings]
+- packaging [optional: Python bindings]
 
 # Operating Systems
 
 Our `cmake` build system is currently only tested on Ubuntu Bionic and Mac OSX with XCode 12 but should work for other sufficiently modern (e.g. has C++11 support and CMake >= 3.1) Unix-based operating systems. Please file a GitHub issue if you have any problems!
 
 # Solvers
+
 To setup and install different solvers, first run the `./contrib/setup-<solver>.sh` script which builds position-independent static libraries in the `<solver>` directory. Then you can configure your `cmake` build with the `configure.sh` script. Enable a solver with `./configure.sh --<solver>`. By default only `libsmt-switch.so` is built without any solvers.
 
 Some of the backend solvers have non-BSD compatible licenses. There are no provided setup scripts for these solvers. However, there are instructions for setting up these solvers in `./contrib`. Should you choose to link against these solver libraries, you assume all responsibility for meeting the license requirements of those libraries.
@@ -88,35 +96,41 @@ Once you've configured the build system, simply enter the build directory (`./bu
 
 ### BSD compatible
 
-* Bitwuzla
-* Boolector
-* cvc5
-* Z3
+- Bitwuzla
+- Boolector
+- cvc5
+- Z3
 
 ### Non-BSD compatible
 
-* MathSAT
-* Yices2
+- MathSAT
+- Yices2
 
 ## Custom Solver Location
+
 If you'd like to try your own version of a solver, you can use the `configure.sh` script to point to your custom location with `--<solver>-home`. You will need to build static libraries (.a) and have them be accessible in the standard location for that solver. For example, you would point to a custom location of cvc5 like so:
 `./configure.sh --prefix=<your desired install location> --cvc5-home ./custom-cvc5`
 
 where `./custom-cvc5/build/src/libcvc5.a` and `./custom-cvc5/build/src/parser/libcvc5parser.a` already exist. `build` is the default build directory for `cvc5`, and thus that's where `cmake` is configured to look.
 
 ## Static Linking
+
 GMP is linked by name (`-lgmp`) rather than by path, so a fully static link (`-static`) picks up `libgmp.a` and an ordinary one keeps using the shared library, with nothing to configure either way. GMP is not bundled into the installed `libsmt-switch-<solver>.a`, so a consumer still has to name it on its own link line. If that link is fully static and mixes a backend needing the C++ bindings (MathSAT, Z3) with one needing only the C library (cvc5, Yices2), put `-lgmpxx` before `-lgmp`: `libgmpxx` references symbols from `libgmp`, and an archive only resolves what is still undefined by the time the linker reaches it.
 
 # Building Tests
+
 You can run all tests for the currently built solvers with `make test` from the build directory. To run a single test, run the binary `./tests/<test name>`. After you have a full installation, you can build the tests yourself by updating the includes to include the `smt-switch` directory. For example: `#include "cvc5_factory.h"` -> `#include "smt-switch/cvc5_factory.h"`.
 
 ## Debug
+
 The tests currently use C-style assertions which are compiled out in Release mode (the default). To build tests with assertions, please add the `--debug` flag when using `./configure.sh`.
 
 # Python bindings
+
 It is highly recommended to use a Python [virtual environment](https://docs.python.org/3/library/venv.html) or [Conda environment](https://docs.conda.io/en/latest/) when building Python bindings. Note: only Python 3.5 or later is supported.
 
 First, install the required packages:
+
 ```
 python3 -m pip install packaging
 ```
@@ -124,9 +138,11 @@ python3 -m pip install packaging
 Then, to compile Python bindings, use the `--python` flag of `configure.sh`. Afterwards, build `smt-switch` as usual. The Python wheel will be built inside `build/python` as the file `smt_switch-<version>-<tags>.whl`, where the version will be the current version you are building, and the tags will depend on the version of Python you have installed and your operating system. To install this in your Python environment, you can run `python3 -m pip install build/python/<filename>.whl`.
 
 ## PySMT front end
-Optionally, smt-switch can be used with a [pySMT](https://pysmt.readthedocs.io/en/latest/) front-end .  To install the pySMT front-end install `smt-switch` with the `pysmt` extra (`python3 -m pip install build/python/<filename>.whl[pysmt]`).  Note, some shells, like `zsh`, require brackets to be escaped or the path to be quoted, i.e., `build/python/<filename>.whl\[pysmt\]` or `"build/python/<filename>.whl[pysmt]"`.
+
+Optionally, smt-switch can be used with a [pySMT](https://pysmt.readthedocs.io/en/latest/) front-end . To install the pySMT front-end install `smt-switch` with the `pysmt` extra (`python3 -m pip install build/python/<filename>.whl[pysmt]`). Note, some shells, like `zsh`, require brackets to be escaped or the path to be quoted, i.e., `build/python/<filename>.whl\[pysmt\]` or `"build/python/<filename>.whl[pysmt]"`.
 
 A pySMT solver for each switch back-end can be instantiated directly or using the helper function `Solver`:
+
 ```Python
 from smt_switch import pysmt_frontend
 
@@ -147,16 +163,18 @@ with pysmt_frontend.Solver("cvc5") as solver:
 Please refer to the pySMT docs for further information.
 
 ## Testing python bindings
-Python bindings can be tested with [pytest](https://docs.pytest.org/en/latest/), which can be installed by running `python3 -m pip install pytest` or by installing the python bindings with the `test` extra (`python3 -m pip install build/python/<filename>.whl[test]`). To run all tests, switch to the appropriate folder with `cd tests/python` and simply run `pytest`. To run a particular test, use the `-k test_name[parameter1-...-parameter_n]` format, e.g. `pytest -k test_bvadd[create_btor_solver]`.  The tests for the pySMT front-end will only be run if it is installed. Note, multiple extras may be installed by passing them as a comma separated list: `python3 -m pip install build/python/<filename>.whl[test,pysmt]`.
+
+Python bindings can be tested with [pytest](https://docs.pytest.org/en/latest/), which can be installed by running `python3 -m pip install pytest` or by installing the python bindings with the `test` extra (`python3 -m pip install build/python/<filename>.whl[test]`). To run all tests, switch to the appropriate folder with `cd tests/python` and simply run `pytest`. To run a particular test, use the `-k test_name[parameter1-...-parameter_n]` format, e.g. `pytest -k test_bvadd[create_btor_solver]`. The tests for the pySMT front-end will only be run if it is installed. Note, multiple extras may be installed by passing them as a comma separated list: `python3 -m pip install build/python/<filename>.whl[test,pysmt]`.
 
 # Current Limitations and Gotchas
+
 While we try to guarantee that all solver backends are fully compliant with the abstract interface, and exhibit the exact same behavior given the same API calls, we are not able to do this in every case (yet). Below are some known, current limitations along with recommended usage.
 
-* **Undefined behavior.** Sharing terms between different solver instances will result in undefined behavior. This is because we use a static cast to recover the backend solver implementation from an abstract object. To move terms between solver instances, you can use a `TermTranslator` which will rebuild the term in another solver. A given `TermTranslator` object can only translate terms from **one** solver to **one** new one. If some symbols have already been created in the new solver, you can populate the `TermTranslator`'s cache so that it knows which symbols correspond to each other
-* Bitwuzla's `substitute` implementation does not work for formulas containing uninterpreted functions. To get around this, you can use a LoggingSolver. See below.
-* Bitwuzla does not support `reset_assertions` yet. You can however simulate this by setting the option "base-context-1" to "true". Under the hood, this will do all solving starting at context 1 instead of 0. This will allow you to call `reset_assertions` just like for any other solver.
-* The Z3 backend has not implemented term iteration (getting children) yet, but that should be added soon.
-* Datatypes are currently only supported in cvc5
+- **Undefined behavior.** Sharing terms between different solver instances will result in undefined behavior. This is because we use a static cast to recover the backend solver implementation from an abstract object. To move terms between solver instances, you can use a `TermTranslator` which will rebuild the term in another solver. A given `TermTranslator` object can only translate terms from **one** solver to **one** new one. If some symbols have already been created in the new solver, you can populate the `TermTranslator`'s cache so that it knows which symbols correspond to each other
+- Bitwuzla's `substitute` implementation does not work for formulas containing uninterpreted functions. To get around this, you can use a LoggingSolver. See below.
+- Bitwuzla does not support `reset_assertions` yet. You can however simulate this by setting the option "base-context-1" to "true". Under the hood, this will do all solving starting at context 1 instead of 0. This will allow you to call `reset_assertions` just like for any other solver.
+- The Z3 backend has not implemented term iteration (getting children) yet, but that should be added soon.
+- Datatypes are currently only supported in cvc5
 
 ## Recommended usage
 
@@ -164,15 +182,15 @@ While we try to guarantee that all solver backends are fully compliant with the 
 
 A `LoggingSolver` is a wrapper around another `SmtSolver` that keeps track of Term DAGs at the smt-switch level. This guarantees that if you create a term and query it for its sort, op, and children, it will give you back the exact same objects you built it with. Without the `LoggingSolver` wrapper, this is not guaranteed for all solvers. This is because some solvers perform on-the-fly rewriting and/or alias sorts (e.g. treat `BOOL` and `BV` of size one equivalently). Below, we give some recommendations for when to use a `LoggingSolver` for different backends. To use a `LoggingSolver`, pass `true` to the `create` function when instantiating a solver.
 
-* Bitwuzla
-  * Use a `LoggingSolver` when you want to avoid issues with sort aliasing between booleans and bit-vectors of size one and/or if you'd like to ensure that a term's children are exactly what were used to create it. Bitwuzla performs very smart on-the-fly rewriting. Additionally, use a `LoggingSolver` if you will need to use the `substitute` method on formulas that contain uninterpreted functions.
-* cvc5
-  * cvc5 does not alias sorts or perform on-the-fly rewriting. Thus, there should never be any reason to use a `LoggingSolver`.
-* MathSAT
-  * Use a `LoggingSolver` only if you want to guarantee that a term's Op and children are exactly what you used to create it. Without a `LoggingSolver`, MathSAT will perform _very_ light rewriting.
-* Yices2
-  * Use a `LoggingSolver` if you need term iteration
-  * Yices2 has a different term representation under the hood which cannot easily be converted back to SMT-LIB. Thus, term traversal is currently only supported through a `LoggingSolver`.
+- Bitwuzla
+  - Use a `LoggingSolver` when you want to avoid issues with sort aliasing between booleans and bit-vectors of size one and/or if you'd like to ensure that a term's children are exactly what were used to create it. Bitwuzla performs very smart on-the-fly rewriting. Additionally, use a `LoggingSolver` if you will need to use the `substitute` method on formulas that contain uninterpreted functions.
+- cvc5
+  - cvc5 does not alias sorts or perform on-the-fly rewriting. Thus, there should never be any reason to use a `LoggingSolver`.
+- MathSAT
+  - Use a `LoggingSolver` only if you want to guarantee that a term's Op and children are exactly what you used to create it. Without a `LoggingSolver`, MathSAT will perform _very_ light rewriting.
+- Yices2
+  - Use a `LoggingSolver` if you need term iteration
+  - Yices2 has a different term representation under the hood which cannot easily be converted back to SMT-LIB. Thus, term traversal is currently only supported through a `LoggingSolver`.
 
 ## Contributions
 

--- a/examples/README.md
+++ b/examples/README.md
@@ -3,6 +3,7 @@
 This directory contains example usage of smt-switch.
 
 ## QF_UFBV
+
 `QF_UFBV` stands for quantifier-free uninterpreted functions and bit-vectors.
 The files [cvc5_qf_ufbv.cpp](cvc5_qf_ufbv.cpp) and
 [btor_qf_ufbv.cpp](btor_qf_ufbv.cpp) demonstrate some common usage of the API
@@ -31,6 +32,7 @@ To remove the built binaries, run `make clean`. To clean up all the build and
 install files for `smt-switch` in this directory, run `make clean-all`.
 
 ## Python bindings
+
 You can also run the same example through the Python bindings with the file,
 [python_qf_ufbv.py](python_qf_ufbv.py). This requires building the Python
 bindings, which can be done by running `./build.sh --python`. If you have

--- a/issues.md
+++ b/issues.md
@@ -1,22 +1,25 @@
 # Issues to Consider
 
 ## Hashing
-* If we rely on the solver to traverse terms and wrap the resulting terms, we need to rely on the equality operator for the underlying objects
-* If everything is a shared_ptr, this might be counterintuitive, because you can use == but it won't do quite what you think
-  * it sounds like it does compare the underlying data, but even that might not be good enough
-  * Imagine you have two versions of an AbsTerm implementation, one from when it was created and one that was supplied by the solver when traversing
-    * There's no way to tell if they're the same or different, without comparing the underlying solver term that is pointed to
+
+- If we rely on the solver to traverse terms and wrap the resulting terms, we need to rely on the equality operator for the underlying objects
+- If everything is a shared_ptr, this might be counterintuitive, because you can use == but it won't do quite what you think
+  - it sounds like it does compare the underlying data, but even that might not be good enough
+  - Imagine you have two versions of an AbsTerm implementation, one from when it was created and one that was supplied by the solver when traversing
+    - There's no way to tell if they're the same or different, without comparing the underlying solver term that is pointed to
 
 ## Models
-* in Boolector, assignments are returned as strings.
-  * We can then turn these back into bit-vectors, but there's no way to recover the value once it's a node again
-  * Additionally, for arrays, there's no boolector structure for this. We'll need to have a representation for this
-  * cvc5 has it's stores on a constant array structure, but maybe we should have a common representation for all solvers
-  * a map with a default value would be most convenient
+
+- in Boolector, assignments are returned as strings.
+  - We can then turn these back into bit-vectors, but there's no way to recover the value once it's a node again
+  - Additionally, for arrays, there's no boolector structure for this. We'll need to have a representation for this
+  - cvc5 has it's stores on a constant array structure, but maybe we should have a common representation for all solvers
+  - a map with a default value would be most convenient
 
 ## Sorts
-* It would be useful to be able to query the sort from boolector - two options
-  * reconstruct a sort object using calls to boolector functions <-- I think this one is better
-    * but, whenever possible, don't reconstruct a sort object
-    * for example, in get_value, can do everything with raw BoolectorSorts
-  * store it explicitly -- this would require knowing what sort an op produces
+
+- It would be useful to be able to query the sort from boolector - two options
+  - reconstruct a sort object using calls to boolector functions \<-- I think this one is better
+    - but, whenever possible, don't reconstruct a sort object
+    - for example, in get_value, can do everything with raw BoolectorSorts
+  - store it explicitly -- this would require knowing what sort an op produces


### PR DESCRIPTION
Nothing enforced a format on the Markdown files. Running mdformat with `--wrap keep` leaves every prose line break as it is, so this diff is structural only and can be read on its own. Settling on a wrap width would be separate work.

Bullet markers switch from `*` to `-`, headings and lists gain the surrounding blank lines they were missing, indented code blocks become fenced, and runs of repeated spaces inside a paragraph collapse to a single space.

Every document renders the same before and after, checked by rendering both with a CommonMark parser and comparing the HTML with runs of whitespace collapsed, the way a browser collapses them.