### PR TITLE
fix: Change python back to python3

### DIFF
--- a/ci-scripts/upload-wheel.sh
+++ b/ci-scripts/upload-wheel.sh
@@ -1,6 +1,6 @@
 #!/usr/bin/env bash
 set -euo pipefail
-python -m venv .uploadenv
+python3 -m venv .uploadenv
 # shellcheck source=/dev/null  # activate script created by the command above
 source .uploadenv/bin/activate
 pip install twine


### PR DESCRIPTION
There is no binary called python on macOS.