### PR TITLE
build: Enable the double-quote-cython-strings hook

### DIFF
--- a/.git-blame-ignore-revs
+++ b/.git-blame-ignore-revs
@@ -30,3 +30,6 @@ ea1664d973f43040669734cb5922879302efb9c5
 
 # style: Reformat pyproject.toml with tombi (#543)
 f7ecf8531b4439fa73e0ae6df2df952739055888
+
+# style: Double-quote the strings in the Cython sources (#559)
+d370e8876eeb9c16a1e53746733a9f1ce330afd9

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -61,6 +61,8 @@ repos:
     hooks:
       # ruff cannot parse Cython, so .pyx and .pxd reach no other linter.
       - id: cython-lint
+      # Single-line strings only; docstrings keep their triple single quotes.
+      - id: double-quote-cython-strings
   - repo: https://github.com/BlankSpruce/gersemi-pre-commit
     rev: 0.28.1
     hooks:


### PR DESCRIPTION
The Cython sources are already double-quoted, so the hook only keeps them that way. It is a separate hook from cython-lint rather than one of its rules, and it rewrites files where cython-lint only reports.

Recording the reformat in `.git-blame-ignore-revs` keeps `git blame` on the commit that wrote each line: quoting was all that changed, and the generated C++ was identical either way.