### PR TITLE
build: Enable tombi-lint and pin tombi's schemas in CI

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -7,6 +7,12 @@ name: Lint
 jobs:
   prek:
     runs-on: ubuntu-latest
+    # Run tombi against pinned schemas rather than whatever schemastore serves
+    # today, so a schema change cannot alter a result here on its own.
+    # TOMBI_OFFLINE only takes true or false; anything else is an error.
+    env:
+      TOMBI_OFFLINE: "true"
+      TOMBI_CACHE_HOME: ${{ github.workspace }}/.tombi-cache
     steps:
       - uses: actions/checkout@v7
       # prek is a drop-in replacement for pre-commit that reads the same

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -9,8 +9,9 @@
 #
 # contrib/memstream-0.1 is a vendored third-party drop, kept byte-identical to
 # upstream so it can be diffed against new releases. The rest of contrib/ is
-# first-party and is checked normally.
-exclude: ^contrib/memstream-0\.1/
+# first-party and is checked normally. The JSON schemas in .tombi-cache are
+# vendored for the same reason; the README there is ours, so it is checked.
+exclude: ^(contrib/memstream-0\.1/|\.tombi-cache/.*\.json$)
 repos:
   - repo: https://github.com/pre-commit/pre-commit-hooks
     rev: v6.0.0
@@ -62,9 +63,12 @@ repos:
   - repo: https://github.com/tombi-toml/tombi-pre-commit
     rev: v1.5.2
     hooks:
+      # No --offline here, so a local run resolves schemas over the network.
+      # CI instead sets TOMBI_OFFLINE and points TOMBI_CACHE_HOME at
+      # .tombi-cache, which pins the schemas it cannot bundle. Both routes
+      # validate the same thing; see DEVELOPERS.md to reproduce CI locally.
       - id: tombi-format
-        # Skip the remote schema catalog, unreliable in CI.
-        args: [--offline]
+      - id: tombi-lint
   - repo: https://github.com/hukkin/mdformat
     rev: 1.0.0
     hooks:

--- a/.tombi-cache/README.md
+++ b/.tombi-cache/README.md
@@ -1,0 +1,25 @@
+# Vendored JSON schemas
+
+tombi validates TOML against schemas it bundles, but some of those refer out to
+schemas it does not bundle and would otherwise fetch from schemastore on every
+run. This directory holds copies of those, so CI validates against a fixed
+version rather than whatever is served that day. See
+[DEVELOPERS.md](../DEVELOPERS.md) for how CI is pointed here.
+
+The layout is tombi's own cache layout, `https/<host>/<path>`, so each file has
+to sit at the path its URL maps to. Every one is a download rather than a file
+we maintain, so keep it byte-identical to upstream and let the pre-commit config
+skip it.
+
+## Refreshing
+
+Nothing signals that a copy has gone stale, so re-download them now and then,
+and after a tombi upgrade:
+
+```sh
+curl -o .tombi-cache/https/www.schemastore.org/partial-setuptools.json \
+  https://www.schemastore.org/partial-setuptools.json
+```
+
+If that leaves a diff, run `pre-commit run --all-files` before committing it: a
+schema change can start failing a file that used to pass.

