### PR TITLE
python: Fix the package metadata published to PyPI

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -47,7 +47,9 @@ jobs:
           # Where the setup.py and pyproject.toml build infrastructure is
           package-dir: build/python
         env:
-          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-*"
+          # Every released CPython that is not yet end-of-life
+          # Keep in sync with requires-python in python/pyproject.toml
+          CIBW_BUILD: "cp310-* cp311-* cp312-* cp313-* cp314-*"
           CIBW_SKIP: "*-musllinux_*"
           CIBW_ARCHS_LINUX: ${{ matrix.arch }}
           CIBW_MANYLINUX_X86_64_IMAGE: quay.io/pypa/manylinux_2_28_x86_64

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -180,7 +180,7 @@ if(BUILD_PYTHON_BINDINGS)
   find_python_in_virtualenv()
   # Want python for building a module, so use Development.Module. See:
   # https://stackoverflow.com/questions/78495429/attempting-to-build-python-binary-modules-on-manylinux-find-packagepython3-on
-  find_package(Python 3.9 REQUIRED COMPONENTS Interpreter Development.Module)
+  find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development.Module)
 endif()
 
 # should we build boolector?

--- a/README.md
+++ b/README.md
@@ -206,7 +206,7 @@ flag when using `./configure.sh`.
 It is highly recommended to use a Python
 [virtual environment](https://docs.python.org/3/library/venv.html) or
 [Conda environment](https://docs.conda.io/en/latest/) when building Python
-bindings. Note: only Python 3.5 or later is supported.
+bindings. Note: only Python 3.10 or later is supported.
 
 First, install the required packages:
 

--- a/python/CMakeLists.txt
+++ b/python/CMakeLists.txt
@@ -1,9 +1,11 @@
-# First, ensure we have Python 3.9 or newer with all required components
+# First, ensure we have Python 3.10 or newer with all required components. The
+# floor has to match requires-python in pyproject.toml: building against an
+# older interpreter would produce a wheel that pip then refuses to install.
 # Check for a virtualenv python first
 find_python_in_virtualenv()
 # Want python for building a module, so use Development.Module. See:
 # https://stackoverflow.com/questions/78495429/attempting-to-build-python-binary-modules-on-manylinux-find-packagepython3-on
-find_package(Python 3.9 REQUIRED COMPONENTS Interpreter Development.Module)
+find_package(Python 3.10 REQUIRED COMPONENTS Interpreter Development.Module)
 
 # Include helper function to check for required Python packages
 include(CheckPythonModule)
@@ -41,6 +43,17 @@ configure_file(
   "${CMAKE_CURRENT_BINARY_DIR}/pyproject.toml"
   COPYONLY
 )
+
+# The wheel is built from the binary directory, so the readme and the license
+# that the package metadata references have to be copied there as well.
+# Otherwise setuptools only warns and falls back to an empty long description,
+# and the wheel ends up shipping no license text at all.
+configure_file(
+  "${CMAKE_CURRENT_SOURCE_DIR}/README.md"
+  "${CMAKE_CURRENT_BINARY_DIR}/README.md"
+  COPYONLY
+)
+configure_file("${PROJECT_SOURCE_DIR}/LICENSE" "${CMAKE_CURRENT_BINARY_DIR}/LICENSE" COPYONLY)
 
 # Add Python package directory containing Cython files.
 add_subdirectory(smt_switch)

--- a/python/README.md
+++ b/python/README.md
@@ -1,0 +1,86 @@
+# smt-switch
+
+Python bindings for
+[smt-switch](https://github.com/stanford-centaur/smt-switch), a generic C++ API
+for SMT solving. It provides a single abstract interface that several SMT
+solvers implement, so you can write solver-agnostic code and switch back ends
+without rewriting it.
+
+## Installation
+
+```sh
+python3 -m pip install smt-switch
+```
+
+The published wheels bundle the solver back ends with permissive licenses:
+[Bitwuzla](https://bitwuzla.github.io/), [cvc5](https://cvc5.github.io/), and
+[Z3](https://github.com/Z3Prover/z3). Boolector, MathSAT, and Yices 2 are
+supported by smt-switch but are not included in the wheels; to use those, build
+from source as described in the
+[main README](https://github.com/stanford-centaur/smt-switch#python-bindings).
+
+Two optional extras are available: `smt-switch[pysmt]` installs the
+[pySMT](https://pysmt.readthedocs.io/en/latest/) front end, and
+`smt-switch[test]` installs [pytest](https://docs.pytest.org/en/latest/) for
+running the test suite.
+
+## Usage
+
+Every back end is created through the same factory interface and driven through
+the same solver object:
+
+```python
+import smt_switch as ss
+
+solver = ss.create_cvc5_solver(logging=False)
+solver.set_opt("produce-models", "true")
+
+bv8 = solver.make_sort(ss.sortkinds.BV, 8)
+x = solver.make_symbol("x", bv8)
+y = solver.make_symbol("y", bv8)
+
+# x + y == 10 and x != 0
+solver.assert_formula(
+    solver.make_term(
+        ss.primops.Equal,
+        solver.make_term(ss.primops.BVAdd, x, y),
+        solver.make_term(10, bv8),
+    )
+)
+solver.assert_formula(
+    solver.make_term(ss.primops.Distinct, x, solver.make_term(0, bv8))
+)
+
+result = solver.check_sat()
+if result.is_sat():
+    print("x =", int(solver.get_value(x)))
+    print("y =", int(solver.get_value(y)))
+```
+
+The back ends compiled into your installation are available in the
+`smt_switch.solvers` dictionary, which maps a name such as `"cvc5"` to its
+factory function. This is the easiest way to run the same code across every
+available solver:
+
+```python
+import smt_switch as ss
+
+for name, create_solver in ss.solvers.items():
+    solver = create_solver(logging=False)
+    ...
+```
+
+## Documentation and support
+
+Further documentation, the C++ API, build instructions for the other solver back
+ends, and known limitations are in the
+[main repository](https://github.com/stanford-centaur/smt-switch). Please report
+problems on the
+[issue tracker](https://github.com/stanford-centaur/smt-switch/issues).
+
+## License
+
+smt-switch is distributed under the BSD 3-Clause license. Note that the solver
+back ends carry their own licenses. See
+[LICENSE](https://github.com/stanford-centaur/smt-switch/blob/main/LICENSE) for
+details.

--- a/python/pyproject.toml
+++ b/python/pyproject.toml
@@ -2,13 +2,39 @@
 name = "smt-switch"
 description = "Python bindings for the smt-switch C++ SMT solving library"
 readme = { file = "README.md", content-type = "text/markdown" }
-requires-python = ">=3.9"
+requires-python = ">=3.10"
 license = "BSD-3-Clause"
+license-files = ["LICENSE"]
 authors = [
   { name = "Yoni Zohar", email = "yoni.zohar@biu.ac.il" },
   { name = "Áron Ricardo Perez-Lopez", email = "arpl@cs.stanford.edu" },
   { name = "Makai Mann", email = "makaim@cs.stanford.edu" },
   { name = "Clark Barrett", email = "barrett@cs.stanford.edu" },
+]
+keywords = [
+  "SMT",
+  "SMT-LIB",
+  "formal-methods",
+  "formal-verification",
+  "satisfiability",
+  "solver",
+  "theorem-prover",
+]
+classifiers = [
+  "Development Status :: 5 - Production/Stable",
+  "Intended Audience :: Developers",
+  "Intended Audience :: Science/Research",
+  "Operating System :: MacOS",
+  "Operating System :: POSIX :: Linux",
+  "Programming Language :: Cython",
+  "Programming Language :: Python :: 3 :: Only",
+  "Programming Language :: Python :: 3.10",
+  "Programming Language :: Python :: 3.11",
+  "Programming Language :: Python :: 3.12",
+  "Programming Language :: Python :: 3.13",
+  "Programming Language :: Python :: 3.14",
+  "Topic :: Scientific/Engineering :: Mathematics",
+  "Topic :: Software Development :: Libraries :: Python Modules",
 ]
 dependencies = []
 dynamic = ["version"]
@@ -23,7 +49,7 @@ pysmt = ["pysmt"]
 test = ["pytest"]
 
 [build-system]
-requires = ["Cython>=3.0.0", "setuptools>=61.0.0"]
+requires = ["Cython>=3.0.0", "setuptools>=77.0.0"]
 build-backend = "setuptools.build_meta"
 
 [tool.setuptools]


### PR DESCRIPTION
The wheel is built from `build/python`, but only `pyproject.toml` was copied there. Both `readme` and the default `license-files` globs therefore resolved to nothing: setuptools only warns about a missing readme and falls back to an empty long description, so release 1.1.4 went out with a blank PyPI page and no license text, which BSD-3-Clause requires us to ship.

- Copy `README.md` and `LICENSE` into the build directory, and add a `python/README.md` written for PyPI rather than reusing the root one, which is C++-centric and full of links that would 404 there.
- Set `license-files`, `classifiers`, and `keywords`, all of which were absent from the published metadata.
- Raise the `setuptools` floor to 77.0.0. A bare SPDX string for `license` is PEP 639, which 61.0.0 rejects outright; CI never hit this only because it installs setuptools unpinned.

Also adopt an explicit version policy: ship every released CPython that is not yet end-of-life upstream. Python 3.9 has been end-of-life since 2025-10-31 and no `cp39` wheels were ever built, so `requires-python` claimed support that did not exist and left 3.9 users with "no matching distribution found". It now says `>=3.10`, matching the wheels, and 3.14 is added as the one live version that was missing. The CMake floor moves with it, since building against an older interpreter would produce a wheel that pip then refuses to install.