### PR TITLE
fix: Enable codespell and fix the misspellings it finds

### DIFF
--- a/.codespellrc
+++ b/.codespellrc
@@ -1,0 +1,4 @@
+# StrAt is the SMT-LIB str.at operator, and appears too widely to annotate.
+# Matched case-sensitively, so a lowercase typo of the same shape still counts.
+[codespell]
+ignore-regex = \bStrAt\b

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -38,6 +38,10 @@ repos:
       # Python sources.
       - id: check-ast
       - id: debug-statements # breakpoint() calls and debugger imports
+  - repo: https://github.com/codespell-project/codespell
+    rev: v2.4.3
+    hooks:
+      - id: codespell
   - repo: https://github.com/astral-sh/ruff-pre-commit
     rev: v0.16.6
     hooks:

--- a/DEVELOPERS.md
+++ b/DEVELOPERS.md
@@ -130,7 +130,7 @@ that some methods have default implementations in `*.cpp` files under the `src`
 directory. These default implementations can be replaced with solver-specific
 implementations for performance improvements. For example, `substitute` takes a
 map and a term and performs sub-term substitution. This has a default
-implementation but is overriden in the `boolector` implementation to rely on
+implementation but is overridden in the `boolector` implementation to rely on
 `boolector's` underlying substitution map infrastructure.
 
 All your solver header and source files should be put in `<solver name>/include`

--- a/README.md
+++ b/README.md
@@ -238,7 +238,7 @@ the helper function `Solver`:
 ```Python
 from smt_switch import pysmt_frontend
 
-# direct instantiation must pass an enviroment and a logic
+# direct instantiation must pass an environment and a logic
 solver = pysmt_frontend.SwitchCvc5(ENV, LOGIC)
 
 # with the helper function will try to use a general logic

--- a/btor/src/boolector_term.cpp
+++ b/btor/src/boolector_term.cpp
@@ -17,7 +17,7 @@
 #include "boolector_term.h"
 
 // include standard version of open_memstream
-// for compatability with FreeBSD / Darwin which doesn't support it natively
+// for compatibility with FreeBSD / Darwin which doesn't support it natively
 extern "C" {
 #include "memstream.h"
 }

--- a/configure.sh
+++ b/configure.sh
@@ -22,7 +22,7 @@ Configures the CMAKE build environment.
 --yices2-home=STR       custom YICES2 location  (default: deps/yices2)
 --build-dir=STR         custom build directory  (default: build)
 --debug                 build debug with debug symbols (default: off)
---static                create static libaries (default: off)
+--static                create static libraries (default: off)
 --without-tests         build without the smt-switch test suite (default: off)
 --no-system-gtest       do not use system GTest sources; forces download (default: off)
 --python                compile with python bindings (default: off)

--- a/include/exceptions.h
+++ b/include/exceptions.h
@@ -50,7 +50,7 @@ class SmtException : public std::exception
 
   /** Returns a pointer to the (constant) error description.
    *  @return A pointer to a const char*. The underlying memory
-   *          is in posession of the Exception object. Callers must
+   *          is in possession of the Exception object. Callers must
    *          not attempt to free the memory.
    */
   virtual const char * what() const throw() { return msg.c_str(); }

--- a/include/solver.h
+++ b/include/solver.h
@@ -70,7 +70,7 @@ class AbsSmtSolver
 
   /* Check satisfiability of the current assertions under the given assumptions
    * Note: the assumptions must be boolean literals, not arbitrary formulas
-   * SMTLIB: (check-sat-assuming (t1 t2 ... tn)) with asssumption literals =
+   * SMTLIB: (check-sat-assuming (t1 t2 ... tn)) with assumption literals =
    * [t1,...,tn]
    * @param assumptions a vector of boolean literals
    * @return a result object - see result.h

--- a/include/sorting_network.h
+++ b/include/sorting_network.h
@@ -22,7 +22,7 @@ namespace smt {
 
 /** \class SortingNetwork
  *         Implements a symbolic sorting network for boolean-sorted terms.
- *         All methods are const so it can be re-used for terms from the same
+ *         All methods are const so it can be reused for terms from the same
  *          solver.
  *         Returns a vector of new terms, which can be used to determine how
  *          many terms are assigned to true symbolically.

--- a/include/term.h
+++ b/include/term.h
@@ -132,7 +132,7 @@ inline bool operator>=(const Term & t1, const Term & t2)
 std::ostream & operator<<(std::ostream & output, const Term t);
 
 // term iterators
-// impelementation based on
+// implementation based on
 // https://www.codeproject.com/Articles/92671/How-to-write-abstract-iterators-in-Cplusplus
 class TermIterBase
 {

--- a/include/utils.h
+++ b/include/utils.h
@@ -123,7 +123,7 @@ bool is_cnf(Term formula);
 
 /** \class
  * UnsatcoreReducer class.
- * Implements an interative unsatcore reducer procedure.
+ * Implements an iterative unsatcore reducer procedure.
  *
  * reducer_solver is the solver that will be used for unsatcore extraction in
  * the procedure. It is different from the ext_solver (external solver used to

--- a/msat/src/msat_factory.cpp
+++ b/msat/src/msat_factory.cpp
@@ -36,8 +36,8 @@ SmtSolver MsatSolverFactory::create(bool logging)
 
 SmtSolver MsatSolverFactory::create_interpolating_solver()
 {
-  MsatInterpolatingSolver * mis = new MsatInterpolatingSolver();
-  std::shared_ptr<MsatInterpolatingSolver> s(mis);
+  MsatInterpolatingSolver * ps = new MsatInterpolatingSolver();
+  std::shared_ptr<MsatInterpolatingSolver> s(ps);
   return s;
 }
 

--- a/msat/src/msat_solver.cpp
+++ b/msat/src/msat_solver.cpp
@@ -1331,7 +1331,7 @@ Result MsatInterpolatingSolver::get_interpolant(const Term & A,
 // otherwise, the function backtracks the solver to the point where the match
 // ends and asserts the remaining formulas from that point onward.
 //
-// The folllowing invariant should hold before and after the call:
+// The following invariant should hold before and after the call:
 // `#backtrack-points == last_itp_query_assertions_.size() == itp_grps_.size()`
 Result MsatInterpolatingSolver::get_sequence_interpolants(
     const TermVec & formulae, TermVec & out_I) const

