### PR TITLE
ci: Rework the build matrix and job naming

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -5,8 +5,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: [ubuntu, macos]
-        os_version: [latest]
+        runner: [ubuntu-latest, macos-latest]
         build_type: [release, debug]
         solver:
           - bitwuzla
@@ -15,19 +14,17 @@ jobs:
           - msat
           - yices2
           - z3
-        include:
-          - build_type: debug
-            config_opts: --debug
-          - solver: msat
-            setup_opts: --auto-yes
-    name: ${{ matrix.os }}:${{ matrix.solver }}-${{ matrix.build_type }}
-    runs-on: ${{ matrix.os }}-${{ matrix.os_version }}
+    name: ${{ matrix.solver }} on ${{ matrix.runner }} (${{ matrix.build_type }})
+    runs-on: ${{ matrix.runner }}
+    env:
+      # The install-packages scripts are named after the label's first element
+      RUNNER_LABEL: ${{ matrix.runner }}
     steps:
       - name: Check out project source
         uses: actions/checkout@v7
       - name: Install packages
-        run: ./ci-scripts/install-packages-${{ matrix.os }}.sh
-      - name: Compute hash from setup scripts for caching solver builds
+        run: ./ci-scripts/install-packages-"${RUNNER_LABEL%%-*}".sh
+      - name: Compute the cache key for the solver build
         id: compute-solver-hash
         run: ./ci-scripts/compute-solver-hash.sh ${{ matrix.solver }}
       - name: Restore solver build from cache
@@ -35,10 +32,11 @@ jobs:
         id: cache
         with:
           path: deps
-          key: deps-${{ hashFiles(format('ci-scripts/install-packages-{0}.sh', matrix.os)) }}-${{ steps.compute-solver-hash.outputs.result }}
+          key: deps-${{ steps.compute-solver-hash.outputs.result }}
       - name: Set up underlying solver
         if: steps.cache.outputs.cache-hit != 'true'
-        run: ./ci-scripts/setup-${{ matrix.solver }}.sh ${{ matrix.setup_opts }}
+        # setup-msat.sh asks to accept a licence; the others read no input
+        run: yes | ./ci-scripts/setup-${{ matrix.solver }}.sh
       - name: Save solver build to cache
         uses: actions/cache/save@v6
         if: steps.cache.outputs.cache-hit != 'true' && matrix.build_type == 'release'
@@ -50,7 +48,7 @@ jobs:
       - name: Configure
         env:
           CMAKE_GENERATOR: Ninja
-        run: ./configure.sh --${{ matrix.solver }} --python --smtlib-reader --static ${{ matrix.config_opts }}
+        run: ./configure.sh --${{ matrix.solver }} --python --smtlib-reader --static ${{ matrix.build_type == 'debug' && '--debug' || '' }}
       - name: Build
         run: ninja -C build
       - name: Install Python bindings
@@ -65,7 +63,7 @@ jobs:
         if: steps.test-cpp.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
-          name: ${{ matrix.os }}-${{ matrix.solver }}-${{ matrix.build_type }}-test-log-${{ github.run_id }}
+          name: test-log-${{ matrix.runner }}-${{ matrix.solver }}-${{ matrix.build_type }}
           path: build/Testing/Temporary/LastTest.log
       - name: Fail pipeline due to C++ test failure
         if: steps.test-cpp.outcome == 'failure'

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -16,23 +16,23 @@ on:
 jobs:
   build_wheels:
     name: ${{ matrix.name }}
-    runs-on: ${{ matrix.os }}
+    runs-on: ${{ matrix.runner }}
     strategy:
       matrix:
         name: [manylinux-x86_64, manylinux-aarch64, macos-x86_64, macos-arm64]
         include:
           - name: manylinux-x86_64
-            os: ubuntu-latest
+            runner: ubuntu-latest
             arch: x86_64
           - name: manylinux-aarch64
-            os: ubuntu-24.04-arm
+            runner: ubuntu-24.04-arm
             arch: aarch64
             shell: bash
           - name: macos-x86_64
-            os: macos-15-intel
+            runner: macos-15-intel
             macos-target: 15
           - name: macos-arm64
-            os: macos-15
+            runner: macos-15
             macos-target: 15
     steps:
       - uses: actions/checkout@v7

--- a/ci-scripts/compute-solver-hash.sh
+++ b/ci-scripts/compute-solver-hash.sh
@@ -5,6 +5,9 @@ gethash() {
 }
 solver=$1
 solver_hash=$(gethash ci-scripts/setup-"$1".sh)
+# The installed packages decide what the solver builds against
+# shellcheck disable=SC2154 # RUNNER_LABEL is set by the workflow
+solver_hash+=$(gethash ci-scripts/install-packages-"${RUNNER_LABEL%%-*}".sh)
 if [[ $solver =~ ^(bitwuzla|btor|cvc5|z3)$ ]]; then
   solver_hash+=$(gethash contrib/common-setup.sh)
   if [[ $solver == bitwuzla ]]; then

--- a/ci-scripts/setup-msat.sh
+++ b/ci-scripts/setup-msat.sh
@@ -10,28 +10,23 @@ Usage: $0 [<option> ...]
 Downloads the MathSAT SMT Solver. Note that this solver is under a custom (non-BSD-compliant) license.
 
 -h, --help              display this message and exit
--y, --auto-yes          automatically agree to conditions (default: off)
 EOF
   exit 0
 }
 
-get_msat=default
 while (($# > 0)); do
   case "$1" in
     -h | --help) usage ;;
-    -y | --auto-yes) get_msat=y ;;
     *) echo "unexpected argument: $1" && exit 1 ;;
   esac
   shift
 done
 
-if [[ $get_msat == default ]]; then
-  printf "%s\n" \
-    "MathSAT is distributed under a custom (non-BSD-compliant) license." \
-    "By continuing, you acknowledge this and assume responsibility for" \
-    "meeting the license conditions."
-  read -rp "Continue? [y]es/[n]o: " get_msat
-fi
+printf "%s\n" \
+  "MathSAT is distributed under a custom (non-BSD-compliant) license." \
+  "By continuing, you acknowledge this and assume responsibility for" \
+  "meeting the license conditions."
+read -rp "Continue? [y]es/[n]o: " get_msat
 
 if [[ $get_msat != y ]]; then
   echo "Not downloading MathSAT"


### PR DESCRIPTION
runs-on built its label from two matrix keys, one of which had a single value, so it could only ever name a -latest runner. One runner key holding the full label says the same and admits an architecture variant like ubuntu-24.04-arm as another entry. cibuildwheel.yml already lists full labels, so its key is renamed to match.

The job name becomes prose rather than ubuntu:z3-release, as only a person ever reads it and a name may contain spaces. This renames every job, so a required status check naming one has to be updated.

The install-packages scripts are named after a runner label's first element, so the workflow exports the label and its two readers strip it at the first dash. compute-solver-hash.sh hashes the script it picks as well now, leaving the cache key a single value that still changes when the packages do.

The artifact name leads with test-log and drops the run id, which was redundant: artifacts belong to one run, so the matrix values alone keep it unique.