### PR TITLE
build: Cover the Python templates in a bare ruff run

### DIFF
--- a/.ruff.toml
+++ b/.ruff.toml
@@ -8,6 +8,10 @@ extend-exclude = ["build", "deps"]
 # excludes above.
 force-exclude = true
 
+# ruff discovers *.py and *.pyi; the templates CMake configures need naming
+# here, or a run outside pre-commit skips them.
+extend-include = ["*.py.in"]
+
 [lint]
 select = ["ALL"]
 


### PR DESCRIPTION
python/setup.py.in and python/smt_switch/__init__.py.in are Python that ruff's file discovery does not find, since it looks for *.py and *.pyi. The pre-commit hooks reach them through their own file filter, so running ruff directly checked less than the hooks did.

extend-include names the templates, which closes that gap: `ruff check` and `ruff format` with no path arguments now cover them, and both report the tree clean. It extends ruff's defaults rather than replacing them, which `include` would do.

This does not make the hooks' filter redundant. pre-commit decides which paths to hand a hook from its own file type detection, which never reports a .py.in as Python, so without that filter the hook would not pass these files to ruff at all.