### PR TITLE
Use Nexcess mirror instead of generic GNU one

### DIFF
--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -65,10 +65,10 @@ jobs:
               wget
             # Build GMP and MPFR manually, which are too old in the repos
             mkdir -p {project}/deps && pushd {project}/deps
-            wget https://ftpmirror.gnu.org/gmp/gmp-6.3.0.tar.xz
+            wget -4 https://mirror.us-midwest-1.nexcess.net/gnu/gmp/gmp-6.3.0.tar.xz
             tar -xf gmp-6.3.0.tar.xz && mv gmp-6.3.0 gmp && rm -f gmp-6.3.0.tar.xz
             pushd gmp && ./configure --enable-cxx && make install && popd
-            wget https://ftpmirror.gnu.org/mpfr/mpfr-4.2.2.tar.xz
+            wget -4 https://mirror.us-midwest-1.nexcess.net/gnu/mpfr/mpfr-4.2.2.tar.xz
             tar -xf mpfr-4.2.2.tar.xz && mv mpfr-4.2.2 mpfr && rm -f mpfr-4.2.2.tar.xz
             cd mpfr && ./configure && make install && popd
             bash {project}/ci-scripts/cibw-build-deps.sh


### PR DESCRIPTION
The official ftpmirror.gnu.org (just like ftp.gnu.org) has frequent outages and rate limiting. The mirror hosted by Nexcess is the fastest and likely the most stable of the US-based ones. It does not like IPv6, however, hence the `-4` to wget.