### PR TITLE
build: Rework comments about pre-commit hooks

### DIFF
--- a/.mdformat.toml
+++ b/.mdformat.toml
@@ -1,6 +1,3 @@
-# Used by the mdformat hook in .pre-commit-config.yaml.
-#
-# mdformat does not wrap at all unless given a width: its default is `keep`,
-# which leaves existing line breaks alone. Keeping the width here rather than
-# in the hook's `args` means a manual `mdformat` run matches what the hook does.
+# mdformat does not wrap at all unless given a width; its default is `keep`,
+# which leaves existing line breaks alone.
 wrap = 80

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -3,6 +3,10 @@
 #
 # Hook revisions are kept current by Dependabot (see .github/dependabot.yml).
 #
+# An `args` key replaces a hook's own default arguments rather than adding to
+# them. Before adding or editing one, read the hook's .pre-commit-hooks.yaml
+# and repeat any default that is still wanted.
+#
 # contrib/memstream-0.1 is a vendored third-party drop, kept byte-identical to
 # upstream so it can be diffed against new releases. The rest of contrib/ is
 # first-party and is checked normally.
@@ -21,36 +25,25 @@ repos:
       - id: check-case-conflict
       - id: check-illegal-windows-names
       - id: check-merge-conflict
-      # ci-scripts/ contains symlinks into contrib/; these guard against them
-      # being replaced by plain files, e.g. on a checkout without symlink
-      # support.
-      - id: check-symlinks
-      - id: destroyed-symlinks
       - id: check-executables-have-shebangs
       - id: check-shebang-scripts-are-executable
       - id: detect-private-key
-      # Syntax checks for configuration and Python sources.
+      # ci-scripts/ symlinks into contrib/; these keep those links intact.
+      - id: check-symlinks
+      - id: destroyed-symlinks
+      # Configuration syntax.
       - id: check-yaml
       - id: check-toml
+      # Python sources.
       - id: check-ast
-      - id: debug-statements
+      - id: debug-statements # breakpoint() calls and debugger imports
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.6
     hooks:
-      # ruff-check comes before ruff-format, the order ruff recommends: --fix
-      # can leave code that the formatter then rewrites.
-      #
-      # The rule selection lives in .ruff.toml, which still carries a block of
-      # temporary ignores for the rules this tree violates. Those are being
-      # removed one at a time, so this hook stays green in the meantime.
-      #
-      # Both hooks also cover the .py.in templates that CMake configures into
-      # the build tree. Reaching them needs `files` *and* a `types_or`
-      # override: identify tags .py.in as plain text, never as python, so the
-      # manifest's `types_or` can never match it and the two are ANDed. That
-      # makes `files` the real filter, which is why it has to spell out the
-      # extensions the manifest would otherwise have handled -- .md included,
-      # since ruff formats the Python in Markdown code blocks.
+      # ruff-check runs first, as ruff recommends, since --fix can leave code
+      # the formatter then rewrites. The overrides below are what reach the
+      # .py.in templates, which pre-commit never tags as python; `files` has
+      # to name each extension, .md included for Python in Markdown fences.
       - id: ruff-check
         args: [--fix]
         types_or: [text]
@@ -61,74 +54,51 @@ repos:
   - repo: https://github.com/BlankSpruce/gersemi-pre-commit
     rev: 0.28.1
     hooks:
-      # Uses .gersemirc. Leave `args` unset to keep the hook's default `-i`.
-      - id: gersemi
+      - id: gersemi # formats CMake
   - repo: https://github.com/google/yamlfmt
     rev: v0.21.0
     hooks:
-      # Uses .yamlfmt. Also covers .clang-format, which is YAML despite its name.
-      - id: yamlfmt
+      - id: yamlfmt # also covers .clang-format, which is YAML
   - repo: https://github.com/tombi-toml/tombi-pre-commit
     rev: v1.5.2
     hooks:
-      # Uses tombi.toml. tombi orders tables and keys as its bundled schema
-      # defines, and sorts only the arrays that schema declares unordered.
       - id: tombi-format
         # Skip the remote schema catalog, unreliable in CI.
         args: [--offline]
   - repo: https://github.com/hukkin/mdformat
     rev: 1.0.0
     hooks:
-      # Uses .mdformat.toml. mdformat-gfm is required to support the GitHub
-      # extensions: mdformat targets CommonMark, which has no tables, so
-      # without it a table reads as an ordinary paragraph and the configured
-      # wrap reflows it into prose.
       - id: mdformat
