### PR TITLE
style: Reformat pyproject.toml with tombi

### DIFF
--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -1,14 +1,9 @@
-[build-system]
-requires = ["setuptools>=61.0.0", "Cython>=3.0.0"]
-build-backend = "setuptools.build_meta"
-
 [project]
 name = "smt-switch"
 description = "Python bindings for the smt-switch C++ SMT solving library"
 readme = { file = "README.md", content-type = "text/markdown" }
 requires-python = ">=3.9"
 license = "BSD-3-Clause"
-dynamic = ["version"]
 authors = [
   { name = "Yoni Zohar", email = "yoni.zohar@biu.ac.il" },
   { name = "Áron Ricardo Perez-Lopez", email = "arpl@cs.stanford.edu" },
@@ -16,15 +11,20 @@ authors = [
   { name = "Clark Barrett", email = "barrett@cs.stanford.edu" },
 ]
 dependencies = []
+dynamic = ["version"]
+
+[project.urls]
+Homepage = "https://github.com/stanford-centaur/smt-switch"
+Issues = "https://github.com/stanford-centaur/smt-switch/issues"
+Repository = "https://github.com/stanford-centaur/smt-switch.git"
 
 [project.optional-dependencies]
 pysmt = ["pysmt"]
 test = ["pytest"]
 
-[project.urls]
-Homepage = "https://github.com/stanford-centaur/smt-switch"
-Repository = "https://github.com/stanford-centaur/smt-switch.git"
-Issues = "https://github.com/stanford-centaur/smt-switch/issues"
+[build-system]
+requires = ["Cython>=3.0.0", "setuptools>=61.0.0"]
+build-backend = "setuptools.build_meta"
 
 [tool.setuptools]
 packages = ["smt_switch", "smt_switch.pysmt_frontend"]


### PR DESCRIPTION
Apply tombi's formatting to the TOML files, keeping the layout change as a diff of its own so that `git blame` can skip it. Which formatter the repository enforces is a separate question.

tombi arranges tables and keys into the order its bundled schema defines. pyproject.toml gains that order: [build-system] moves below the [project] tables, [project.urls] moves up with its keys sorted, and build-system.requires is sorted.

None of that changes what the file means. TOML says that key/value pairs within tables are not guaranteed to be in any specific order, and the pyproject specification says nothing about table order either. Array order is structural, but tombi only sorts the arrays its schema declares unordered: an array of tables, an array under an unrecognised tool table, and the authors list are all left exactly as written.

.ruff.toml comes out unchanged, and taplo-format, which is what currently enforces TOML formatting, accepts the result.