--- a/python/smt_switch/pysmt_frontend/__init__.py
+++ b/python/smt_switch/pysmt_frontend/__init__.py
@@ -45,7 +45,7 @@ except ImportError:
 # resemblance this function exists to provide.
 def Solver(name: str, logic: logics.Logic | None = None) -> SolverT:  # noqa: N802
     """
-    Convience function for building a pysmt solver object with a switch backend.
+    Convenience function for building a pysmt solver object with a switch backend.
     Similar to `pysmt.shortcuts.Solver`.
     """
     try:

--- a/python/smt_switch/pysmt_frontend/pysmt_solver.py
+++ b/python/smt_switch/pysmt_frontend/pysmt_solver.py
@@ -417,7 +417,7 @@ class SwitchConverter(Converter, DagWalker):
         f = self.walk_symbol(name, name.args())
         return self.make_term(ss.primops.Apply, [f, *args])
 
-    # Int / real operatos
+    # Int / real operators
     walk_lt = make_walk_binary(ss.primops.Lt)
     walk_le = make_walk_binary(ss.primops.Le)
     walk_equals = make_walk_binary(ss.primops.Equal)

--- a/src/generic_solver.cpp
+++ b/src/generic_solver.cpp
@@ -177,7 +177,7 @@ void GenericSolver::start_solver()
     argv[cmd_line_args.size() + 1] = NULL;
     execv(path.c_str(), (char **)argv);
     // Nothing below this line should be executed by child process. If so,
-    // it means that the execl function wasn't successfull, so lets exit:
+    // it means that the execl function wasn't successful, so lets exit:
     std::string msg("failure to run binary: ");
     msg += path;
     throw IncorrectUsageException(msg);
@@ -192,7 +192,7 @@ void GenericSolver::start_solver()
 
 void GenericSolver::write_internal(std::string str) const
 {
-  // track how many charas were written so far
+  // track how many chars were written so far
   unsigned int written_chars = 0;
   // continue writing  until entire str was written
   while (written_chars < str.size())
@@ -279,7 +279,7 @@ std::string GenericSolver::read_internal() const
       read_buf[i] = 0;
     }
   }
