### PR TITLE
build: Fail tombi-lint on warnings

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -69,6 +69,8 @@ repos:
       # validate the same thing; see DEVELOPERS.md to reproduce CI locally.
       - id: tombi-format
       - id: tombi-lint
+        # Without this a warning exits 0 and the hook passes.
+        args: [--error-on-warnings]
   - repo: https://github.com/hukkin/mdformat
     rev: 1.0.0
     hooks:

--- a/tombi.toml
+++ b/tombi.toml
@@ -5,10 +5,3 @@
 [format.rules]
 trailing-comment-alignment = true
 trailing-comment-space-width = 1
-
-# Every lint rule defaults to a warning, and tombi exits 0 on a warning, so a
-# finding would sit behind a passing hook where pre-commit hides its output.
-[lint.rules]
-dotted-keys-out-of-order = "error"
-key-empty = "error"
-tables-out-of-order = "error"

--- a/tombi.toml
+++ b/tombi.toml
@@ -1,7 +1,4 @@
-# Used by the tombi hooks in .pre-commit-config.yaml.
-#
-# tombi's default is to put a fixed two spaces before a trailing comment, which
-# would undo the alignment .ruff.toml uses for the comments on its ignore list.
+# tombi's default is to put a fixed two spaces before a trailing comment
 [format.rules]
 trailing-comment-alignment = true
 trailing-comment-space-width = 1


### PR DESCRIPTION
tombi's lint rules all default to warnings and tombi exits 0 on a warning, so a finding sits behind a passing hook where pre-commit hides the output. #548 worked around that by promoting three rules to errors in tombi.toml, which reaches only the rules named there.

--error-on-warnings reaches all of them, and warnings that are not lint rules at all. One of those matters here: when a schema reference fails to resolve tombi says so and exits 0, having skipped validating that table. That is the gap #548 vendored a schema to close, so it should not be able to reopen quietly.

What gets reported still comes from tombi.toml, so a local tombi run shows what it did before.

Also took the opportunity to trim the top comment in tombi.toml, yielding a more compact file.