### PR TITLE
style: Re-wrap the Markdown prose at 80 columns

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -7,9 +7,9 @@ external contributions are subject to the following terms:
   must be signed using `git commit -s`
 - By submitting a signed contribution, you agree to all the terms of the
   3-clause BSD license (see [LICENSE](./LICENSE))
-- But submitting a signed contribution, you agree that the [Developer
-  Certificate of Origin](https://developercertificate.org/) (reproduced below)
-  applies to your contribution.
+- But submitting a signed contribution, you agree that the
+  [Developer Certificate of Origin](https://developercertificate.org/)
+  (reproduced below) applies to your contribution.
 
 ```
 Developer Certificate of Origin

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -2,14 +2,22 @@
 
 ## Cutting a New Release
 
-To make a new release of `smt-switch`, simply update the version in [VERSION](./VERSION). Once this is committed to master it will trigger the [auto release workflow](./.github/workflows/auto-draft-release.yml) which will create a new version tag and open a draft release. Once you submit the release that will then trigger the [cibuildwheel workflow](./.github/workflows/cibuildwheel.yml) to generate Python wheels and upload them to PyPi.
+To make a new release of `smt-switch`, simply update the version in
+[VERSION](./VERSION). Once this is committed to master it will trigger the
+[auto release workflow](./.github/workflows/auto-draft-release.yml) which will
+create a new version tag and open a draft release. Once you submit the release
+that will then trigger the
+[cibuildwheel workflow](./.github/workflows/cibuildwheel.yml) to generate Python
+wheels and upload them to PyPi.
 
 ## Style Decisions
 
-- Formatting is enforced by [pre-commit](https://pre-commit.com) (see [.pre-commit-config.yaml](./.pre-commit-config.yaml))
+- Formatting is enforced by [pre-commit](https://pre-commit.com) (see
+  [.pre-commit-config.yaml](./.pre-commit-config.yaml))
 - Class names are capitalized
 - Kind enums are all capitalized
-- Operator enums use smt-lib names, but with the first letter (and letters after an underscore if it exists) capitalized
+- Operator enums use smt-lib names, but with the first letter (and letters after
+  an underscore if it exists) capitalized
   - Exception: "bv" is always capitalized to "BV"
 - Functions/methods are lower-cased with underscores
 - Interface matches smt-lib closely
@@ -23,18 +31,18 @@ pip install pre-commit
 pre-commit install
 ```
 
-To check the whole tree, run `pre-commit run --all-files`. CI runs the same hooks with
-[prek](https://github.com/j178/prek), a drop-in replacement that reads the same
-configuration, so `prek run --all-files` works too.
+To check the whole tree, run `pre-commit run --all-files`. CI runs the same
+hooks with [prek](https://github.com/j178/prek), a drop-in replacement that
+reads the same configuration, so `prek run --all-files` works too.
 
 C++ formatting follows [.clang-format](./.clang-format) and is enforced by the
-clang-format hook. Note that clang-format's output changes between releases, so the
-version pinned in [.pre-commit-config.yaml](./.pre-commit-config.yaml) is what decides
-the layout; bumping it may reformat files it previously left alone.
+clang-format hook. Note that clang-format's output changes between releases, so
+the version pinned in [.pre-commit-config.yaml](./.pre-commit-config.yaml) is
+what decides the layout; bumping it may reformat files it previously left alone.
 
 YAML formatting is enforced by the yamlfmt hook and configured by
-[.yamlfmt](./.yamlfmt). It covers [.clang-format](./.clang-format) too, since that
-file is YAML.
+[.yamlfmt](./.yamlfmt). It covers [.clang-format](./.clang-format) too, since
+that file is YAML.
 
 Commits that only reformat are listed in
 [.git-blame-ignore-revs](./.git-blame-ignore-revs) so that `git blame` can skip
@@ -44,12 +52,19 @@ them. GitHub uses that file automatically; locally it needs
 ## Design Decisions
 
 - Everything is a pointer
-  - There are `using` statements which give convenient names so things may not *look* like pointers, but they are all shared_ptr to abstract base classes
-  - In the solver implementations, the abstract class pointers are statically casted to the correct type. In particular, this means that mixing terms from different solvers will result in undefined behavior
+  - There are `using` statements which give convenient names so things may not
+    *look* like pointers, but they are all shared_ptr to abstract base classes
+  - In the solver implementations, the abstract class pointers are statically
+    casted to the correct type. In particular, this means that mixing terms from
+    different solvers will result in undefined behavior
 - Modern C++
-  - This library attempts to make use of modern C++ design paradigms whenever possible. In particular, we use C++17 for the support of constexpr arrays, and variants.
-  - The philosophy here is that it is better to rely on the new standard than adopt another dependency such as `boost`
-- The abstract classes provide a common interface, but they were designed to give each solver as much flexibility as possible
+  - This library attempts to make use of modern C++ design paradigms whenever
+    possible. In particular, we use C++17 for the support of constexpr arrays,
+    and variants.
+  - The philosophy here is that it is better to rely on the new standard than
+    adopt another dependency such as `boost`
+- The abstract classes provide a common interface, but they were designed to
+  give each solver as much flexibility as possible
 
 There are three abstract classes:
 
@@ -57,24 +72,45 @@ There are three abstract classes:
 - `AbsSort`
 - `AbsTerm`
 
-Each one has a `using` declaration which provides a convenient name for a `shared_ptr` to the abstract class, e.g. `using Solver=std::shared_ptr<AbsSolver>`.
+Each one has a `using` declaration which provides a convenient name for a
+`shared_ptr` to the abstract class, e.g.
+`using Solver=std::shared_ptr<AbsSolver>`.
 
-An `Op` is a simple struct that holds a `PrimOp` and up to two integer indices. The constructor for a single `PrimOp` is marked `explicit` so that there is no ambiguity in overloaded functions that take a `PrimOp` or an `Op`. Note: this could have workded by only taking an `Op`, but that would require constructing (either implicitly or explicitly) an `Op` object even if we just want to apply a `PrimOp`.
+An `Op` is a simple struct that holds a `PrimOp` and up to two integer indices.
+The constructor for a single `PrimOp` is marked `explicit` so that there is no
+ambiguity in overloaded functions that take a `PrimOp` or an `Op`. Note: this
+could have workded by only taking an `Op`, but that would require constructing
+(either implicitly or explicitly) an `Op` object even if we just want to apply a
+`PrimOp`.
 
 ## Utils
 
-There is an implementation of assertions and logging commands using `constexpr` functions in `include/utils.h`, these should be the only assertions/logging functions used throughout the codebase.
+There is an implementation of assertions and logging commands using `constexpr`
+functions in `include/utils.h`, these should be the only assertions/logging
+functions used throughout the codebase.
 
 # Implementing New Solvers
 
-As a general principle, smt-switch is meant to be as lightweight as possible. In other words, it should query the underlying solver for information (e.g. the sort of a term) whenever possible. To implement a new solver, look at the abstract classes in:
+As a general principle, smt-switch is meant to be as lightweight as possible. In
+other words, it should query the underlying solver for information (e.g. the
+sort of a term) whenever possible. To implement a new solver, look at the
+abstract classes in:
 
 - `include/sort.h`
 - `include/term.h`
 - `include/solver.h`
 
-You will need to implement a solver-specific version of each of those classes. To be able to build terms, you should map each operator in `include/ops.h`. Note that some methods have default implementations in `*.cpp` files under the `src` directory. These default implementations can be replaced with solver-specific implementations for performance improvements. For example, `substitute` takes a map and a term and performs sub-term substitution. This has a default implementation but is overriden in the `boolector` implementation to rely on `boolector's` underlying substitution map infrastructure.
+You will need to implement a solver-specific version of each of those classes.
+To be able to build terms, you should map each operator in `include/ops.h`. Note
+that some methods have default implementations in `*.cpp` files under the `src`
+directory. These default implementations can be replaced with solver-specific
+implementations for performance improvements. For example, `substitute` takes a
+map and a term and performs sub-term substitution. This has a default
+implementation but is overriden in the `boolector` implementation to rely on
+`boolector's` underlying substitution map infrastructure.
 
-All your solver header and source files should be put in `<solver name>/include` and `<solver name>/src`, respectively.
+All your solver header and source files should be put in `<solver name>/include`
+and `<solver name>/src`, respectively.
 
-Finally, you would make a `create` method which can instantiate a pointer to your new solver. For example, see `include/cvc5_factory.h`.
+Finally, you would make a `create` method which can instantiate a pointer to
+your new solver. For example, see `include/cvc5_factory.h`.

--- a/README.md
+++ b/README.md
@@ -1,6 +1,7 @@
 # Smt-Switch
 
-A generic C++ API for SMT solving. It provides abstract classes which can be implemented by different SMT solvers.
+A generic C++ API for SMT solving. It provides abstract classes which can be
+implemented by different SMT solvers.
 
 # Quick Start
 
@@ -16,7 +17,8 @@ $ make test
 
 More details are in the Solvers section of this README.
 
-For an example of how to link and use `smt-switch`, please see the [examples directory](./examples).
+For an example of how to link and use `smt-switch`, please see the
+[examples directory](./examples).
 
 # Architecture Overview
 
@@ -26,20 +28,54 @@ There are three abstract classes:
 - `AbsSort`
 - `AbsTerm`
 
-Each of them has a `using` statement that names a smart pointer of that type, e.g. `using Term = shared_ptr<AbsTerm>;`. The key thing to remember when using this library is that all solver-specific objects are pointers to the abstract base class. `SmtSolver`, `Sort`, and `Term` are all smart pointers. Note: there are many convenience functions which operate on these pointers, so they may not *look* like pointers. Additionally, the library also includes `using` statements for commonly used data structures, for example, `TermVec` is a vector of shared pointers to `AbsTerm`s.
+Each of them has a `using` statement that names a smart pointer of that type,
+e.g. `using Term = shared_ptr<AbsTerm>;`. The key thing to remember when using
+this library is that all solver-specific objects are pointers to the abstract
+base class. `SmtSolver`, `Sort`, and `Term` are all smart pointers. Note: there
+are many convenience functions which operate on these pointers, so they may not
+*look* like pointers. Additionally, the library also includes `using` statements
+for commonly used data structures, for example, `TermVec` is a vector of shared
+pointers to `AbsTerm`s.
 
-The function names are based on SMT-LIB. The general rule is that functions/methods in this library can be obtained syntactically from SMT-LIB commands by replacing dashes with underscores. There are a few exceptions, for example `assert` is `assert_formula` in this library to avoid clashing with the `assert` macro. Operator names are also based on SMT-LIB operators, and can be obtained syntactically from an SMT-LIB operator by capitalizing the first letter and any letter after an underscore. The only exception is `bv` which is always capitalized to `BV` and does not count towards the capitalization of the first letter. Some examples include:
+The function names are based on SMT-LIB. The general rule is that
+functions/methods in this library can be obtained syntactically from SMT-LIB
+commands by replacing dashes with underscores. There are a few exceptions, for
+example `assert` is `assert_formula` in this library to avoid clashing with the
+`assert` macro. Operator names are also based on SMT-LIB operators, and can be
+obtained syntactically from an SMT-LIB operator by capitalizing the first letter
+and any letter after an underscore. The only exception is `bv` which is always
+capitalized to `BV` and does not count towards the capitalization of the first
+letter. Some examples include:
 
 - `And`
 - `BVAnd`
 - `Zero_Extend`
 - `BVAshr`
 
-Please see this [extended abstract](https://arxiv.org/abs/2007.01374) for more documentation or the `tests` directory for some example usage.
+Please see this [extended abstract](https://arxiv.org/abs/2007.01374) for more
+documentation or the `tests` directory for some example usage.
 
 # Creating a Smt-Switch Solver
 
-To create a Smt-Switch solver through the API, first include the relevant factory header and then use the static `create` method. It takes a single boolean parameter which configures term logging. If passed `false`, the created `SmtSolver` relies on the underlying solver for term traversal and querying a term for the `Sort` or `Op`. If passed `true`, it instantiates a `LoggingSolver` wrapper which keeps track of the `Op`, `Sort` and children of terms as they are created. A `LoggingSolver` wraps all the terms and sorts created through the API. Thus, a `LoggingSolver` always returns a `LoggingTerm`. However, this is invisible to the user and all the objects can be used in the expected way. The logging feature is useful for solvers that alias sorts (for example don't distinguish between booleans and bitvectors of size one) or perform on-the-fly rewriting. The `LoggingSolver` wrapper ensures that the built term has the expected `Op`, `Sort` and children. In other words, the created term is exactly what was built through the API -- it cannot be rewritten or alias the sort. This drastically simplifies transferring between solvers and can be more intuitive than on-the-fly rewriting. Note: the rewriting still happens in the underlying solver, but this is hidden at the Smt-Switch level. Some solvers, such as `Yices2`, rely on the `LoggingSolver` for term traversal. E.g. creating a `Yices2` `SmtSolver` without term logging would not allow term traversal.
+To create a Smt-Switch solver through the API, first include the relevant
+factory header and then use the static `create` method. It takes a single
+boolean parameter which configures term logging. If passed `false`, the created
+`SmtSolver` relies on the underlying solver for term traversal and querying a
+term for the `Sort` or `Op`. If passed `true`, it instantiates a `LoggingSolver`
+wrapper which keeps track of the `Op`, `Sort` and children of terms as they are
+created. A `LoggingSolver` wraps all the terms and sorts created through the
+API. Thus, a `LoggingSolver` always returns a `LoggingTerm`. However, this is
+invisible to the user and all the objects can be used in the expected way. The
+logging feature is useful for solvers that alias sorts (for example don't
+distinguish between booleans and bitvectors of size one) or perform on-the-fly
+rewriting. The `LoggingSolver` wrapper ensures that the built term has the
+expected `Op`, `Sort` and children. In other words, the created term is exactly
+what was built through the API -- it cannot be rewritten or alias the sort. This
+drastically simplifies transferring between solvers and can be more intuitive
+than on-the-fly rewriting. Note: the rewriting still happens in the underlying
+solver, but this is hidden at the Smt-Switch level. Some solvers, such as
+`Yices2`, rely on the `LoggingSolver` for term traversal. E.g. creating a
+`Yices2` `SmtSolver` without term logging would not allow term traversal.
 
 Here is an example that creates a solver interface to cvc5:
 
@@ -57,7 +93,8 @@ int main()
 
 # Dependencies
 
-Smt-Switch depends on the following libraries. Dependencies needed only for certain backends and/or optional features are marked \["optional" : _reason_\].
+Smt-Switch depends on the following libraries. Dependencies needed only for
+certain backends and/or optional features are marked \["optional" : _reason_\].
 
 - CMake >= 3.10
 - GNU Make or Ninja
@@ -69,8 +106,10 @@ Smt-Switch depends on the following libraries. Dependencies needed only for cert
   - Bitwuzla (has setup script in `contrib`)
   - Boolector (has setup script in `contrib`)
   - cvc5 (has setup script in `contrib`)
-  - MathSAT (must be obtained independently; user responsible for meeting license conditions)
-  - Yices2 (must be obtained independently; user responsible for meeting license conditions)
+  - MathSAT (must be obtained independently; user responsible for meeting
+    license conditions)
+  - Yices2 (must be obtained independently; user responsible for meeting license
+    conditions)
 - pthread [optional: Bitwuzla]
 - gmp [optional: cvc5, MathSAT, Yices2, Z3]
 - gmpxx, the gmp C++ bindings [optional: MathSAT, Z3]
@@ -82,15 +121,32 @@ Smt-Switch depends on the following libraries. Dependencies needed only for cert
 
 # Operating Systems
 
-Our `cmake` build system is currently only tested on Ubuntu Bionic and Mac OSX with XCode 12 but should work for other sufficiently modern (e.g. has C++11 support and CMake >= 3.1) Unix-based operating systems. Please file a GitHub issue if you have any problems!
+Our `cmake` build system is currently only tested on Ubuntu Bionic and Mac OSX
+with XCode 12 but should work for other sufficiently modern (e.g. has C++11
+support and CMake >= 3.1) Unix-based operating systems. Please file a GitHub
+issue if you have any problems!
 
 # Solvers
 
-To setup and install different solvers, first run the `./contrib/setup-<solver>.sh` script which builds position-independent static libraries in the `<solver>` directory. Then you can configure your `cmake` build with the `configure.sh` script. Enable a solver with `./configure.sh --<solver>`. By default only `libsmt-switch.so` is built without any solvers.
+To setup and install different solvers, first run the
+`./contrib/setup-<solver>.sh` script which builds position-independent static
+libraries in the `<solver>` directory. Then you can configure your `cmake` build
+with the `configure.sh` script. Enable a solver with
+`./configure.sh --<solver>`. By default only `libsmt-switch.so` is built without
+any solvers.
 
-Some of the backend solvers have non-BSD compatible licenses. There are no provided setup scripts for these solvers. However, there are instructions for setting up these solvers in `./contrib`. Should you choose to link against these solver libraries, you assume all responsibility for meeting the license requirements of those libraries.
+Some of the backend solvers have non-BSD compatible licenses. There are no
+provided setup scripts for these solvers. However, there are instructions for
+setting up these solvers in `./contrib`. Should you choose to link against these
+solver libraries, you assume all responsibility for meeting the license
+requirements of those libraries.
 
-Once you've configured the build system, simply enter the build directory (`./build` by default) and run `make`. Each solver you add produces a `libsmt-switch-<solver>.so` shared object file. Running `make install` installs these libraries and the public header files into the configured prefix (`/usr/local` by default). Note that the header files are put in a directory, e.g. `/usr/local/include/smt-switch`.
+Once you've configured the build system, simply enter the build directory
+(`./build` by default) and run `make`. Each solver you add produces a
+`libsmt-switch-<solver>.so` shared object file. Running `make install` installs
+these libraries and the public header files into the configured prefix
+(`/usr/local` by default). Note that the header files are put in a directory,
+e.g. `/usr/local/include/smt-switch`.
 
 ## Currently Supported Solvers
 
@@ -108,26 +164,49 @@ Once you've configured the build system, simply enter the build directory (`./bu
 
 ## Custom Solver Location
 
-If you'd like to try your own version of a solver, you can use the `configure.sh` script to point to your custom location with `--<solver>-home`. You will need to build static libraries (.a) and have them be accessible in the standard location for that solver. For example, you would point to a custom location of cvc5 like so:
+If you'd like to try your own version of a solver, you can use the
+`configure.sh` script to point to your custom location with `--<solver>-home`.
+You will need to build static libraries (.a) and have them be accessible in the
+standard location for that solver. For example, you would point to a custom
+location of cvc5 like so:
 `./configure.sh --prefix=<your desired install location> --cvc5-home ./custom-cvc5`
 
-where `./custom-cvc5/build/src/libcvc5.a` and `./custom-cvc5/build/src/parser/libcvc5parser.a` already exist. `build` is the default build directory for `cvc5`, and thus that's where `cmake` is configured to look.
+where `./custom-cvc5/build/src/libcvc5.a` and
+`./custom-cvc5/build/src/parser/libcvc5parser.a` already exist. `build` is the
+default build directory for `cvc5`, and thus that's where `cmake` is configured
+to look.
 
 ## Static Linking
 
-GMP is linked by name (`-lgmp`) rather than by path, so a fully static link (`-static`) picks up `libgmp.a` and an ordinary one keeps using the shared library, with nothing to configure either way. GMP is not bundled into the installed `libsmt-switch-<solver>.a`, so a consumer still has to name it on its own link line. If that link is fully static and mixes a backend needing the C++ bindings (MathSAT, Z3) with one needing only the C library (cvc5, Yices2), put `-lgmpxx` before `-lgmp`: `libgmpxx` references symbols from `libgmp`, and an archive only resolves what is still undefined by the time the linker reaches it.
+GMP is linked by name (`-lgmp`) rather than by path, so a fully static link
+(`-static`) picks up `libgmp.a` and an ordinary one keeps using the shared
+library, with nothing to configure either way. GMP is not bundled into the
+installed `libsmt-switch-<solver>.a`, so a consumer still has to name it on its
+own link line. If that link is fully static and mixes a backend needing the C++
+bindings (MathSAT, Z3) with one needing only the C library (cvc5, Yices2), put
+`-lgmpxx` before `-lgmp`: `libgmpxx` references symbols from `libgmp`, and an
+archive only resolves what is still undefined by the time the linker reaches it.
 
 # Building Tests
 
-You can run all tests for the currently built solvers with `make test` from the build directory. To run a single test, run the binary `./tests/<test name>`. After you have a full installation, you can build the tests yourself by updating the includes to include the `smt-switch` directory. For example: `#include "cvc5_factory.h"` -> `#include "smt-switch/cvc5_factory.h"`.
+You can run all tests for the currently built solvers with `make test` from the
+build directory. To run a single test, run the binary `./tests/<test name>`.
+After you have a full installation, you can build the tests yourself by updating
+the includes to include the `smt-switch` directory. For example:
+`#include "cvc5_factory.h"` -> `#include "smt-switch/cvc5_factory.h"`.
 
 ## Debug
 
-The tests currently use C-style assertions which are compiled out in Release mode (the default). To build tests with assertions, please add the `--debug` flag when using `./configure.sh`.
+The tests currently use C-style assertions which are compiled out in Release
+mode (the default). To build tests with assertions, please add the `--debug`
+flag when using `./configure.sh`.
 
 # Python bindings
 
-It is highly recommended to use a Python [virtual environment](https://docs.python.org/3/library/venv.html) or [Conda environment](https://docs.conda.io/en/latest/) when building Python bindings. Note: only Python 3.5 or later is supported.
+It is highly recommended to use a Python
+[virtual environment](https://docs.python.org/3/library/venv.html) or
+[Conda environment](https://docs.conda.io/en/latest/) when building Python
+bindings. Note: only Python 3.5 or later is supported.
 
 First, install the required packages:
 
@@ -135,13 +214,26 @@ First, install the required packages:
 python3 -m pip install packaging
 ```
 
-Then, to compile Python bindings, use the `--python` flag of `configure.sh`. Afterwards, build `smt-switch` as usual. The Python wheel will be built inside `build/python` as the file `smt_switch-<version>-<tags>.whl`, where the version will be the current version you are building, and the tags will depend on the version of Python you have installed and your operating system. To install this in your Python environment, you can run `python3 -m pip install build/python/<filename>.whl`.
+Then, to compile Python bindings, use the `--python` flag of `configure.sh`.
+Afterwards, build `smt-switch` as usual. The Python wheel will be built inside
+`build/python` as the file `smt_switch-<version>-<tags>.whl`, where the version
+will be the current version you are building, and the tags will depend on the
+version of Python you have installed and your operating system. To install this
+in your Python environment, you can run
+`python3 -m pip install build/python/<filename>.whl`.
 
 ## PySMT front end
 
-Optionally, smt-switch can be used with a [pySMT](https://pysmt.readthedocs.io/en/latest/) front-end . To install the pySMT front-end install `smt-switch` with the `pysmt` extra (`python3 -m pip install build/python/<filename>.whl[pysmt]`). Note, some shells, like `zsh`, require brackets to be escaped or the path to be quoted, i.e., `build/python/<filename>.whl\[pysmt\]` or `"build/python/<filename>.whl[pysmt]"`.
+Optionally, smt-switch can be used with a
+[pySMT](https://pysmt.readthedocs.io/en/latest/) front-end . To install the
+pySMT front-end install `smt-switch` with the `pysmt` extra
+(`python3 -m pip install build/python/<filename>.whl[pysmt]`). Note, some
+shells, like `zsh`, require brackets to be escaped or the path to be quoted,
+i.e., `build/python/<filename>.whl\[pysmt\]` or
+`"build/python/<filename>.whl[pysmt]"`.
 
-A pySMT solver for each switch back-end can be instantiated directly or using the helper function `Solver`:
+A pySMT solver for each switch back-end can be instantiated directly or using
+the helper function `Solver`:
 
 ```Python
 from smt_switch import pysmt_frontend
@@ -164,37 +256,81 @@ Please refer to the pySMT docs for further information.
 
 ## Testing python bindings
 
-Python bindings can be tested with [pytest](https://docs.pytest.org/en/latest/), which can be installed by running `python3 -m pip install pytest` or by installing the python bindings with the `test` extra (`python3 -m pip install build/python/<filename>.whl[test]`). To run all tests, switch to the appropriate folder with `cd tests/python` and simply run `pytest`. To run a particular test, use the `-k test_name[parameter1-...-parameter_n]` format, e.g. `pytest -k test_bvadd[create_btor_solver]`. The tests for the pySMT front-end will only be run if it is installed. Note, multiple extras may be installed by passing them as a comma separated list: `python3 -m pip install build/python/<filename>.whl[test,pysmt]`.
+Python bindings can be tested with [pytest](https://docs.pytest.org/en/latest/),
+which can be installed by running `python3 -m pip install pytest` or by
+installing the python bindings with the `test` extra
+(`python3 -m pip install build/python/<filename>.whl[test]`). To run all tests,
+switch to the appropriate folder with `cd tests/python` and simply run `pytest`.
+To run a particular test, use the `-k test_name[parameter1-...-parameter_n]`
+format, e.g. `pytest -k test_bvadd[create_btor_solver]`. The tests for the pySMT
+front-end will only be run if it is installed. Note, multiple extras may be
+installed by passing them as a comma separated list:
+`python3 -m pip install build/python/<filename>.whl[test,pysmt]`.
 
 # Current Limitations and Gotchas
 
-While we try to guarantee that all solver backends are fully compliant with the abstract interface, and exhibit the exact same behavior given the same API calls, we are not able to do this in every case (yet). Below are some known, current limitations along with recommended usage.
+While we try to guarantee that all solver backends are fully compliant with the
+abstract interface, and exhibit the exact same behavior given the same API
+calls, we are not able to do this in every case (yet). Below are some known,
+current limitations along with recommended usage.
 
-- **Undefined behavior.** Sharing terms between different solver instances will result in undefined behavior. This is because we use a static cast to recover the backend solver implementation from an abstract object. To move terms between solver instances, you can use a `TermTranslator` which will rebuild the term in another solver. A given `TermTranslator` object can only translate terms from **one** solver to **one** new one. If some symbols have already been created in the new solver, you can populate the `TermTranslator`'s cache so that it knows which symbols correspond to each other
-- Bitwuzla's `substitute` implementation does not work for formulas containing uninterpreted functions. To get around this, you can use a LoggingSolver. See below.
-- Bitwuzla does not support `reset_assertions` yet. You can however simulate this by setting the option "base-context-1" to "true". Under the hood, this will do all solving starting at context 1 instead of 0. This will allow you to call `reset_assertions` just like for any other solver.
-- The Z3 backend has not implemented term iteration (getting children) yet, but that should be added soon.
+- **Undefined behavior.** Sharing terms between different solver instances will
+  result in undefined behavior. This is because we use a static cast to recover
+  the backend solver implementation from an abstract object. To move terms
+  between solver instances, you can use a `TermTranslator` which will rebuild
+  the term in another solver. A given `TermTranslator` object can only translate
+  terms from **one** solver to **one** new one. If some symbols have already
+  been created in the new solver, you can populate the `TermTranslator`'s cache
+  so that it knows which symbols correspond to each other
+- Bitwuzla's `substitute` implementation does not work for formulas containing
+  uninterpreted functions. To get around this, you can use a LoggingSolver. See
+  below.
+- Bitwuzla does not support `reset_assertions` yet. You can however simulate
+  this by setting the option "base-context-1" to "true". Under the hood, this
+  will do all solving starting at context 1 instead of 0. This will allow you to
+  call `reset_assertions` just like for any other solver.
+- The Z3 backend has not implemented term iteration (getting children) yet, but
+  that should be added soon.
 - Datatypes are currently only supported in cvc5
 
 ## Recommended usage
 
 ### Logging solvers
 
-A `LoggingSolver` is a wrapper around another `SmtSolver` that keeps track of Term DAGs at the smt-switch level. This guarantees that if you create a term and query it for its sort, op, and children, it will give you back the exact same objects you built it with. Without the `LoggingSolver` wrapper, this is not guaranteed for all solvers. This is because some solvers perform on-the-fly rewriting and/or alias sorts (e.g. treat `BOOL` and `BV` of size one equivalently). Below, we give some recommendations for when to use a `LoggingSolver` for different backends. To use a `LoggingSolver`, pass `true` to the `create` function when instantiating a solver.
+A `LoggingSolver` is a wrapper around another `SmtSolver` that keeps track of
+Term DAGs at the smt-switch level. This guarantees that if you create a term and
+query it for its sort, op, and children, it will give you back the exact same
+objects you built it with. Without the `LoggingSolver` wrapper, this is not
+guaranteed for all solvers. This is because some solvers perform on-the-fly
+rewriting and/or alias sorts (e.g. treat `BOOL` and `BV` of size one
+equivalently). Below, we give some recommendations for when to use a
+`LoggingSolver` for different backends. To use a `LoggingSolver`, pass `true` to
+the `create` function when instantiating a solver.
 
 - Bitwuzla
-  - Use a `LoggingSolver` when you want to avoid issues with sort aliasing between booleans and bit-vectors of size one and/or if you'd like to ensure that a term's children are exactly what were used to create it. Bitwuzla performs very smart on-the-fly rewriting. Additionally, use a `LoggingSolver` if you will need to use the `substitute` method on formulas that contain uninterpreted functions.
+  - Use a `LoggingSolver` when you want to avoid issues with sort aliasing
+    between booleans and bit-vectors of size one and/or if you'd like to ensure
+    that a term's children are exactly what were used to create it. Bitwuzla
+    performs very smart on-the-fly rewriting. Additionally, use a
+    `LoggingSolver` if you will need to use the `substitute` method on formulas
+    that contain uninterpreted functions.
 - cvc5
-  - cvc5 does not alias sorts or perform on-the-fly rewriting. Thus, there should never be any reason to use a `LoggingSolver`.
+  - cvc5 does not alias sorts or perform on-the-fly rewriting. Thus, there
+    should never be any reason to use a `LoggingSolver`.
 - MathSAT
-  - Use a `LoggingSolver` only if you want to guarantee that a term's Op and children are exactly what you used to create it. Without a `LoggingSolver`, MathSAT will perform _very_ light rewriting.
+  - Use a `LoggingSolver` only if you want to guarantee that a term's Op and
+    children are exactly what you used to create it. Without a `LoggingSolver`,
+    MathSAT will perform _very_ light rewriting.
 - Yices2
   - Use a `LoggingSolver` if you need term iteration
-  - Yices2 has a different term representation under the hood which cannot easily be converted back to SMT-LIB. Thus, term traversal is currently only supported through a `LoggingSolver`.
+  - Yices2 has a different term representation under the hood which cannot
+    easily be converted back to SMT-LIB. Thus, term traversal is currently only
+    supported through a `LoggingSolver`.
 
 ## Contributions
 
 We welcome external contributions, please see
 [CONTRIBUTING.md](./CONTRIBUTING.md) for more details. If you are interested in
 becoming a long-term contributor to smt-switch, please contact one of the
-primary authors in [AUTHORS](./AUTHORS). For development instructions and guidelines, see the [DEVELOPERS doc](./DEVELOPERS.md).
+primary authors in [AUTHORS](./AUTHORS). For development instructions and
+guidelines, see the [DEVELOPERS doc](./DEVELOPERS.md).

--- a/issues.md
+++ b/issues.md
@@ -2,24 +2,33 @@
 
 ## Hashing
 
-- If we rely on the solver to traverse terms and wrap the resulting terms, we need to rely on the equality operator for the underlying objects
-- If everything is a shared_ptr, this might be counterintuitive, because you can use == but it won't do quite what you think
-  - it sounds like it does compare the underlying data, but even that might not be good enough
-  - Imagine you have two versions of an AbsTerm implementation, one from when it was created and one that was supplied by the solver when traversing
-    - There's no way to tell if they're the same or different, without comparing the underlying solver term that is pointed to
+- If we rely on the solver to traverse terms and wrap the resulting terms, we
+  need to rely on the equality operator for the underlying objects
+- If everything is a shared_ptr, this might be counterintuitive, because you can
+  use == but it won't do quite what you think
+  - it sounds like it does compare the underlying data, but even that might not
+    be good enough
+  - Imagine you have two versions of an AbsTerm implementation, one from when it
+    was created and one that was supplied by the solver when traversing
+    - There's no way to tell if they're the same or different, without comparing
+      the underlying solver term that is pointed to
 
 ## Models
 
 - in Boolector, assignments are returned as strings.
-  - We can then turn these back into bit-vectors, but there's no way to recover the value once it's a node again
-  - Additionally, for arrays, there's no boolector structure for this. We'll need to have a representation for this
-  - cvc5 has it's stores on a constant array structure, but maybe we should have a common representation for all solvers
+  - We can then turn these back into bit-vectors, but there's no way to recover
+    the value once it's a node again
+  - Additionally, for arrays, there's no boolector structure for this. We'll
+    need to have a representation for this
+  - cvc5 has it's stores on a constant array structure, but maybe we should have
+    a common representation for all solvers
   - a map with a default value would be most convenient
 
 ## Sorts
 
 - It would be useful to be able to query the sort from boolector - two options
-  - reconstruct a sort object using calls to boolector functions \<-- I think this one is better
+  - reconstruct a sort object using calls to boolector functions \<-- I think
+    this one is better
     - but, whenever possible, don't reconstruct a sort object
     - for example, in get_value, can do everything with raw BoolectorSorts
   - store it explicitly -- this would require knowing what sort an op produces

--- a/tests/btor/README.md
+++ b/tests/btor/README.md
@@ -1,10 +1,14 @@
 # Tests Using the Boolector Solver
 
-These tests demonstrate the usage of the API and test your installation of Boolector. These are meant to be run after an installation of `smt-switch`.
+These tests demonstrate the usage of the API and test your installation of
+Boolector. These are meant to be run after an installation of `smt-switch`.
 
-To install `smt-switch` with `boolector`, you would run the following from the top-level directory:
-`sudo make install install-btor`
+To install `smt-switch` with `boolector`, you would run the following from the
+top-level directory: `sudo make install install-btor`
 
 # Dependencies
 
-We have tried to automate dependency installations for unusual packages, but we have not installed all the boolector dependencies that you can rely on a package manager for. If your build is not working, please see the installation instructions on the boolector [github](https://github.com/Boolector/boolector).
+We have tried to automate dependency installations for unusual packages, but we
+have not installed all the boolector dependencies that you can rely on a package
+manager for. If your build is not working, please see the installation
+instructions on the boolector [github](https://github.com/Boolector/boolector).

--- a/tests/cvc5/README.md
+++ b/tests/cvc5/README.md
@@ -1,10 +1,14 @@
 # Tests Using the cvc5 Solver
 
-These tests demonstrate the usage of the API and test your installation of `cvc5`. These are meant to be run after an installation of `smt-switch`.
+These tests demonstrate the usage of the API and test your installation of
+`cvc5`. These are meant to be run after an installation of `smt-switch`.
 
-To install `smt-switch` with `cvc5`, you would run the following from the top-level directory:
-`sudo make install install-cvc5`
+To install `smt-switch` with `cvc5`, you would run the following from the
+top-level directory: `sudo make install install-cvc5`
 
 # Dependencies
 
-We have tried to automate dependency installations for unusual packages, but we have not installed all the `cvc5` dependencies that you can rely on a package manager for. If your build is not working, please see the installation instructions on the `cvc5` [github](https://github.com/cvc5/cvc5/).
+We have tried to automate dependency installations for unusual packages, but we
+have not installed all the `cvc5` dependencies that you can rely on a package
+manager for. If your build is not working, please see the installation
+instructions on the `cvc5` [github](https://github.com/cvc5/cvc5/).


### PR DESCRIPTION
The Markdown files followed no single line-length convention. Some were hard-wrapped at exactly 80, others ran a whole paragraph to one line, past a thousand columns in places, and the rest sat somewhere between.

Settle on 80: it is the width the already-wrapped files use, the default for markdownlint's MD013, and what Google's Markdown style guide specifies. Note that mdformat does not wrap unless asked, its `--wrap` default being `keep`.

Inline code spans with no whitespace to break at can still exceed the limit, since the formatter has nowhere to fold them.

Every document renders the same before and after, checked by rendering both with a CommonMark parser and comparing the HTML with runs of whitespace collapsed, the way a browser collapses them.