-  // normalize outout of solver:
+  // normalize output of solver:
   // - no newlines in the middle of the content
   // - no double spaces
   while (result.find("\n") != std::string::npos)
@@ -969,7 +969,7 @@ Term GenericSolver::make_symbol(const std::string name, const Sort & sort)
   // always put pipes around name in case there
   // are special symbols / spaces
   std::string piped_name = "|" + name + "|";
-  // make sure that the symbol name is not aready taken.
+  // make sure that the symbol name is not already taken.
   if (name_term_map->find(piped_name) != name_term_map->end())
   {
     throw IncorrectUsageException(
@@ -984,7 +984,7 @@ Term GenericSolver::make_symbol(const std::string name, const Sort & sort)
   (*term_name_map)[term] = piped_name;
 
   // communicate the creation of the symbol to the binary of the solver.
-  // When the sort is not a fucntion, we specify an empty domain.
+  // When the sort is not a function, we specify an empty domain.
   // Otherwise, the name of the sort includes the domain.
   run_command("(" + DECLARE_FUN_STR + " " + piped_name
               + (sort->get_sort_kind() == FUNCTION ? " " : " () ")
@@ -1085,7 +1085,7 @@ Term GenericSolver::get_value(const Term & t) const
   {
     if (value.substr(0, 2) == "#b")
     {
-      // bianry representation
+      // binary representation
       resulting_term = make_value(value.substr(2, value.size() - 2), sort, 2);
     }
     else if (value.substr(0, 2) == "#x")
@@ -1275,7 +1275,7 @@ UnorderedTermMap GenericSolver::get_array_values(const Term & arr,
                                                  Term & out_const_base) const
 {
   throw NotImplementedException(
-      "Generic solvers do not support get-value for arryas");
+      "Generic solvers do not support get-value for arrays");
 }
 
 void GenericSolver::reset()

--- a/src/logging_term.cpp
+++ b/src/logging_term.cpp
@@ -119,7 +119,7 @@ bool LoggingTerm::compare(const Term & t) const
     {
       // because of hash-consing, we can compare the pointers
       // otherwise would recursively call compare on the LoggingTerm children
-      // Note: calling get() intead of comparing the Term shared_ptrs directly
+      // Note: calling get() instead of comparing the Term shared_ptrs directly
       // because operator== is overloaded for Terms such that it uses the
       // compare method of the underlying object (i.e. it would be a recursive
       // call to compare)

--- a/src/smtlib_reader.cpp
+++ b/src/smtlib_reader.cpp
@@ -353,7 +353,7 @@ void SmtLibReader::new_symbol(const std::string & name, const Sort & sort)
 {
   if (global_symbols_.get_symbol(name))
   {
-    throw SmtException("Re-declaring symbol: " + name);
+    throw SmtException("Redeclaring symbol: " + name);
   }
 
   auto it = all_symbols_.find(name);
@@ -361,7 +361,7 @@ void SmtLibReader::new_symbol(const std::string & name, const Sort & sort)
   {
     if (it->second->get_sort() != sort)
     {
-      throw SmtException("Current Limitation: cannot re-declare symbol " + name
+      throw SmtException("Current Limitation: cannot redeclare symbol " + name
                          + " with a different sort");
     }
     global_symbols_.add_mapping(name, it->second);
@@ -516,7 +516,7 @@ Term SmtLibReader::create_param(const std::string & name, const Sort & sort)
 {
   assert(current_scope());
   Term param;
-  // some solvers don't allow re-using parameter names
+  // some solvers don't allow reusing parameter names
   // need to find a fresh one
   std::size_t id = 0;
   while (!param)

--- a/src/solver.cpp
+++ b/src/solver.cpp
@@ -47,8 +47,8 @@ SortVec AbsSmtSolver::make_datatype_sorts(
     const std::vector<DatatypeDecl> & decls) const
 {
   throw NotImplementedException(
-      "make_datatype_sorts for mutually recursive datatypes not yet implementd "
-      "by "
+      "make_datatype_sorts for mutually recursive datatypes not yet "
+      "implemented by "
       + to_string(solver_enum));
 }
 

--- a/src/term_translator.cpp
+++ b/src/term_translator.cpp
@@ -588,7 +588,7 @@ Term TermTranslator::cast_op(Op op, const TermVec & terms) const
   {
     // assuming the array itself doesn't need to be casted
     // only the index
-    // we have no suport for or issue with that
+    // we have no support for or issue with that
     return solver->make_term(
         Select,
         terms[0],
@@ -599,7 +599,7 @@ Term TermTranslator::cast_op(Op op, const TermVec & terms) const
   {
     // assuming the array itself doesn't need to be casted
     // only the index
-    // we have no suport for or issue with that
+    // we have no support for or issue with that
     Sort arrsort = terms[0]->get_sort();
     return solver->make_term(Store,
                              terms[0],

--- a/src/tree_walker.cpp
+++ b/src/tree_walker.cpp
@@ -26,7 +26,7 @@ std::pair<Term, std::vector<int>> TreeWalker::visit(Term & node)
   }
 
   // out is meant to store the result of querying the query cache
-  // by default, out gives topmost node's occurence with which to query cache
+  // by default, out gives topmost node's occurrence with which to query cache
   // before continuing
   std::pair<Term, std::vector<int>> out;
   out.first = node;

--- a/src/utils.cpp
+++ b/src/utils.cpp
@@ -481,13 +481,13 @@ class EliminateBooleanConstants : public IdentityWalker
   }
   WalkerStepResult visit_term(Term & term)
   {
-    Term tru = solver_->make_term(true);
-    Term fal = solver_->make_term(false);
+    Term true_term = solver_->make_term(true);
+    Term false_term = solver_->make_term(false);
     auto is_true = [&](Term t) {  // If the term is "true"
-      return (t == tru);
+      return (t == true_term);
     };
     auto is_false = [&](Term t) {  // If the term is "false"
-      return (t == fal);
+      return (t == false_term);
     };
     if (!preorder_)
     {

--- a/tests/btor/btor-transfer.cpp
+++ b/tests/btor/btor-transfer.cpp
@@ -51,7 +51,7 @@ int main()
 
   Term constraint2 = tt.transfer_term(constraint);
   Term T2 = tt.transfer_term(T);
-  // ensure it can handle transfering again (even though it already built the
+  // ensure it can handle transferring again (even though it already built the
   // node)
   tt.transfer_term(constraint);
   s2->assert_formula(constraint2);

--- a/tests/cvc5/cvc5-transfer.cpp
+++ b/tests/cvc5/cvc5-transfer.cpp
@@ -51,7 +51,7 @@ int main()
   TermTranslator tt(s2);
 
   Term constraint2 = tt.transfer_term(constraint);
-  // ensure it can handle transfering again (even though it already built the
+  // ensure it can handle transferring again (even though it already built the
   // node)
   constraint2 = tt.transfer_term(constraint);
   s2->assert_formula(constraint2);

--- a/tests/msat/msat-transfer.cpp
+++ b/tests/msat/msat-transfer.cpp
@@ -55,7 +55,7 @@ void transfer_int_test()
 
   Term constraint2 = tt.transfer_term(constraint);
   Term T2 = tt.transfer_term(T);
-  // ensure it can handle transfering again (even though it already built the
+  // ensure it can handle transferring again (even though it already built the
   // node)
   constraint2 = tt.transfer_term(constraint);
   s2->assert_formula(constraint2);
@@ -92,7 +92,7 @@ void transfer_bv_test()
 
   Term constraint2 = tt.transfer_term(constraint);
   Term T2 = tt.transfer_term(T);
-  // ensure it can handle transfering again (even though it already built the
+  // ensure it can handle transferring again (even though it already built the
   // node)
   constraint2 = tt.transfer_term(constraint);
   s2->assert_formula(constraint2);

--- a/tests/test-term-translation.cpp
+++ b/tests/test-term-translation.cpp
@@ -136,7 +136,7 @@ TEST_P(SelfTranslationTests, BVTransfer)
   ASSERT_EQ(T2, s2->make_term(true));
   Term two_2 = tt.transfer_term(two);
   ASSERT_EQ(two_2, s2->make_term(2, s2->make_sort(BV, 8)));
-  // ensure it can handle transfering again (even though it already built the
+  // ensure it can handle transferring again (even though it already built the
   // node)
   Term cached_constraint2 = constraint2;
   constraint2 = tt.transfer_term(constraint);

--- a/tests/unit/unit-sort.cpp
+++ b/tests/unit/unit-sort.cpp
@@ -197,7 +197,7 @@ TEST_P(UnitSortArithTests, SameSortDiffObj)
   EXPECT_EQ(realsort, realsort_2);
 }
 
-// One of the tests requries parsing values
+// One of the tests requires parsing values
 // of uninterpreted sorts.
 // This is not supported by the generic solver, and hence
 // it is excluded.

--- a/tests/unit/unit-util.cpp
+++ b/tests/unit/unit-util.cpp
@@ -197,10 +197,10 @@ TEST_P(UnitUtilDimacsTests, cnf_to_dimacs)
   cnf_to_dimacs(cnf, y);  // cnf = ((a v b v ~c) /\ (b v ~c v d) /\ (d v ~c v
                           // a))
   string ret = y.str();
-  string ans = "p cnf 4 3\n1 -2 3 0\n3 -2 4 0\n-2 4 1 0\n";
-  ASSERT_TRUE(ret == ans) << ret << " " << ans << endl
-                          << cnf << endl
-                          << s->get_solver_enum() << endl;
+  string expected = "p cnf 4 3\n1 -2 3 0\n3 -2 4 0\n-2 4 1 0\n";
+  ASSERT_TRUE(ret == expected) << ret << " " << expected << endl
+                               << cnf << endl
+                               << s->get_solver_enum() << endl;
 
   // Test 2
   Term clause4 = a;
@@ -210,16 +210,16 @@ TEST_P(UnitUtilDimacsTests, cnf_to_dimacs)
   ostringstream y2;
   cnf_to_dimacs(cnf2, y2);  // cnf2 = ((a) /\ (~b) /\ (a v b))
   string ret2 = y2.str();
-  string ans2 = "p cnf 2 3\n1 2 0\n-1 0\n2 0\n";
-  ASSERT_TRUE(ret2 == ans2);
+  string expected2 = "p cnf 2 3\n1 2 0\n-1 0\n2 0\n";
+  ASSERT_TRUE(ret2 == expected2);
 
   // Testing an empty cnf
   Term cnf3 = s->make_term(true);
   ostringstream y3;
   cnf_to_dimacs(cnf3, y3);  // cnf3 = True
   string ret3 = y3.str();
-  string ans3 = "p cnf 0 0\n";
-  ASSERT_TRUE(ret3 == ans3) << ret3 << endl << ans3 << endl;
+  string expected3 = "p cnf 0 0\n";
+  ASSERT_TRUE(ret3 == expected3) << ret3 << endl << expected3 << endl;
 
   // Testing empty clause
   Term clause7 = s->make_term(false);
@@ -227,8 +227,8 @@ TEST_P(UnitUtilDimacsTests, cnf_to_dimacs)
   ostringstream y4;
   cnf_to_dimacs(cnf4, y4);  // cnf4 = ((~b) /\ (False) /\ (a v b v ~c))
   string ret4 = y4.str();
-  string ans4 = "p cnf 3 3\n-1 2 3 0\n0\n-2 0\n";
-  ASSERT_TRUE(ret4 == ans4) << ret4 << endl << cnf4 << endl;
+  string expected4 = "p cnf 3 3\n-1 2 3 0\n0\n-2 0\n";
+  ASSERT_TRUE(ret4 == expected4) << ret4 << endl << cnf4 << endl;
 }
 
 TEST_P(UnitUtilDimacsTests, tseitin)
@@ -256,7 +256,7 @@ TEST_P(UnitUtilDimacsTests, tseitin)
   s->pop(1);
   ASSERT_TRUE((r1.is_sat() && r2.is_sat()) || (r1.is_unsat() && r2.is_unsat()));
   string st = cnf1->to_string();
-  string ans =
+  string expected =
       "(and tseitin_to_cnf_4 (and (or (not t) (not tseitin_to_cnf_1)) (or t "
       "tseitin_to_cnf_1) (or (not tseitin_to_cnf_2) p q) (and (or "
       "tseitin_to_cnf_2 (not p)) (or tseitin_to_cnf_2 (not q))) (or "
@@ -265,7 +265,7 @@ TEST_P(UnitUtilDimacsTests, tseitin)
       "(or (or (not tseitin_to_cnf_3) tseitin_to_cnf_1) (not "
       "tseitin_to_cnf_4)) (or tseitin_to_cnf_3 tseitin_to_cnf_4) (or (not "
       "tseitin_to_cnf_1) tseitin_to_cnf_4)))";
-  ASSERT_TRUE(st == ans) << st << endl << endl << ans << endl;
+  ASSERT_TRUE(st == expected) << st << endl << endl << expected << endl;
 
   // b=Not(p xor q)
   Term b = s->make_term(Not, s->make_term(Xor, p, q));
@@ -282,13 +282,13 @@ TEST_P(UnitUtilDimacsTests, tseitin)
   ASSERT_TRUE((r1.is_sat() && r2.is_sat()) || (r1.is_unsat() && r2.is_unsat()));
 
   st = cnf2->to_string();
-  ans =
+  expected =
       "(and tseitin_to_cnf_6 (and (or (or (not p) (not q)) (not "
       "tseitin_to_cnf_5)) (or (or p q) (not tseitin_to_cnf_5)) (or (or "
       "tseitin_to_cnf_5 q) (not p)) (or (or tseitin_to_cnf_5 p) (not q)) (or "
       "(not tseitin_to_cnf_5) (not tseitin_to_cnf_6)) (or tseitin_to_cnf_5 "
       "tseitin_to_cnf_6)))";
-  ASSERT_TRUE(st == ans) << st << endl << endl << ans << endl << endl;
+  ASSERT_TRUE(st == expected) << st << endl << endl << expected << endl << endl;
 
   // c=((not p) and p)
   Term c = s->make_term(And, s->make_term(Not, p), p);
@@ -305,8 +305,8 @@ TEST_P(UnitUtilDimacsTests, tseitin)
   ASSERT_TRUE((r1.is_sat() && r2.is_sat()) || (r1.is_unsat() && r2.is_unsat()));
 
   st = cnf3->to_string();
-  ans = "(and (not p) p)";
-  ASSERT_TRUE(st == ans);
+  expected = "(and (not p) p)";
+  ASSERT_TRUE(st == expected);
 
   Term d1 = s->make_term(Or, p, q);
   Term d2 = s->make_term(Or, r, t);
@@ -327,8 +327,8 @@ TEST_P(UnitUtilDimacsTests, tseitin)
   ASSERT_TRUE((r1.is_sat() && r2.is_sat()) || (r1.is_unsat() && r2.is_unsat()));
 
   st = cnf4->to_string();
-  ans = "(and (or p q) (or r t))";
-  ASSERT_TRUE(st == ans);
+  expected = "(and (or p q) (or r t))";
+  ASSERT_TRUE(st == expected);
   // e=false
   Term e = s->make_term(false);
   Term cnf5 = to_cnf(e, s);
@@ -344,8 +344,8 @@ TEST_P(UnitUtilDimacsTests, tseitin)
   ASSERT_TRUE((r1.is_sat() && r2.is_sat()) || (r1.is_unsat() && r2.is_unsat()));
 
   st = cnf5->to_string();
-  ans = "false";
-  ASSERT_TRUE(st == ans);
+  expected = "false";
+  ASSERT_TRUE(st == expected);
 
   // f=true
   Term f = s->make_term(true);
@@ -362,8 +362,8 @@ TEST_P(UnitUtilDimacsTests, tseitin)
   ASSERT_TRUE((r1.is_sat() && r2.is_sat()) || (r1.is_unsat() && r2.is_unsat()));
 
   st = cnf6->to_string();
-  ans = "true";
-  ASSERT_TRUE(st == ans);
+  expected = "true";
+  ASSERT_TRUE(st == expected);
 
   TermVec vec;
   vec.push_back(p);
@@ -387,13 +387,13 @@ TEST_P(UnitUtilDimacsTests, tseitin)
   ASSERT_TRUE((r1.is_sat() && r2.is_sat()) || (r1.is_unsat() && r2.is_unsat()));
 
   st = cnf7->to_string();
-  ans = "(or p q r t)";
-  ASSERT_TRUE(st == ans);
+  expected = "(or p q r t)";
+  ASSERT_TRUE(st == expected);
 
   Term fa = s->make_term(false);
   Term tr = s->make_term(true);
 
-  // cheking function is_cnf
+  // checking function is_cnf
 
   TermVec vecs;
   vecs.push_back(p);
@@ -420,17 +420,17 @@ TEST_P(UnitUtilDimacsTests, tseitin)
   ASSERT_FALSE(check);
 
   // checking elimination of true and false
-  Term tru = s->make_term(true);
-  Term fal = s->make_term(false);
+  Term true_term = s->make_term(true);
+  Term false_term = s->make_term(false);
 
   // formula=and(true, p)
-  Term formula = s->make_term(And, tru, p);
+  Term formula = s->make_term(And, true_term, p);
   Term as = to_cnf(formula, s);
   ASSERT_TRUE(as == p);
 
   // formula=and(or(p, true), or(q, false))
-  formula =
-      s->make_term(And, s->make_term(Or, p, tru), s->make_term(Or, q, fal));
+  formula = s->make_term(
+      And, s->make_term(Or, p, true_term), s->make_term(Or, q, false_term));
   as = to_cnf(formula, s);
   ASSERT_TRUE(as == q);
 
@@ -451,12 +451,12 @@ TEST_P(UnitUtilDimacsTests, tseitin)
   ASSERT_TRUE((r1.is_sat() && r2.is_sat()) || (r1.is_unsat() && r2.is_unsat()));
 
   st = cnf8->to_string();
-  ans =
+  expected =
       "(and tseitin_to_cnf_8 (and (or (not tseitin_to_cnf_7) p q) (and (or "
       "tseitin_to_cnf_7 (not p)) (or tseitin_to_cnf_7 (not q))) (or (not "
       "tseitin_to_cnf_7) (not tseitin_to_cnf_8)) (or tseitin_to_cnf_7 "
       "tseitin_to_cnf_8)))";
-  ASSERT_TRUE(st == ans);
+  ASSERT_TRUE(st == expected);
 }
 
 INSTANTIATE_TEST_SUITE_P(

--- a/tests/unit/unit-walker.cpp
+++ b/tests/unit/unit-walker.cpp
@@ -245,7 +245,7 @@ TEST_P(UnitWalkerTests, SimpleTree)
 
 TEST_P(UnitWalkerTests, PathDecomp)
 {
-  // using TreeWalker to traverse slightly more comlicated formula
+  // using TreeWalker to traverse slightly more complicated formula
 
   SolverConfiguration sc = GetParam();
   if (sc.is_logging_solver)

--- a/z3/include/z3_solver.h
+++ b/z3/include/z3_solver.h
@@ -128,7 +128,7 @@ class Z3Solver : public AbsSmtSolver
   mutable z3::solver slv;
   std::unordered_map<std::string, Term> symbol_table;
   ///< keep track of declared symbols to avoid
-  ///< re-declaring
+  ///< redeclaring
 
   uint64_t context_level;  ///< context level for incremental solving
 

--- a/z3/src/z3_solver.cpp
+++ b/z3/src/z3_solver.cpp
@@ -120,7 +120,7 @@ void Z3Solver::set_opt(const std::string option, const std::string value)
 
   // READ PLEASE
   // The easiest handling of Z3's set function's param requirements is to have
-  // vectors with the names of different options in the list correspoinding with
+  // vectors with the names of different options in the list corresponding with
   // which param the z3 api expects, it's worth discussing what options we think
   // should go in these lists to start and obviously it is very easy to add more
   // down the line


### PR DESCRIPTION
Nothing checked spelling in prose or comments before. Real misspellings are corrected, and the hyphenated compounds codespell objects to, like re-used, are closed up.

Several identifiers it read as misspellings are renamed rather than ignored, since ignoring a word hides it everywhere else too: an expected value in a test, a pair of terms standing in for true and false, and a pointer to a solver. Only the SMT-LIB str.at operator has to stay, so `.codespellrc` ignores that one by name.