### PR TITLE
build: Enable the mdformat hook

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -21,3 +21,9 @@ f8935125f9812bd70592991629692f2b71f952e6
 
 # style: Reformat the YAML files with yamlfmt (#538)
 ea1664d973f43040669734cb5922879302efb9c5
+
+# style: Apply mdformat's structural fixes to the Markdown files (#540)
+52a1324ea0fdc4d841d4ee77dd75f6ea8b474331
+
+# style: Re-wrap the Markdown prose at 80 columns (#541)
+8fe931dafb31417033a689fd91e84a90a2f981e9

--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,0 +1,6 @@
+# Used by the mdformat hook in .pre-commit-config.yaml.
+#
+# mdformat does not wrap at all unless given a width: its default is `keep`,
+# which leaves existing line breaks alone. Keeping the width here rather than
+# in the hook's `args` means a manual `mdformat` run matches what the hook does.
+wrap = 80

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -75,6 +75,15 @@ repos:
       # --default-schema-catalogs fetches a remote schema catalog, which is
       # unreliable in CI and broken offline. check-toml covers syntax.
       - id: taplo-format
+  - repo: https://github.com/hukkin/mdformat
+    rev: 1.0.0
+    hooks:
+      # Uses .mdformat.toml. mdformat-gfm is required to support the GitHub
+      # extensions: mdformat targets CommonMark, which has no tables, so
+      # without it a table reads as an ordinary paragraph and the configured
+      # wrap reflows it into prose.
+      - id: mdformat
+        additional_dependencies: [mdformat-gfm==1.0.0]
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.13.1-1
     hooks:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -44,6 +44,11 @@ YAML formatting is enforced by the yamlfmt hook and configured by
 [.yamlfmt](./.yamlfmt). It covers [.clang-format](./.clang-format) too, since
 that file is YAML.
 
+Markdown formatting is enforced by the mdformat hook and configured by
+[.mdformat.toml](./.mdformat.toml), which wraps prose at 80 columns. Because the
+width lives in that file rather than in the hook's arguments, running `mdformat`
+by hand gives the same result as the hook does.
+
 Commits that only reformat are listed in
 [.git-blame-ignore-revs](./.git-blame-ignore-revs) so that `git blame` can skip
 them. GitHub uses that file automatically; locally it needs


### PR DESCRIPTION
The reformats landed separately in #540 and #541, so this change has no diff of its own: the hook is a no-op on the tree as it stands.

The wrap width lives in .mdformat.toml rather than in the hook's `args`, so that running `mdformat` by hand gives the same result as the hook. mdformat does not wrap at all unless given a width, its `--wrap` default being `keep`.

mdformat-gfm is pinned as a hook dependency to support the GitHub extensions. mdformat targets CommonMark, which has no tables, so without it a table parses as an ordinary paragraph and the configured wrap reflows it into prose.

Also record #540 and #541 in .git-blame-ignore-revs, since both are layout only, and describe the new configuration in DEVELOPERS.md.