### PR TITLE
Use Nexcess mirror instead of generic GNU one

### DIFF
--- a/contrib/common-setup.sh
+++ b/contrib/common-setup.sh
@@ -70,7 +70,7 @@ if ! declare -F download_step >/dev/null; then
       version=$git_branch
     fi
     dep_filename=$dep_name-$version
-    wget -O "$dep_filename.tar.gz" "$source_url"
+    wget -4 -O "$dep_filename.tar.gz" "$source_url"
     tar -xf "$dep_filename.tar.gz"
     rm "$dep_filename.tar.gz"
     mv "$dep_filename" "$dep_name"

--- a/contrib/setup-bison.sh
+++ b/contrib/setup-bison.sh
@@ -1,6 +1,7 @@
 #!/bin/bash
 version=3.8.2
-source_url=https://ftpmirror.gnu.org/gnu/bison/bison-$version.tar.gz
+_mirror_host=mirror.us-midwest-1.nexcess.net
+source_url=https://$_mirror_host/gnu/bison/bison-$version.tar.gz
 
 # shellcheck source=contrib/make-setup.sh
 source "$(dirname "$0")/make-setup.sh"


### PR DESCRIPTION
The official ftpmirror.gnu.org (just like ftp.gnu.org) has frequent outages and rate limiting. The mirror hosted by Nexcess is the fastest and likely the most stable of the US-based ones. It does not like IPv6, however, hence the `-4` to wget.