--- a/.tombi-cache/https/www.schemastore.org/partial-setuptools.json
+++ b/.tombi-cache/https/www.schemastore.org/partial-setuptools.json
@@ -1,0 +1,481 @@
+{
+  "$schema": "http://json-schema.org/draft-07/schema#",
+  "$id": "https://json.schemastore.org/partial-setuptools.json",
+  "$comment": "TODO: Use https://github.com/pypa/setuptools/blob/fb7f3d3cab98f2c00cbf18fe887ce73007f49e18/setuptools/config/setuptools.schema.json",
+  "title": "``tool.setuptools`` table",
+  "type": "object",
+  "additionalProperties": false,
+  "properties": {
+    "platforms": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      }
+    },
+    "provides": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "pep508-identifier"
+      },
+      "description": "Package and virtual package names contained within this package **(not supported by pip)**"
+    },
+    "obsoletes": {
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "pep508-identifier"
+      },
+      "description": "Packages which this package renders obsolete **(not supported by pip)**"
+    },
+    "zip-safe": {
+      "type": "boolean",
+      "description": "Whether the project can be safely installed and run from a zip file. **OBSOLETE**: only relevant for ``pkg_resources``, ``easy_install`` and ``setup.py install`` in the context of ``eggs`` (**DEPRECATED**)."
+    },
+    "script-files": {
+      "$comment": "TODO: is this field deprecated/should be removed?",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Legacy way of defining scripts (entry-points are preferred). Equivalent to the ``script`` keyword in ``setup.py`` (it was renamed to avoid confusion with entry-point based ``project.scripts`` defined in :pep:`621`). **DISCOURAGED**: generic script wrappers are tricky and may not work properly. Whenever possible, please use ``project.scripts`` instead."
+    },
+    "eager-resources": {
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "Resources that should be extracted together, if any of them is needed, or if any C extensions included in the project are imported. **OBSOLETE**: only relevant for ``pkg_resources``, ``easy_install`` and ``setup.py install`` in the context of ``eggs`` (**DEPRECATED**)."
+    },
+    "packages": {
+      "oneOf": [
+        {
+          "title": "Array of Python package identifiers",
+          "type": "array",
+          "items": {
+            "$ref": "#/definitions/package-name"
+          }
+        },
+        {
+          "$ref": "#/definitions/find-directive"
+        }
+      ],
+      "description": "Packages that should be included in the distribution. It can be given either as a list of package identifiers or as a ``dict``-like structure with a single key ``find`` which corresponds to a dynamic call to ``setuptools.config.expand.find_packages`` function. The ``find`` key is associated with a nested ``dict``-like structure that can contain ``where``, ``include``, ``exclude`` and ``namespaces`` keys, mimicking the keyword arguments of the associated function."
+    },
+    "package-dir": {
+      "type": "object",
+      "additionalProperties": false,
+      "propertyNames": {
+        "anyOf": [
+          {
+            "const": ""
+          },
+          {
+            "$ref": "#/definitions/package-name"
+          }
+        ]
+      },
+      "patternProperties": {
+        "^.*$": {
+          "type": "string"
+        }
+      },
+      "description": ":class:`dict`-like structure mapping from package names to directories where their code can be found. The empty string (as key) means that all packages are contained inside the given directory will be included in the distribution."
+    },
+    "package-data": {
+      "type": "object",
+      "additionalProperties": false,
+      "propertyNames": {
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "python-module-name"
+          },
+          {
+            "const": "*"
+          }
+        ]
+      },
+      "patternProperties": {
+        "^.*$": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Mapping from package names to lists of glob patterns. Usually this option is not needed when using ``include-package-data = true`` For more information on how to include data files, check ``setuptools`` `docs <https://setuptools.pypa.io/en/latest/userguide/datafiles.html>`_."
+    },
+    "include-package-data": {
+      "type": "boolean",
+      "description": "Automatically include any data files inside the package directories that are specified by ``MANIFEST.in`` For more information on how to include data files, check ``setuptools`` `docs <https://setuptools.pypa.io/en/latest/userguide/datafiles.html>`_."
+    },
+    "exclude-package-data": {
+      "type": "object",
+      "additionalProperties": false,
+      "propertyNames": {
+        "anyOf": [
+          {
+            "type": "string",
+            "format": "python-module-name"
+          },
+          {
+            "const": "*"
+          }
+        ]
+      },
+      "patternProperties": {
+        "^.*$": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "Mapping from package names to lists of glob patterns that should be excluded For more information on how to include data files, check ``setuptools`` `docs <https://setuptools.pypa.io/en/latest/userguide/datafiles.html>`_."
+    },
+    "namespace-packages": {
+      "$comment": "https://setuptools.pypa.io/en/latest/userguide/package_discovery.html",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "python-module-name"
+      },
+      "description": "**DEPRECATED**: use implicit namespaces instead (:pep:`420`)."
+    },
+    "py-modules": {
+      "$comment": "TODO: clarify the relationship with ``packages``",
+      "description": "Modules that setuptools will manipulate",
+      "type": "array",
+      "items": {
+        "type": "string",
+        "format": "python-module-name"
+      }
+    },
+    "ext-modules": {
+      "$comment": "https://setuptools.pypa.io/en/latest/userguide/ext_modules.html",
+      "description": "Extension modules to be compiled by setuptools",
+      "type": "array",
+      "items": {
+        "$ref": "#/definitions/ext-module"
+      }
+    },
+    "data-files": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        }
+      },
+      "description": "``dict``-like structure where each key represents a directory and the value is a list of glob patterns that should be installed in them. **DISCOURAGED**: please notice this might not work as expected with wheels. Whenever possible, consider using data files inside the package directories (or create a new namespace package that only contains data files). See `data files support <https://setuptools.pypa.io/en/latest/userguide/datafiles.html>`_."
+    },
+    "cmdclass": {
+      "type": "object",
+      "patternProperties": {
+        "^.*$": {
+          "type": "string",
+          "format": "python-qualified-identifier"
+        }
+      },
+      "description": "Mapping of distutils-style command names to ``setuptools.Command`` subclasses which in turn should be represented by strings with a qualified class name (i.e., \"dotted\" form with module), e.g.::\n\n     cmdclass = {mycmd = \"pkg.subpkg.module.CommandClass\"}\n\n The command class should be a directly defined at the top-level of the containing module (no class nesting)."
+    },
+    "license-files": {
+      "$comment": "TODO: revise if PEP 639 is accepted. Probably ``project.license-files``?",
+      "type": "array",
+      "items": {
+        "type": "string"
+      },
+      "description": "**PROVISIONAL**: list of glob patterns for all license files being distributed. (likely to become standard with :pep:`639`). By default: ``['LICEN[CS]E*', 'COPYING*', 'NOTICE*', 'AUTHORS*']``"
+    },
+    "dynamic": {
+      "type": "object",
+      "description": "Instructions for loading :pep:`621`-related metadata dynamically",
+      "additionalProperties": false,
+      "properties": {
+        "version": {
+          "oneOf": [
+            {
+              "$ref": "#/definitions/attr-directive"
+            },
+            {
+              "$ref": "#/definitions/file-directive"
+            }
+          ],
+          "description": "A version dynamically loaded via either the ``attr:`` or ``file:`` directives. Please make sure the given file or attribute respects :pep:`440`. Also ensure to set ``project.dynamic`` accordingly."
+        },
+        "classifiers": {
+          "$ref": "#/definitions/file-directive"
+        },
+        "description": {
+          "$ref": "#/definitions/file-directive"
+        },
+        "entry-points": {
+          "$ref": "#/definitions/file-directive"
+        },
+        "dependencies": {
+          "$ref": "#/definitions/file-directive-for-dependencies"
+        },
+        "optional-dependencies": {
+          "type": "object",
+          "propertyNames": {
+            "type": "string",
+            "format": "python-identifier"
+          },
+          "additionalProperties": false,
+          "patternProperties": {
+            ".+": {
+              "$ref": "#/definitions/file-directive-for-dependencies"
+            }
+          }
+        },
+        "readme": {
+          "type": "object",
+          "anyOf": [
+            {
+              "$ref": "#/definitions/file-directive"
+            },
+            {
+              "type": "object",
+              "properties": {
+                "content-type": {
+                  "type": "string"
+                },
+                "file": {
+                  "$ref": "#/definitions/file-directive/properties/file"
+                }
+              },
+              "additionalProperties": false
+            }
+          ],
+          "required": ["file"]
+        }
+      }
+    }
+  },
+  "definitions": {
+    "package-name": {
+      "title": "Valid package name",
+      "description": "Valid package name (importable or :pep:`561`).",
+      "type": "string",
+      "anyOf": [
+        {
+          "type": "string",
+          "format": "python-module-name"
+        },
+        {
+          "type": "string",
+          "format": "pep561-stub-name"
+        }
+      ]
+    },
+    "file-directive": {
+      "title": "'file:' directive",
+      "description": "Value is read from a file (or list of files and then concatenated)",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "file": {
+          "oneOf": [
+            {
+              "type": "string"
+            },
+            {
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            }
+          ]
+        }
+      },
+      "required": ["file"]
+    },
+    "file-directive-for-dependencies": {
+      "title": "'file:' directive for dependencies",
+      "allOf": [
+        {
+          "description": "**BETA**: subset of the ``requirements.txt`` format without ``pip`` flags and options (one :pep:`508`-compliant string per line, lines that are blank or start with ``#`` are excluded). See `dynamic metadata <https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#dynamic-metadata>`_."
+        },
+        {
+          "$ref": "#/definitions/file-directive"
+        }
+      ]
+    },
+    "attr-directive": {
+      "title": "'attr:' directive",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "attr": {
+          "type": "string",
+          "format": "python-qualified-identifier"
+        }
+      },
+      "required": ["attr"],
+      "description": "Value is read from a module attribute. Supports callables and iterables; unsupported types are cast via ``str()``"
+    },
+    "ext-module": {
+      "title": "Extension module",
+      "description": "Parameters to construct a :class:`setuptools.Extension` object",
+      "type": "object",
+      "required": ["name", "sources"],
+      "additionalProperties": false,
+      "properties": {
+        "name": {
+          "type": "string",
+          "format": "python-module-name"
+        },
+        "sources": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "include-dirs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "define-macros": {
+          "type": "array",
+          "items": {
+            "type": "array",
+            "minItems": 2,
+            "maxItems": 2,
+            "items": [
+              {
+                "description": "macro name",
+                "type": "string"
+              },
+              {
+                "description": "macro value",
+                "oneOf": [
+                  {
+                    "type": "string"
+                  },
+                  {
+                    "type": "null"
+                  }
+                ]
+              }
+            ],
+            "additionalItems": false
+          }
+        },
+        "undef-macros": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "library-dirs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "libraries": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "runtime-library-dirs": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extra-objects": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extra-compile-args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "extra-link-args": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "export-symbols": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "swig-opts": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "depends": {
+          "type": "array",
+          "items": {
+            "type": "string"
+          }
+        },
+        "language": {
+          "type": "string"
+        },
+        "optional": {
+          "type": "boolean"
+        },
+        "py-limited-api": {
+          "type": "boolean"
+        }
+      }
+    },
+    "find-directive": {
+      "title": "'find:' directive",
+      "type": "object",
+      "additionalProperties": false,
+      "properties": {
+        "find": {
+          "type": "object",
+          "additionalProperties": false,
+          "properties": {
+            "where": {
+              "description": "Directories to be searched for packages (Unix-style relative path)",
+              "type": "array",
+              "items": {
+                "type": "string"
+              }
+            },
+            "exclude": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Exclude packages that match the values listed in this field. Can container shell-style wildcards (e.g. ``'pkg.*'``)"
+            },
+            "include": {
+              "type": "array",
+              "items": {
+                "type": "string"
+              },
+              "description": "Restrict the found packages to just the ones listed in this field. Can container shell-style wildcards (e.g. ``'pkg.*'``)"
+            },
+            "namespaces": {
+              "type": "boolean",
+              "description": "When ``True``, directories without a ``__init__.py`` file will also be scanned for :pep:`420`-style implicit namespaces"
+            }
+          },
+          "description": "Dynamic `package discovery <https://setuptools.pypa.io/en/latest/userguide/package_discovery.html>`_."
+        }
+      }
+    }
+  },
+  "description": "``setuptools``-specific configurations that can be set by users that require customization. These configurations are completely optional and probably can be skipped when creating simple packages. They are equivalent to some of the `Keywords <https://setuptools.pypa.io/en/latest/references/keywords.html>`_ used by the ``setup.py`` file, and can be set via the ``tool.setuptools`` table. It considers only ``setuptools`` `parameters <https://setuptools.pypa.io/en/latest/userguide/pyproject_config.html#setuptools-specific-configuration>`_ that are not covered by :pep:`621`; and intentionally excludes ``dependency_links`` and ``setup_requires`` (incompatible with modern workflows/standards)."
+}

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -51,6 +51,23 @@ TOML formatting is enforced by the tombi-format hook and configured by
 [tombi.toml](./tombi.toml). tombi puts tables and keys in the order its bundled
 schema defines, so adding a table to a file it has a schema for may move it.
 
