### PR TITLE
fix: Enable actionlint and clear its findings

### DIFF
--- a/.github/workflows/auto-draft-release.yml
+++ b/.github/workflows/auto-draft-release.yml
@@ -20,16 +20,16 @@ jobs:
           # Drop comment lines and take the first line that remains
           VERSION_VALUE=$(grep -v '^#' VERSION | head -n 1 | tr -d '[:space:]')
           echo "Detected version: $VERSION_VALUE"
-          echo "version=$VERSION_VALUE" >> $GITHUB_OUTPUT
+          echo "version=$VERSION_VALUE" >> "$GITHUB_OUTPUT"
       - name: Check if tag exists
         id: check_tag
         env:
           VERSION: ${{ steps.version.outputs.version }}
         run: |
           if git tag -l "v$VERSION" | grep -q .; then
-            echo "tag_exists=true" >> $GITHUB_OUTPUT
+            echo "tag_exists=true" >> "$GITHUB_OUTPUT"
           else
-            echo "tag_exists=false" >> $GITHUB_OUTPUT
+            echo "tag_exists=false" >> "$GITHUB_OUTPUT"
           fi
       # Create and push the tag if it doesn't already exist
       - name: Create and push tag

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Set up Python virtual environment
         run: |
           python3 -m venv .venv --system-site-packages
-          echo "$(pwd)/.venv/bin" >> $GITHUB_PATH
+          echo "$(pwd)/.venv/bin" >> "$GITHUB_PATH"
       - name: Configure
         env:
           CMAKE_GENERATOR: Ninja
@@ -63,7 +63,7 @@ jobs:
       - name: Build
         run: ninja -C build
       - name: Install Python bindings
-        run: pip install $(ls build/python/*.whl)[pysmt,test]
+        run: pip install "$(ls build/python/*.whl)[pysmt,test]"
       - name: Test C++
         id: test-cpp
         continue-on-error: true

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -77,6 +77,14 @@ repos:
       - id: yamllint
         # Without this a warning exits 0 and the hook passes.
         args: [--strict]
+  - repo: https://github.com/rhysd/actionlint
+    rev: v1.7.12
+    hooks:
+      # Also runs shellcheck over every `run:` block, but only if shellcheck is
+      # on PATH: the runner image ships it, a local machine may not, and it is
+      # skipped silently when missing. The shellcheck hook below does not help,
+      # as that copy lives in its own environment.
+      - id: actionlint
   - repo: https://github.com/tombi-toml/tombi-pre-commit
     rev: v1.5.2
     hooks:


### PR DESCRIPTION
Nothing checked the workflows themselves, and nothing checked the shell in their `run:` blocks either, since the shellcheck hook only matches `*.sh`. Every finding is shellcheck reporting an unquoted expansion.

One of them mattered. Where the wheel is installed, the shell treats `[pysmt,test]` as a character class rather than pip extras: a sibling file one character longer than the wheel would match it and drop the extras, and a space in the path would split the argument in two. Quoting the whole word settles both and passes pip exactly what it receives today.