### PR TITLE
build: Enable the yamllint hook

### DIFF
--- a/.github/workflows/auto-draft-release.yml
+++ b/.github/workflows/auto-draft-release.yml
@@ -13,18 +13,20 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v7
         with:
-          fetch-depth: 0 # Fetch all history to ensure we can check if tag exists
+          fetch-depth: 0 # Fetch all history so the tag check works
       - name: Read VERSION file
         id: version
         run: |
-          # Use grep to filter out comment lines, then take the first non-comment line
+          # Drop comment lines and take the first line that remains
           VERSION_VALUE=$(grep -v '^#' VERSION | head -n 1 | tr -d '[:space:]')
           echo "Detected version: $VERSION_VALUE"
           echo "version=$VERSION_VALUE" >> $GITHUB_OUTPUT
       - name: Check if tag exists
         id: check_tag
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
-          if git tag -l "v${{ steps.version.outputs.version }}" | grep -q .; then
+          if git tag -l "v$VERSION" | grep -q .; then
             echo "tag_exists=true" >> $GITHUB_OUTPUT
           else
             echo "tag_exists=false" >> $GITHUB_OUTPUT
@@ -32,11 +34,14 @@ jobs:
       # Create and push the tag if it doesn't already exist
       - name: Create and push tag
         if: steps.check_tag.outputs.tag_exists == 'false'
+        env:
+          VERSION: ${{ steps.version.outputs.version }}
         run: |
           git config user.name "github-actions[bot]"
-          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
-          git tag -a v${{ steps.version.outputs.version }} -m "Version ${{ steps.version.outputs.version }}"
-          git push origin "v${{ steps.version.outputs.version }}"
+          git config user.email \
+            "41898282+github-actions[bot]@users.noreply.github.com"
+          git tag -a "v$VERSION" -m "Version $VERSION"
+          git push origin "v$VERSION"
       - name: Create draft GitHub Release
         if: steps.check_tag.outputs.tag_exists == 'false'
         uses: softprops/action-gh-release@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,11 +14,16 @@ jobs:
           - msat
           - yices2
           - z3
-    name: ${{ matrix.solver }} on ${{ matrix.runner }} (${{ matrix.build_type }})
+    name: >-
+      ${{ matrix.solver }} on ${{ matrix.runner }}
+      (${{ matrix.build_type }})
     runs-on: ${{ matrix.runner }}
     env:
       # The install-packages scripts are named after the label's first element
       RUNNER_LABEL: ${{ matrix.runner }}
+      # Names the artifact; a fold here would put a space in it
+      BUILD_ID: >-
+        ${{ matrix.runner }}-${{ matrix.solver }}-${{ matrix.build_type }}
     steps:
       - name: Check out project source
         uses: actions/checkout@v7
@@ -39,16 +44,22 @@ jobs:
         run: yes | ./ci-scripts/setup-${{ matrix.solver }}.sh
       - name: Save solver build to cache
         uses: actions/cache/save@v6
-        if: steps.cache.outputs.cache-hit != 'true' && matrix.build_type == 'release'
+        if: >-
+          steps.cache.outputs.cache-hit != 'true'
+          && matrix.build_type == 'release'
         with:
           path: deps
           key: ${{ steps.cache.outputs.cache-primary-key }}
       - name: Set up Python virtual environment
-        run: python3 -m venv .venv --system-site-packages && echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
+        run: |
+          python3 -m venv .venv --system-site-packages
+          echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
       - name: Configure
         env:
           CMAKE_GENERATOR: Ninja
-        run: ./configure.sh --${{ matrix.solver }} --python --smtlib-reader --static ${{ matrix.build_type == 'debug' && '--debug' || '' }}
+        run: |
+          ./configure.sh --${{ matrix.solver }} --python --smtlib-reader \
+            --static ${{ matrix.build_type == 'debug' && '--debug' || '' }}
       - name: Build
         run: ninja -C build
       - name: Install Python bindings
@@ -57,16 +68,19 @@ jobs:
         id: test-cpp
         continue-on-error: true
         env:
-          DYLD_FALLBACK_LIBRARY_PATH: /opt/homebrew/lib # this lets the precompiled MathSAT binary find libgmp
+          # Lets the precompiled MathSAT binary find libgmp
+          DYLD_FALLBACK_LIBRARY_PATH: /opt/homebrew/lib
         run: ctest --test-dir build
       - name: Upload failing test log
         if: steps.test-cpp.outcome == 'failure'
         uses: actions/upload-artifact@v7
         with:
-          name: test-log-${{ matrix.runner }}-${{ matrix.solver }}-${{ matrix.build_type }}
+          name: test-log-${{ env.BUILD_ID }}
           path: build/Testing/Temporary/LastTest.log
       - name: Fail pipeline due to C++ test failure
         if: steps.test-cpp.outcome == 'failure'
-        run: echo "C++ tests failed. Inspect the artifact for details." && exit 1
+        run: |
+          echo "C++ tests failed. Inspect the artifact for details."
+          exit 1
       - name: Test Python bindings
         run: pytest tests/python

--- a/.github/workflows/cibuildwheel.yml
+++ b/.github/workflows/cibuildwheel.yml
@@ -38,7 +38,7 @@ jobs:
       - uses: actions/checkout@v7
         with:
           fetch-depth: 0
-      # cibuildwheel requires the pyproject.toml to be present from the beginning
+      # cibuildwheel needs pyproject.toml present from the start
       - name: Place pyproject.toml
         run: |
           mkdir -p ./build/python