+Some of those schemas are not bundled, and tombi fetches them from schemastore,
+which serves no versioned URLs and has had outages in the past. Either a schema
+change or an outage could then decide a CI result, an outage failing the run
+outright, since tombi exits non-zero when it cannot fetch. So CI runs tombi
+offline against the copies vendored in `.tombi-cache`, by setting:
+
+```sh
+TOMBI_OFFLINE=true
+TOMBI_CACHE_HOME=<repository root>/.tombi-cache
+```
+
+Locally the hooks run without those, fetching the current schemas instead, which
+validates the same thing as long as schemastore has not changed. Export both to
+reproduce a CI run exactly. `TOMBI_OFFLINE` accepts only `true` or `false`; any
+other value is an error. See [.tombi-cache/README.md](./.tombi-cache/README.md)
+for how to refresh the vendored copies.
+
 Commits that only reformat are listed in
 [.git-blame-ignore-revs](./.git-blame-ignore-revs) so that `git blame` can skip
 them. GitHub uses that file automatically; locally it needs

--- a/tombi.toml
+++ b/tombi.toml
@@ -5,3 +5,10 @@
 [format.rules]
 trailing-comment-alignment = true
 trailing-comment-space-width = 1
+
+# Every lint rule defaults to a warning, and tombi exits 0 on a warning, so a
+# finding would sit behind a passing hook where pre-commit hides its output.
+[lint.rules]
+dotted-keys-out-of-order = "error"
+key-empty = "error"
+tables-out-of-order = "error"


### PR DESCRIPTION
TOML had a formatter but no linter. tombi-lint reports nothing on the files here, so enabling it only catches what arrives later.

Every tombi lint rule defaults to a warning and tombi exits 0 on a warning, so a finding would sit behind a passing hook with pre-commit hiding the output. Promote the ones that can fire here to errors.

tombi validates pyproject.toml against a bundled schema that refers [tool.setuptools] out to one it does not bundle. #544 passed --offline, so that reference never resolved and a wrong type in that table passed. Fetching it instead leaves the result to schemastore, which serves no versioned URLs and has had outages; an outage fails the run outright, since tombi exits non-zero when it cannot fetch.

So vendor that one schema and have CI resolve it from the repository. The hooks no longer pass --offline, so a local run fetches the current schemas and agrees with CI as long as schemastore has not changed. DEVELOPERS.md records how to reproduce a CI run exactly.