+        # mdformat targets CommonMark, which has no tables; without the plugin
+        # a table reads as a paragraph and the configured wrap reflows it.
         additional_dependencies: [mdformat-gfm==1.0.0]
   - repo: https://github.com/scop/pre-commit-shfmt
     rev: v3.13.1-1
     hooks:
-      # -w is one of the hook's default args and must be repeated, because
-      # `args` replaces the defaults rather than extending them.
-      #
-      # -i 2 matches the indentation the majority of these scripts already
-      # use. Deliberately no -ln: the contrib/*-setup.sh libraries have no
-      # shebang, and shfmt's default language detection already parses them
-      # as bash. Deliberately no .editorconfig either, since shfmt would then
-      # take its indentation from that file and ignore these flags.
       - id: shfmt
+        # -w    write in place; without it shfmt prints to stdout and the
+        #       hook passes having formatted nothing
+        # -i 2  two-space indent, as most of these scripts use; default is tabs
+        # -ci   indent switch cases
+        # -s    simplify redundant syntax
         args: [-w, -i, "2", -ci, -s]
   - repo: https://github.com/shellcheck-py/shellcheck-py
     rev: v0.11.0.1-1
     hooks:
-      # Configured by .shellcheckrc, which turns on external-sources so that
-      # the `# shellcheck source=` directives in contrib/setup-*.sh resolve
-      # no matter which files a given commit stages.
       - id: shellcheck
   - repo: https://github.com/openstack/bashate
     rev: 2.1.1
     hooks:
-      # -i E003 drops "indent not a multiple of 4": bashate hardcodes a
-      # 4-space rule with no way to configure the width, which contradicts the
-      # `shfmt -i 2` above.
-      #
-      # -e E promotes every remaining rule to an error. Some of them, E006
-      # among them, are warnings by default, and bashate exits 0 on a warning;
-      # pre-commit hides the output of a hook that passes, so those would
-      # never be seen. The ignore above still wins, since bashate applies it
-      # before the error/warning split.
       - id: bashate
+        # -i E003  drop "indent not a multiple of 4", hardcoded in bashate and
+        #          at odds with the shfmt -i 2 above; applied before -e
+        # -e E     make every other rule an error, since bashate exits 0 on a
+        #          warning and pre-commit hides a passing hook's output
         args: [-i, E003, -e, E]
   - repo: https://github.com/pre-commit/mirrors-clang-format
     rev: v23.1.0
     hooks:
-      # Uses .clang-format: the Google style, with braces on their own line for
-      # functions, classes and control statements, and `Type * name` pointer
-      # alignment. Leave `args` unset to keep the hook's default `-i
-      # -style=file`.
-      #
-      # The mirror's revision is the clang-format version, and its output is
-      # not stable across versions: a bump can reformat files that the
-      # previous version left alone. Reformat the tree in the same commit that
-      # bumps this rev.
+      # This rev is the clang-format version, and its output is not stable
+      # across versions: a bump can reformat files the previous version left
+      # alone. Reformat the tree in the same commit that bumps it.
       - id: clang-format

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -45,9 +45,7 @@ YAML formatting is enforced by the yamlfmt hook and configured by
 that file is YAML.
 
 Markdown formatting is enforced by the mdformat hook and configured by
-[.mdformat.toml](./.mdformat.toml), which wraps prose at 80 columns. Because the
-width lives in that file rather than in the hook's arguments, running `mdformat`
-by hand gives the same result as the hook does.
+[.mdformat.toml](./.mdformat.toml), which wraps prose at 80 columns.
 
 TOML formatting is enforced by the tombi-format hook and configured by
 [tombi.toml](./tombi.toml). tombi puts tables and keys in the order its bundled


### PR DESCRIPTION
The comments repeated each other and the tools they describe. Move the rule they kept restating -- that an `args` key replaces a hook's default arguments rather than extending them -- to the top, and drop the rest: config file names, which the names already give; what those files set, since an option's reason belongs beside it; and options not passed.

What remains sits next to what it describes, either as a trailing comment on a hook id or on its own line above an `args` list, which leaves room as that list grows. Where a list holds several arguments, each gets a line.

Some things worth knowing were absent. shfmt's -w is the one default this config repeats, and dropping it as redundant would leave shfmt writing to stdout while the hook went on passing. gersemi's name gives no clue that it formats CMake. debug-statements looks for a leftover breakpoint() or debugger import, not the print calls its name suggests.

Some claims were wrong. .ruff.toml no longer carries the temporary ignores described, those having become deliberate choices in #518, and shfmt ignores EditorConfig once given any parser or printer flag, so the flags here are not overridden by it.

The executable and private-key checks also move up, out from under the comment about the ci-scripts/ symlinks that read as though it covered them.