@@ -64,12 +64,15 @@ jobs:
               ninja-build \
               wget
             # Build GMP and MPFR manually, which are too old in the repos
+            gnu_mirror=https://mirror.us-midwest-1.nexcess.net/gnu
+            gmp=gmp-6.3.0
+            mpfr=mpfr-4.2.2
             mkdir -p {project}/deps && pushd {project}/deps
-            wget -4 https://mirror.us-midwest-1.nexcess.net/gnu/gmp/gmp-6.3.0.tar.xz
-            tar -xf gmp-6.3.0.tar.xz && mv gmp-6.3.0 gmp && rm -f gmp-6.3.0.tar.xz
+            wget -4 "$gnu_mirror/gmp/$gmp.tar.xz"
+            tar -xf "$gmp.tar.xz" && mv "$gmp" gmp && rm -f "$gmp.tar.xz"
             pushd gmp && ./configure --enable-cxx && make install && popd
-            wget -4 https://mirror.us-midwest-1.nexcess.net/gnu/mpfr/mpfr-4.2.2.tar.xz
-            tar -xf mpfr-4.2.2.tar.xz && mv mpfr-4.2.2 mpfr && rm -f mpfr-4.2.2.tar.xz
+            wget -4 "$gnu_mirror/mpfr/$mpfr.tar.xz"
+            tar -xf "$mpfr.tar.xz" && mv "$mpfr" mpfr && rm -f "$mpfr.tar.xz"
             cd mpfr && ./configure && make install && popd
             bash {project}/ci-scripts/cibw-build-deps.sh
           CIBW_BEFORE_ALL_MACOS: |
@@ -82,10 +85,8 @@ jobs:
               Cython>=3.0.0 \
               setuptools
             bash {project}/ci-scripts/cibw-build-before.sh
-          # `>` folds the lines below into one space-separated line, which is the
-          # only form cibuildwheel accepts here. With `|` each would keep its
-          # newline and cibuildwheel would read just the first assignment.
-          CIBW_ENVIRONMENT_MACOS: >
+          # cibuildwheel reads only the first assignment if this is `|`
+          CIBW_ENVIRONMENT_MACOS: >-
             CPATH="$(brew --prefix)/include"
             LIBRARY_PATH="$(brew --prefix)/lib"
             PKG_CONFIG_PATH="$(brew --prefix)/lib/pkgconfig"
@@ -93,11 +94,14 @@ jobs:
             MACOSX_DEPLOYMENT_TARGET=${{ matrix.macos-target }}
           CIBW_TEST_COMMAND: |
             # cibuildwheel creates a dedicated virtualenv for the test
-            # make sure to use that python (just calling pytest may use system pytest)
+            # use that python; plain pytest may be the system one
             python3 -m pip install pytest
             python3 -m pytest {project}/tests
       - name: Upload wheels to PyPI
-        if: github.event_name == 'release' || (github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'PyPI')
+        if: >-
+          github.event_name == 'release'
+          || (github.event_name == 'workflow_dispatch'
+          && github.event.inputs.deploy_target == 'PyPI')
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.PYPI_TOKEN }}
@@ -107,7 +111,9 @@ jobs:
           python3 -m pip install twine
           python3 -m twine upload --skip-existing wheelhouse/*.whl
       - name: Upload wheels to TestPyPI
-        if: github.event_name == 'workflow_dispatch' && github.event.inputs.deploy_target == 'Test PyPI'
+        if: >-
+          github.event_name == 'workflow_dispatch'
+          && github.event.inputs.deploy_target == 'Test PyPI'
         env:
           TWINE_USERNAME: __token__
           TWINE_PASSWORD: ${{ secrets.TEST_PYPI_TOKEN }}
@@ -115,4 +121,5 @@ jobs:
           python3 -m venv ./upload-env
           source ./upload-env/bin/activate
           python3 -m pip install twine
-          python3 -m twine upload --skip-existing --repository testpypi wheelhouse/*.whl
+          python3 -m twine upload --skip-existing --repository testpypi \
+            wheelhouse/*.whl

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -60,6 +60,12 @@ repos:
     rev: v0.21.0
     hooks:
       - id: yamlfmt # also covers .clang-format, which is YAML
+  - repo: https://github.com/adrienverge/yamllint
+    rev: v1.38.0
+    hooks:
+      - id: yamllint
+        # Without this a warning exits 0 and the hook passes.
+        args: [--strict]
   - repo: https://github.com/tombi-toml/tombi-pre-commit
     rev: v1.5.2
     hooks:

--- a/.yamllint
+++ b/.yamllint
@@ -1,0 +1,10 @@
+extends: default
+rules:
+  # yamlfmt writes one space before a trailing comment, yamllint wants two
+  comments:
+    min-spaces-from-content: 1
+  # `on:` in a workflow is the GitHub Actions key, not a boolean
+  truthy:
+    check-keys: false
+  # Nothing in the tree opens with `---`
+  document-start: disable


### PR DESCRIPTION
This change adds a YAML linter, for which we already had a formatter. The yamllint file sets options to make sure yamlfmt output is compatible with yamllint and our conventions are respected. Comments have to be slightly reworded and some expressions rewritten to fit within the 80-column line length limit. `run` blocks in workflows execute under `bash -e`, so the `&&` separators are safe to remove.

The pre-commit hook passes --strict, since yamllint exits 0 on a warning.