### PR TITLE
build: Replace taplo with tombi for TOML formatting

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -27,3 +27,6 @@ ea1664d973f43040669734cb5922879302efb9c5
 
 # style: Re-wrap the Markdown prose at 80 columns (#541)
 8fe931dafb31417033a689fd91e84a90a2f981e9
+
+# style: Reformat pyproject.toml with tombi (#543)
+f7ecf8531b4439fa73e0ae6df2df952739055888

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -68,13 +68,14 @@ repos:
     hooks:
       # Uses .yamlfmt. Also covers .clang-format, which is YAML despite its name.
       - id: yamlfmt
-  - repo: https://github.com/ComPWA/taplo-pre-commit
-    rev: v0.9.3
+  - repo: https://github.com/tombi-toml/tombi-pre-commit
+    rev: v1.5.2
     hooks:
-      # taplo-lint is deliberately omitted: its default
-      # --default-schema-catalogs fetches a remote schema catalog, which is
-      # unreliable in CI and broken offline. check-toml covers syntax.
-      - id: taplo-format
+      # Uses tombi.toml. tombi orders tables and keys as its bundled schema
+      # defines, and sorts only the arrays that schema declares unordered.
+      - id: tombi-format
+        # Skip the remote schema catalog, unreliable in CI.
+        args: [--offline]
   - repo: https://github.com/hukkin/mdformat
     rev: 1.0.0
     hooks:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -49,6 +49,10 @@ Markdown formatting is enforced by the mdformat hook and configured by
 width lives in that file rather than in the hook's arguments, running `mdformat`
 by hand gives the same result as the hook does.
 
+TOML formatting is enforced by the tombi-format hook and configured by
+[tombi.toml](./tombi.toml). tombi puts tables and keys in the order its bundled
+schema defines, so adding a table to a file it has a schema for may move it.
+
 Commits that only reformat are listed in
 [.git-blame-ignore-revs](./.git-blame-ignore-revs) so that `git blame` can skip
 them. GitHub uses that file automatically; locally it needs

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,0 +1,7 @@
+# Used by the tombi hooks in .pre-commit-config.yaml.
+#
+# tombi's default is to put a fixed two spaces before a trailing comment, which
+# would undo the alignment .ruff.toml uses for the comments on its ignore list.
+[format.rules]
+trailing-comment-alignment = true
+trailing-comment-space-width = 1


### PR DESCRIPTION
The reformat landed separately in #543, so this change has no diff of its own: the hook is a no-op on the tree as it stands. The two formatters disagree on layout, so they cannot both be enabled.

taplo-pre-commit's newest tag pins taplo 0.9.3, released in July 2024, while taplo itself has since released 0.10.0. tombi is maintained, and covers linting as well, which taplo-lint could not do here: the old comment in this file records that it fetched a remote schema catalog, unreliable in CI and broken offline.

tombi has that problem solved rather than avoided. Its schemas are built in, so `--offline` costs nothing: the output is byte-identical with and without it, and identical again on a cold cache, which is what CI starts from. The flag is set so that formatting never depends on the network.

tombi.toml keeps tombi's default two-space gap before a trailing comment from undoing the alignment in .ruff.toml. check-toml stays. Only the formatter is enabled here; the hook repository also offers tombi-lint.

Also record #543 in .git-blame-ignore-revs, since its diff is layout only, and describe the new configuration in DEVELOPERS.md.